### PR TITLE
feat: heritage fetcher

### DIFF
--- a/apps/researcher/fixtures/create-search-graph.rq
+++ b/apps/researcher/fixtures/create-search-graph.rq
@@ -153,12 +153,16 @@ WHERE {
   # Part of dataset
   ####################
 
+  ?object la:member_of ?dataset .
+
+  # Required property, but it may not exist in a specific language
   OPTIONAL {
-    ?object la:member_of ?dataset .
-    ?dataset dct:title ?tmpTitle .
+    ?dataset dct:title ?tmpTitle
     FILTER(LANG(?tmpTitle) = "" || LANGMATCHES(LANG(?tmpTitle), "en"))
-    BIND(COALESCE(?tmpTitle, "(No name)"@en) AS ?datasetName) # TBD: add multi-language support?
   }
+
+  # TBD: add multi-language support?
+  BIND(COALESCE(?tmpTitle, "(No name)"@en) AS ?datasetName)
 
   ####################
   # Creator

--- a/apps/researcher/fixtures/create-search-graph.rq
+++ b/apps/researcher/fixtures/create-search-graph.rq
@@ -36,6 +36,27 @@ CONSTRUCT {
     cc:materialName ?materialName ;
     cc:techniqueName ?techniqueName ;
     cc:creatorName ?creatorName .
+
+  ?owner a cc:Organization ;
+    cc:name ?ownerName .
+
+  ?creator a cc:Person ;
+    cc:name ?creatorName .
+
+  ?type a cc:DefinedTerm ;
+    cc:name ?typeName .
+
+  ?subject a cc:DefinedTerm ;
+    cc:name ?aboutName .
+
+  ?material a cc:DefinedTerm ;
+    cc:name ?materialName .
+
+  ?technique a cc:DefinedTerm ;
+    cc:name ?techniqueName .
+
+  ?dataset a cc:Dataset ;
+    cc:name ?datasetName .
 }
 WHERE {
   ?object a crm:E22_Human-Made_Object .

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -14,13 +14,16 @@
     "test": "jest --passWithNoTests --testPathIgnorePatterns '<rootDir>/src/.*/*.integration.test.ts'",
     "test:ci": "npm test -- --ci",
     "test:watch": "npm test -- --watchAll",
-    "test:integration": "jest --passWithNoTests --testMatch '**/src/**/*.integration.test.ts'",
+    "test:integration": "jest --testMatch '**/src/**/*.integration.test.ts'",
     "test:integration:watch": "npm run test:integration -- --watchAll",
     "test:e2e": "cypress run",
     "test:e2e:open": "cypress open"
   },
   "dependencies": {
+    "@colonial-collections/iris": "*",
+    "@colonial-collections/label-fetcher": "*",
     "@faker-js/faker": "7.6.0",
+    "@hapi/hoek": "11.0.2",
     "@headlessui/react": "1.7.14",
     "@heroicons/react": "2.0.17",
     "@next/mdx": "13.3.0",
@@ -28,7 +31,8 @@
     "next": "13.2.4    ",
     "next-intl": "2.13.0-beta.2",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@jest/globals": "29.5.0",

--- a/apps/researcher/src/lib/heritage-fetcher/index.integration.test.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/index.integration.test.ts
@@ -1,4 +1,4 @@
-import {HeritageFetcher, SortBy, SortOrder} from '.';
+import {HeritageFetcher} from '.';
 import {LabelFetcher} from '@colonial-collections/label-fetcher';
 import {beforeEach, describe, expect, it} from '@jest/globals';
 import {env} from 'node:process';
@@ -15,11 +15,204 @@ beforeEach(() => {
   });
 });
 
