### PR TITLE
Update e2e workflow

### DIFF
--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -15,7 +15,7 @@ jobs:
         id: waitForPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 60
+          max_timeout: 180
           environment: Preview – colonial-collections-dataset-browser
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -6,6 +6,7 @@ on:
       - 'package.json'
       - 'apps/dataset-browser/**'
       - .github/workflows/end-to-end-testing-dataset-browser.yml
+      - 'packages/**'
 jobs:
   run-end-to-end-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -15,11 +15,11 @@ jobs:
         id: waitForPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 60
+          max_timeout: 180
           environment: Preview – colonial-collections-researcher
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Run Cypress for Dataset Browser 🌲
+      - name: Run Cypress for Researcher 🌲
         uses: cypress-io/github-action@v5
         with:
           project: ./apps/researcher

--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -6,6 +6,7 @@ on:
       - 'package.json'
       - 'apps/researcher/**'
       - .github/workflows/end-to-end-testing-researcher.yml
+      - 'packages/**''
 jobs:
   run-end-to-end-tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I saw two problems with the e2e tests workflow.

- Sometimes, the preview takes more than 60 sec. This will fail the e2e tests.
- Workspace package changes won't trigger the e2e tests. I do want this.

Seeing this workflow in action, I don't like the waiting step. It used to be triggered on a successful build. Now it just waits. This is fragile because sometimes the build takes longer.

Let's see how this works, but we may need to rethink this step. First, I would like this step to work. The end-to-end tests really help me to see if everything still works. It's the first thing I look at with Dependabot pull requests. So I want them to work first and improve later.