-xdescribe('search', () => {
-  it('finds all things if no options are provided', async () => {
+describe('search', () => {
+  it('finds all heritage objects if no options are provided', async () => {
     const result = await heritageFetcher.search();
 
-    console.log(JSON.stringify(result, null, 2));
+    expect(result).toStrictEqual({
+      totalCount: 3,
+      offset: 0,
+      limit: 10,
+      sortBy: 'relevance',
+      sortOrder: 'desc',
+      heritageObjects: [
+        {
+          id: 'https://example.org/objects/1',
+          name: 'Object 1',
+          description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300033618',
+              name: 'paintings (visual works)',
+            },
+          ],
+          subjects: [
+            {
+              id: 'http://vocab.getty.edu/aat/300152441',
+              name: 'celebrations',
+            },
+          ],
+          materials: [
+            {
+              id: 'http://vocab.getty.edu/aat/300014078',
+              name: 'canvas (textile material)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300015050',
+              name: 'oil paint (paint)',
+            },
+          ],
+          creators: [
+            {
+              id: 'https://data.rkd.nl/artists/32439',
+              name: 'Gogh, Vincent van',
+            },
+          ],
+          owner: {
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
+          isPartOf: {
+            id: 'https://example.org/datasets/1',
+            name: 'Dataset 1',
+          },
+        },
+        {
+          id: 'https://example.org/objects/2',
+          name: 'Object 2',
+          description:
+            'Suspendisse ut condimentum leo, et vulputate lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Fusce vel volutpat nunc. Sed vel libero ac lorem dapibus euismod. Aenean a ante et turpis bibendum consectetur at pulvinar quam.',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300046300',
+              name: 'photographs',
+            },
+          ],
+          subjects: [
+            {
+              id: 'http://vocab.getty.edu/aat/300005734',
+              name: 'palaces (official residences)',
+            },
+          ],
+          materials: [
+            {
+              id: 'http://vocab.getty.edu/aat/300014109',
+              name: 'paper (fiber product)',
+            },
+          ],
+          techniques: [
+            {
+              id: 'http://vocab.getty.edu/aat/300133274',
+              name: 'albumen process',
+            },
+          ],
+          creators: [
+            {
+              id: 'https://data.rkd.nl/artists/120388',
+              name: 'Boer, Adriaan',
+            },
+          ],
+          owner: {
+            id: 'https://research.example.org/',
+            name: 'Research Organisation',
+          },
+          isPartOf: {
+            id: 'https://example.org/datasets/13',
+            name: 'Dataset 13',
+          },
+        },
+        {
+          id: 'https://example.org/objects/3',
+          name: 'Object 3',
+          description:
+            'Ut dictum elementum augue sit amet sodales. Vivamus viverra ligula sed arcu cursus sagittis. Donec ac placerat lacus.',
+          inscriptions: ['Maecenas commodo est neque'],
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300033973',
+              name: 'drawings (visual works)',
+            },
+          ],
+          subjects: [
+            {
+              id: 'http://vocab.getty.edu/aat/300005500',
+              name: 'cottages',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300006891',
+              name: 'castles (fortifications)',
+            },
+          ],
+          materials: [
+            {
+              id: 'http://vocab.getty.edu/aat/300014109',
+              name: 'paper (fiber product)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300015012',
+              name: 'ink',
+            },
+          ],
+          owner: {
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
+          isPartOf: {
+            id: 'https://example.org/datasets/10',
+            name: '(No name)',
+          },
+        },
+      ],
+      filters: {
+        owners: [
+          {
+            totalCount: 1,
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
+          {
+            totalCount: 1,
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
+          {
+            totalCount: 1,
+            id: 'https://research.example.org/',
+            name: 'Research Organisation',
+          },
+        ],
+        types: [
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300033618',
+            name: 'paintings (visual works)',
+          },
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300033973',
+            name: 'drawings (visual works)',
+          },
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300046300',
+            name: 'photographs',
+          },
+        ],
+        subjects: [
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300005500',
+            name: 'cottages',
+          },
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300005734',
+            name: 'palaces (official residences)',
+          },
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300006891',
+            name: 'castles (fortifications)',
+          },
+          {
+            totalCount: 1,
+            id: 'http://vocab.getty.edu/aat/300152441',
+            name: 'celebrations',
+          },
+        ],
+      },
+    });
   });
 });
 

--- a/apps/researcher/src/lib/heritage-fetcher/index.integration.test.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/index.integration.test.ts
@@ -1,0 +1,83 @@
+import {HeritageFetcher, SortBy, SortOrder} from '.';
+import {LabelFetcher} from '@colonial-collections/label-fetcher';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {env} from 'node:process';
+
+const labelFetcher = new LabelFetcher({
+  endpointUrl: env.SEARCH_PLATFORM_SPARQL_ENDPOINT_URL as string,
+});
+let heritageFetcher: HeritageFetcher;
+
+beforeEach(() => {
+  heritageFetcher = new HeritageFetcher({
+    endpointUrl: env.SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL as string,
+    labelFetcher,
+  });
+});
+
+xdescribe('search', () => {
+  it('finds all things if no options are provided', async () => {
+    const result = await heritageFetcher.search();
+
+    console.log(JSON.stringify(result, null, 2));
+  });
+});
+
+describe('getById', () => {
+  it('returns undefined if no heritage object matches the ID', async () => {
+    const heritageObject = await heritageFetcher.getById({
+      id: 'AnIdThatDoesNotExist',
+    });
+
+    expect(heritageObject).toBeUndefined();
+  });
+
+  it('returns the heritage object that matches the ID', async () => {
+    const heritageObject = await heritageFetcher.getById({
+      id: 'https://example.org/objects/1',
+    });
+
+    expect(heritageObject).toStrictEqual({
+      id: 'https://example.org/objects/1',
+      name: 'Object 1',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
+      types: [
+        {
+          id: 'http://vocab.getty.edu/aat/300033618',
+          name: 'paintings (visual works)',
+        },
+      ],
+      subjects: [
+        {
+          id: 'http://vocab.getty.edu/aat/300152441',
+          name: 'celebrations',
+        },
+      ],
+      materials: [
+        {
+          id: 'http://vocab.getty.edu/aat/300014078',
+          name: 'canvas (textile material)',
+        },
+        {
+          id: 'http://vocab.getty.edu/aat/300015050',
+          name: 'oil paint (paint)',
+        },
+      ],
+      creators: [
+        {
+          id: 'https://data.rkd.nl/artists/32439',
+          name: 'Gogh, Vincent van',
+        },
+      ],
+      owner: {
+        id: 'https://museum.example.org/',
+        name: 'Museum',
+      },
+      isPartOf: {
+        id: 'https://example.org/datasets/1',
+        name: 'Dataset 1',
+      },
+    });
+  });
+});

--- a/apps/researcher/src/lib/heritage-fetcher/index.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/index.ts
@@ -1,0 +1,433 @@
+import {buildAggregation} from './request';
+import {buildFilters} from './result';
+import {getIrisFromObject} from '@colonial-collections/iris';
+import {LabelFetcher} from '@colonial-collections/label-fetcher';
+import {merge, reach} from '@hapi/hoek';
+import {z} from 'zod';
+
+const constructorOptionsSchema = z.object({
+  endpointUrl: z.string(),
+  labelFetcher: z.instanceof(LabelFetcher),
+});
+
+export type ConstructorOptions = z.infer<typeof constructorOptionsSchema>;
+
+enum RawKeys {
+  Id = '@id',
+  Type = 'http://www w3 org/1999/02/22-rdf-syntax-ns#type',
+  AdditionalType = 'https://colonialcollections nl/search#additionalType',
+  Name = 'https://colonialcollections nl/search#name',
+  Description = 'https://colonialcollections nl/search#description',
+  Inscription = 'https://colonialcollections nl/search#inscription',
+  About = 'https://colonialcollections nl/search#about',
+  Creator = 'https://colonialcollections nl/search#creator',
+  Material = 'https://colonialcollections nl/search#material',
+  Technique = 'https://colonialcollections nl/search#technique',
+  Owner = 'https://colonialcollections nl/search#owner',
+  IsPartOf = 'https://colonialcollections nl/search#isPartOf',
+}
+
+type Thing = {
+  id: string;
+  name?: string; // Name may not exist (e.g. in a specific locale)
+};
+
+export type Organization = Thing;
+export type Term = Thing;
+export type Person = Thing;
+export type Dataset = Thing;
+
+export type HeritageObject = {
+  id: string;
+  name?: string;
+  description?: string;
+  inscriptions?: string[];
+  types?: Term[];
+  subjects?: Term[];
+  materials?: Term[];
+  techniques?: Term[];
+  creators?: Person[];
+  owner?: Organization;
+  isPartOf: Dataset;
+};
+
+export enum SortBy {
+  Name = 'name',
+  Relevance = 'relevance',
+}
+
+const SortByEnum = z.nativeEnum(SortBy);
+
+const sortByToRawKeys = new Map<string, string>([
+  [SortBy.Name, `${RawKeys.Name}.keyword`],
+  [SortBy.Relevance, '_score'],
+]);
+
+export enum SortOrder {
+  Ascending = 'asc',
+  Descending = 'desc',
+}
+
+const SortOrderEnum = z.nativeEnum(SortOrder);
+
+// TBD: add language option, for returning results in a specific locale (e.g. 'nl', 'en')
+export const searchOptionsSchema = z.object({
+  query: z.string().optional().default('*'), // If no query provided, match all
+  offset: z.number().int().nonnegative().optional().default(0),
+  limit: z.number().int().positive().optional().default(10),
+  sortBy: SortByEnum.optional().default(SortBy.Relevance),
+  sortOrder: SortOrderEnum.optional().default(SortOrder.Descending),
+  filters: z
+    .object({
+      owners: z.array(z.string()).optional().default([]),
+      types: z.array(z.string()).optional().default([]),
+      subjects: z.array(z.string()).optional().default([]),
+    })
+    .optional(),
+});
+
+export type SearchOptions = z.input<typeof searchOptionsSchema>;
+
+const rawHeritageObjectSchema = z
+  .object({})
+  .setKey(RawKeys.Id, z.string())
+  .setKey(RawKeys.AdditionalType, z.array(z.string()).optional())
+  .setKey(RawKeys.Name, z.array(z.string()).optional())
+  .setKey(RawKeys.Description, z.array(z.string()).optional())
+  .setKey(RawKeys.Inscription, z.array(z.string()).optional())
+  .setKey(RawKeys.About, z.array(z.string()).optional())
+  .setKey(RawKeys.Creator, z.array(z.string()).optional())
+  .setKey(RawKeys.Material, z.array(z.string()).optional())
+  .setKey(RawKeys.Technique, z.array(z.string()).optional())
+  .setKey(RawKeys.Owner, z.array(z.string()).optional())
+  .setKey(RawKeys.IsPartOf, z.array(z.string()).optional());
+
+type RawHeritageObject = z.infer<typeof rawHeritageObjectSchema>;
+
+const rawBucketSchema = z.object({
+  key: z.string(),
+  doc_count: z.number(),
+});
+
+export type RawBucket = z.infer<typeof rawBucketSchema>;
+
+const rawAggregationSchema = z.object({
+  buckets: z.array(rawBucketSchema),
+});
+
+const rawSearchResponseSchema = z.object({
+  hits: z.object({
+    total: z.object({
+      value: z.number(),
+    }),
+    hits: z.array(
+      z.object({
+        _source: rawHeritageObjectSchema,
+      })
+    ),
+  }),
+});
+
+type RawSearchResponse = z.infer<typeof rawSearchResponseSchema>;
+
+const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
+  z.object({
+    aggregations: z.object({
+      all: z.object({
+        owners: rawAggregationSchema,
+        types: rawAggregationSchema,
+        subjects: rawAggregationSchema,
+      }),
+      owners: rawAggregationSchema,
+      types: rawAggregationSchema,
+      subjects: rawAggregationSchema,
+    }),
+  })
+);
+
+type RawSearchResponseWithAggregations = z.infer<
+  typeof rawSearchResponseWithAggregationsSchema
+>;
+
+export type SearchResultFilter = Thing & {totalCount: number};
+
+export type SearchResult = {
+  totalCount: number;
+  offset: number;
+  limit: number;
+  sortBy: SortBy;
+  sortOrder: SortOrder;
+  heritageObjects: HeritageObject[];
+  filters: {
+    owners: SearchResultFilter[];
+    types: SearchResultFilter[];
+    subjects: SearchResultFilter[];
+  };
+};
+
+const getByIdOptionsSchema = z.object({
+  id: z.string(),
+});
+
+export type GetByIdOptions = z.infer<typeof getByIdOptionsSchema>;
+
+export class HeritageFetcher {
+  private endpointUrl: string;
+  private labelFetcher: LabelFetcher;
+
+  constructor(options: ConstructorOptions) {
+    const opts = constructorOptionsSchema.parse(options);
+
+    this.endpointUrl = opts.endpointUrl;
+    this.labelFetcher = opts.labelFetcher;
+  }
+
+  async makeRequest<T>(searchRequest: Record<string, unknown>): Promise<T> {
+    // Elastic's '@elastic/elasticsearch' package does not work with TriplyDB's
+    // Elasticsearch instance, so we use pure HTTP calls instead
+    const response = await fetch(this.endpointUrl, {
+      method: 'POST',
+      body: JSON.stringify(searchRequest),
+      headers: {'Content-Type': 'application/json'},
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to retrieve information: ${response.statusText} (${response.status})`
+      );
+    }
+
+    const responseData: T = await response.json();
+
+    // Extract the IRIs, if any, from the response.
+    // The IRIs are necessary for fetching their labels later on
+    const iris = getIrisFromObject(responseData);
+    const predicates = ['https://colonialcollections.nl/search#name'];
+    await this.labelFetcher.loadByIris({iris, predicates});
+
+    return responseData;
+  }
+
+  // Map the response to our internal model
+  private fromRawHeritageObjectToHeritageObject(
+    rawHeritageObject: RawHeritageObject
+  ): HeritageObject {
+    const name = reach(rawHeritageObject, `${RawKeys.Name}.0`);
+    const description = reach(rawHeritageObject, `${RawKeys.Description}.0`);
+    const inscriptions = reach(rawHeritageObject, `${RawKeys.Inscription}`);
+
+    const ownerIri = reach(rawHeritageObject, `${RawKeys.Owner}.0`);
+    const owner: Organization = {
+      id: ownerIri,
+      name: this.labelFetcher.getByIri({iri: ownerIri}),
+    };
+
+    const datasetIri = reach(rawHeritageObject, `${RawKeys.IsPartOf}.0`);
+    const dataset: Dataset = {
+      id: datasetIri,
+      name: this.labelFetcher.getByIri({iri: datasetIri}),
+    };
+
+    const toThings = <T>(rawKey: string) => {
+      const iris: string[] | undefined = reach(rawHeritageObject, `${rawKey}`);
+      if (iris === undefined) {
+        return undefined;
+      }
+
+      const things = iris.map((iri: string) => {
+        return {
+          id: iri,
+          name: this.labelFetcher.getByIri({iri}),
+        };
+      });
+
+      return things as T[];
+    };
+
+    const types = toThings<Term>(RawKeys.AdditionalType);
+    const subjects = toThings<Term>(RawKeys.About);
+    const materials = toThings<Term>(RawKeys.Material);
+    const techniques = toThings<Term>(RawKeys.Technique);
+    const creators = toThings<Person>(RawKeys.Creator);
+
+    const heritageObjectWithUndefinedValues: HeritageObject = {
+      id: rawHeritageObject[RawKeys.Id],
+      name,
+      description,
+      inscriptions,
+      types,
+      subjects,
+      materials,
+      techniques,
+      creators,
+      owner,
+      isPartOf: dataset,
+    };
+
+    const heritageObject = merge({}, heritageObjectWithUndefinedValues, {
+      nullOverride: false,
+    });
+
+    return heritageObject;
+  }
+
+  private buildSearchRequest(options: SearchOptions) {
+    const aggregations = {
+      owners: buildAggregation(RawKeys.Owner),
+      types: buildAggregation(RawKeys.AdditionalType),
+      subjects: buildAggregation(RawKeys.About),
+    };
+
+    const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
+
+    const searchRequest = {
+      size: options.limit,
+      from: options.offset,
+      sort: [
+        {
+          [sortByRawKey]: options.sortOrder,
+        },
+      ],
+      query: {
+        bool: {
+          must: [
+            {
+              simple_query_string: {
+                query: options.query,
+                default_operator: 'and',
+              },
+            },
+          ],
+          filter: [
+            {
+              // Only return documents of type 'Thing'
+              terms: {
+                [`${RawKeys.Type}.keyword`]: [
+                  'https://colonialcollections.nl/search#Thing',
+                ],
+              },
+            },
+          ],
+        },
+      },
+      aggregations: {
+        all: {
+          // Aggregate all filters, regardless of the query.
+          // We may need to refine this at some point, if performance needs it,
+          // e.g. by using a separate call and caching the results
+          global: {},
+          aggregations,
+        },
+        ...aggregations,
+      },
+    };
+
+    const queryFilters: Map<string, string[] | undefined> = new Map([
+      [RawKeys.Owner, options.filters?.owners],
+      [RawKeys.AdditionalType, options.filters?.types],
+      [RawKeys.About, options.filters?.subjects],
+    ]);
+
+    for (const [rawHeritageObjectKey, filters] of queryFilters) {
+      if (filters !== undefined && filters.length) {
+        searchRequest.query.bool.filter.push({
+          terms: {
+            [`${rawHeritageObjectKey}.keyword`]: filters,
+          },
+        });
+      }
+    }
+
+    return searchRequest;
+  }
+
+  private async buildSearchResult(
+    options: SearchOptions,
+    rawSearchResponse: RawSearchResponseWithAggregations
+  ) {
+    const {hits, aggregations} = rawSearchResponse;
+
+    const heritageObjects: HeritageObject[] = hits.hits.map(hit => {
+      const rawHeritageObject = hit._source;
+      return this.fromRawHeritageObjectToHeritageObject(rawHeritageObject);
+    });
+
+    const ownerFilters = buildFilters(
+      aggregations.all.owners.buckets,
+      aggregations.owners.buckets,
+      this.labelFetcher
+    );
+
+    const typeFilters = buildFilters(
+      aggregations.all.types.buckets,
+      aggregations.types.buckets,
+      this.labelFetcher
+    );
+
+    const subjectFilters = buildFilters(
+      aggregations.all.subjects.buckets,
+      aggregations.subjects.buckets,
+      this.labelFetcher
+    );
+
+    const searchResult: SearchResult = {
+      totalCount: hits.total.value,
+      offset: options.offset!,
+      limit: options.limit!,
+      sortBy: options.sortBy!,
+      sortOrder: options.sortOrder!,
+      heritageObjects,
+      filters: {
+        owners: ownerFilters,
+        types: typeFilters,
+        subjects: subjectFilters,
+      },
+    };
+
+    return searchResult;
+  }
+
+  async search(options?: SearchOptions): Promise<SearchResult> {
+    const opts = searchOptionsSchema.parse(options ?? {});
+
+    const searchRequest = this.buildSearchRequest(opts);
+
+    const rawResponse =
+      await this.makeRequest<RawSearchResponseWithAggregations>(searchRequest);
+    const searchResponse =
+      rawSearchResponseWithAggregationsSchema.parse(rawResponse);
+
+    const searchResult = await this.buildSearchResult(opts, searchResponse);
+
+    return searchResult;
+  }
+
+  async getById(options: GetByIdOptions): Promise<HeritageObject | undefined> {
+    const opts = getByIdOptionsSchema.parse(options);
+
+    // We cannot use Elasticsearch's Get API: TriplyDB only supports the Search API.
+    // TBD: should we query the triplestore instead?
+    const searchRequest = {
+      query: {
+        term: {
+          '@id.keyword': opts.id,
+        },
+      },
+    };
+
+    const rawResponse = await this.makeRequest<RawSearchResponse>(
+      searchRequest
+    );
+    const searchResponse = rawSearchResponseSchema.parse(rawResponse);
+
+    if (searchResponse.hits.hits.length !== 1) {
+      return undefined;
+    }
+
+    const rawHeritageObject = searchResponse.hits.hits[0]._source;
+    const heritageObject =
+      this.fromRawHeritageObjectToHeritageObject(rawHeritageObject);
+
+    return heritageObject;
+  }
+}

--- a/apps/researcher/src/lib/heritage-fetcher/index.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/index.ts
@@ -100,7 +100,7 @@ const rawHeritageObjectSchema = z
   .setKey(RawKeys.Material, z.array(z.string()).optional())
   .setKey(RawKeys.Technique, z.array(z.string()).optional())
   .setKey(RawKeys.Owner, z.array(z.string()).optional())
-  .setKey(RawKeys.IsPartOf, z.array(z.string()).optional());
+  .setKey(RawKeys.IsPartOf, z.array(z.string()).min(1));
 
 type RawHeritageObject = z.infer<typeof rawHeritageObjectSchema>;
 

--- a/apps/researcher/src/lib/heritage-fetcher/request.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/request.ts
@@ -1,0 +1,10 @@
+export function buildAggregation(id: string) {
+  const aggregation = {
+    terms: {
+      size: 100, // TBD: what's a good size?,
+      field: `${id}.keyword`,
+    },
+  };
+
+  return aggregation;
+}

--- a/apps/researcher/src/lib/heritage-fetcher/result.ts
+++ b/apps/researcher/src/lib/heritage-fetcher/result.ts
@@ -1,0 +1,59 @@
+import type {RawBucket, SearchResultFilter} from '.';
+import type {LabelFetcher} from '@colonial-collections/label-fetcher';
+
+function toUnmatchedFilter(
+  bucket: RawBucket,
+  labelFetcher: LabelFetcher
+): SearchResultFilter {
+  const totalCount = 0; // Initial count; will be overridden by the matching filter, if any
+  const id = bucket.key;
+  const name = labelFetcher.getByIri({iri: id});
+
+  return {totalCount, id, name};
+}
+
+function toMatchedFilter(
+  bucket: RawBucket,
+  labelFetcher: LabelFetcher
+): SearchResultFilter {
+  const totalCount = bucket.doc_count; // Actual count if a filter matched the query
+  const id = bucket.key;
+  const name = labelFetcher.getByIri({iri: id});
+
+  return {totalCount, id, name};
+}
+
+function combineUnmatchedWithMatchedFilters(
+  unmatchedFilters: SearchResultFilter[],
+  matchedFilters: SearchResultFilter[]
+) {
+  const combinedFilters = unmatchedFilters.map(filter => {
+    const matchedFilter = matchedFilters.find(
+      matchedFilter => matchedFilter.id === filter.id
+    );
+    return matchedFilter ?? filter;
+  });
+
+  return combinedFilters;
+}
+
+export function buildFilters(
+  rawUnmatchedFilters: RawBucket[],
+  rawMatchedFilters: RawBucket[],
+  labelFetcher: LabelFetcher
+) {
+  const unmatchedFilters = rawUnmatchedFilters.map(rawUnmatchedFilter => {
+    return toUnmatchedFilter(rawUnmatchedFilter, labelFetcher);
+  });
+  const matchedFilters = rawMatchedFilters.map(rawMatchedFilter => {
+    return toMatchedFilter(rawMatchedFilter, labelFetcher);
+  });
+  const combinedFilters = combineUnmatchedWithMatchedFilters(
+    unmatchedFilters,
+    matchedFilters
+  );
+
+  // TBD: sort filters by totalCount, descending + subsort by totalCount, ascending?
+
+  return combinedFilters;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10774,6 +10774,7 @@
       }
     },
     "packages/label-fetcher": {
+      "name": "@colonial-collections/label-fetcher",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "turbo run test:watch",
     "test:ci": "turbo run test:ci",
     "test:integration": "turbo run test:integration",
+    "test:integration:watch": "turbo run test:integration:watch",
     "test:e2e": "turbo run test:e2e"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,7 @@
     "test:watch": {},
     "test:ci": {},
     "test:integration": {},
+    "test:integration:watch": {},
     "test:e2e": {}
   }
 }


### PR DESCRIPTION
This PR provides an _initial_ implementation of a 'heritage fetcher'. We can use it to make the Research App work with mock data that comes from real Elasticsearch and SPARQL backends.

It has some limitations:
1. It currently only focuses on heritage objects, not on e.g. persons or places
2. It isn't fully integration tested yet
3. The core of the code is quite similar to the 'dataset fetcher' of the Dataset Browser - in order to be DRY, it needs some refactoring as soon as we're happy with the functionality