### PR TITLE
new mock data for Dataset Browser

### DIFF
--- a/apps/dataset-browser/fixtures/search/create-search-graph.rq
+++ b/apps/dataset-browser/fixtures/search/create-search-graph.rq
@@ -1,5 +1,5 @@
 ###############################
-# Query for generating a search graph with dataset descriptions for testing
+# Query for generating a search graph with dataset descriptions
 # Source of the query: https://triplestore.netwerkdigitaalerfgoed.nl/sparql?savedQueryName=Full%20dataset%20descriptions%20for%20publisher&owner=admin&execute
 # Publish the query to https://colonial-heritage.triply.cc/data-hub/-/queries/create-search-graph/ for use in production
 ###############################
@@ -7,6 +7,7 @@
 PREFIX cc: <https://colonialcollections.nl/search#> # Internal, undocumented ontology
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skolem: <https://triplydb.com/.well-known/genid/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -24,6 +25,7 @@ CONSTRUCT {
     cc:datePublished ?issued ;
     cc:spatialCoverage ?place ;
     cc:genre ?genre ;
+    cc:measurement ?datasetMeasurement ;
     # To allow for search actions based on name
     cc:publisherName ?publisherName ;
     cc:licenseName ?licenseName ;
@@ -42,8 +44,23 @@ CONSTRUCT {
 
   ?genre a cc:DefinedTerm ;
     cc:name ?genreName .
+
+  ?datasetMeasurement a cc:Measurement ;
+    cc:measurementOf ?datasetMetric ;
+    cc:value ?datasetMeasurementValue .
+
+  ?datasetMetric a cc:Metric ;
+    cc:name ?datasetMetricName .
+
+  ?distributionMeasurement a cc:Measurement ;
+    cc:measurementOf ?distributionMetric ;
+    cc:value ?distributionMeasurementValue .
+
+  ?distributionMetric a cc:Metric ;
+    cc:name ?distributionMetricName .
 }
 WHERE {
+  BIND(<https://example.org/datasets/11> AS ?dataset)
   ?dataset a dcat:Dataset .
 
   ####################
@@ -150,5 +167,32 @@ WHERE {
       skos:prefLabel ?genreName ;
       skos:inScheme <http://vocab.getty.edu/aat/> .
     FILTER(LANG(?genreName) = "" || LANGMATCHES(LANG(?genreName), "en")) # TBD: which languages to support?
+  }
+
+  ####################
+  # Dataset measurements
+  ####################
+
+  OPTIONAL {
+    ?dataset dqv:hasQualityMeasurement ?datasetMeasurement .
+    ?datasetMeasurement dqv:value ?datasetMeasurementValue ;
+      dqv:isMeasurementOf ?datasetMetric .
+
+    ?datasetMetric skos:prefLabel ?datasetMetricName
+    FILTER(LANG(?datasetMetricName) = "" || LANGMATCHES(LANG(?datasetMetricName), "en")) # TBD: which languages to support?
+  }
+
+  ####################
+  # Distribution measurements
+  ####################
+
+  OPTIONAL {
+    ?dataset dcat:distribution ?distribution .
+    ?distribution dqv:hasQualityMeasurement ?distributionMeasurement .
+    ?distributionMeasurement dqv:value ?distributionMeasurementValue ;
+      dqv:isMeasurementOf ?distributionMetric .
+
+    ?distributionMetric skos:prefLabel ?distributionMetricName
+    FILTER(LANG(?distributionMetricName) = "" || LANGMATCHES(LANG(?distributionMetricName), "en")) # TBD: which languages to support?
   }
 }

--- a/apps/dataset-browser/fixtures/search/create-search-graph.rq
+++ b/apps/dataset-browser/fixtures/search/create-search-graph.rq
@@ -26,6 +26,7 @@ CONSTRUCT {
     cc:spatialCoverage ?place ;
     cc:genre ?genre ;
     cc:measurement ?datasetMeasurement ;
+    cc:measurement ?distributionMeasurement ;
     # To allow for search actions based on name
     cc:publisherName ?publisherName ;
     cc:licenseName ?licenseName ;

--- a/apps/dataset-browser/fixtures/search/create-search-graph.rq
+++ b/apps/dataset-browser/fixtures/search/create-search-graph.rq
@@ -60,7 +60,6 @@ CONSTRUCT {
     cc:name ?distributionMetricName .
 }
 WHERE {
-  BIND(<https://example.org/datasets/11> AS ?dataset)
   ?dataset a dcat:Dataset .
 
   ####################

--- a/apps/dataset-browser/fixtures/search/datasets.ttl
+++ b/apps/dataset-browser/fixtures/search/datasets.ttl
@@ -21,7 +21,15 @@
   dct:created "2019-03-12"^^xsd:date ;
   dct:modified "2023-02-17"^^xsd:date ;
   dct:issued "2023-02-17"^^xsd:date ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10063182> .
+  dct:language "nl-NL", "en-GB" ;
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10063182> ;
+  dcat:distribution <https://example.org/datasets/1/distributions/1> .
+
+<https://example.org/datasets/1/distributions/1>
+  a dcat:Distribution ;
+  dct:title "Turtle distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.ttl> ;
+  dcat:mediaType "text/turtle" .
 
 <https://example.org/datasets/2>
   a dcat:Dataset ;
@@ -34,13 +42,22 @@
   dct:created "2019-03-12"^^schema:Date ;
   dct:modified "2023-02-17"^^schema:Date ;
   dct:issued "2023-02-17"^^schema:Date ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10055279> .
+  dct:language "nl-NL" ;
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10055279> ;
+  dcat:distribution <https://example.org/datasets/2/distributions/1> .
+
+<https://example.org/datasets/2/distributions/1>
+  a dcat:Distribution ;
+  dct:title "RDF/XML distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.rdf> ;
+  dcat:mediaType "application/rdf+xml" .
 
 <https://example.org/datasets/3>
   a dcat:Dataset ;
   dct:title "Dataset 3"@en ;
   dct:license <http://opendatacommons.org/licenses/odbl/1.0/> ;
   dct:publisher <https://archive.example.org/> .
+  # No distribution
 
 <https://example.org/datasets/4>
   a dcat:Dataset ;
@@ -51,17 +68,39 @@
   dct:description "Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac." ;
   dcat:keyword "Hendrerit", "Suspendisse" ;
   dct:modified "2023-02-01"^^xsd:date ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058074> .
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058074> ;
+  dcat:distribution <https://example.org/datasets/4/distributions/1> ,
+                    <https://example.org/datasets/4/distributions/2> .
+
+<https://example.org/datasets/4/distributions/1>
+  a dcat:Distribution ;
+  dct:title "CSV distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.csv> ;
+  dcat:mediaType "text/csv" .
+
+<https://example.org/datasets/4/distributions/2>
+  a dcat:Distribution ;
+  dct:title "PDF distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.pdf> ;
+  dcat:mediaType "application/pdf" .
 
 <https://example.org/datasets/5>
   a dcat:Dataset ;
   dct:type <http://vocab.getty.edu/aat/300404198> ; # Digital media
   dct:title "Dataset 5"@nl, "Dataset 5"@en ;
-  dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+  dct:license <http://rightsstatements.org/vocab/InC/1.0/> ;
   dct:publisher <https://archive.example.org/> ;
   dct:description "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis."@nl,
                   "Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam."@en ;
-  dcat:keyword "Trefwoord"@nl, "Keyword"@en .
+  dcat:keyword "Trefwoord"@nl, "Keyword"@en ;
+  dct:language "nl-NL", "en-GB" ;
+  dcat:distribution <https://example.org/datasets/5/distributions/1> .
+
+<https://example.org/datasets/5/distributions/1>
+  a dcat:Distribution ;
+  dct:title "Microsoft Excel distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.xls> ;
+  dcat:mediaType "application/vnd.ms-excel" .
 
 <https://example.org/datasets/6>
   a dcat:Dataset ;
@@ -69,7 +108,15 @@
   dct:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
   dct:publisher <https://archive.example.org/> ;
   dct:description "Vivamus vitae elit eget ligula efficitur rhoncus. Donec ut urna consequat, tempor leo sed, iaculis erat. Fusce at quam nisi. Ut convallis quam pellentesque, euismod augue at, finibus nibh."@nl ;
-  dct:issued "2010-09-11T08:06:55Z"^^xsd:dateTime .
+  dct:issued "2010-09-11T08:06:55Z"^^xsd:dateTime ;
+  dct:language "nl-NL" ;
+  dcat:distribution <https://example.org/datasets/6/distributions/1> .
+
+<https://example.org/datasets/6/distributions/1>
+  a dcat:Distribution ;
+  dct:title "SPARQL distribution of the dataset" ;
+  dcat:accessURL <https://example.org/sparql> ;
+  dcat:mediaType "application/sparql-query" .
 
 <https://example.org/datasets/7>
   a dcat:Dataset ;
@@ -79,7 +126,21 @@
   dct:publisher <https://archive.example.org/> ;
   dcat:landingPage <https://example.org/> ;
   dct:modified "2023-02-01T23:01:02Z"^^xsd:dateTime ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058074> .
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058074> ;
+  dcat:distribution <https://example.org/datasets/7/distributions/1> ,
+                    <https://example.org/datasets/7/distributions/2> .
+
+<https://example.org/datasets/7/distributions/1>
+  a dcat:Distribution ;
+  dct:title "SPARQL distribution of the dataset" ;
+  dcat:accessURL <https://example.org/sparql> ;
+  dcat:mediaType "application/sparql-query" .
+
+<https://example.org/datasets/7/distributions/2>
+  a dcat:Distribution ;
+  dct:title "N-Triples distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.nt> ;
+  dcat:mediaType "application/n-triples" .
 
 <https://example.org/datasets/8>
   a dcat:Dataset ;
@@ -89,7 +150,14 @@
   dct:publisher <https://archive.example.org/> ;
   dct:description "Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac." ;
   dcat:keyword "Vestibulum", "Phasellus" ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10063351> .
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10063351> ;
+  dcat:distribution <https://example.org/datasets/8/distributions/1> .
+
+<https://example.org/datasets/8/distributions/1>
+  a dcat:Distribution ;
+  dct:title "Turtle distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.ttl> ;
+  dcat:mediaType "text/turtle" .
 
 <https://example.org/datasets/9>
   a dcat:Dataset ;
@@ -97,14 +165,24 @@
   dct:license <https://creativecommons.org/licenses/by/4.0/> ;
   dct:publisher <https://library.example.org/> ;
   dct:description "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis."@nl,
-                  "Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam."@en .
+                  "Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam."@en ;
+  dct:language "nl-NL", "en-GB" .
+  # No distribution
 
 <https://example.org/datasets/10>
   a dcat:Dataset ;
   dct:title "Dataset 10"@nl ;
-  dct:license <http://opendatacommons.org/licenses/by/1.0/> ;
+  dct:license <https://example.org/custom-license> ;
   dct:publisher <https://library.example.org/> ;
-  dct:description "Vivamus vitae elit eget ligula efficitur rhoncus. Donec ut urna consequat, tempor leo sed, iaculis erat. Fusce at quam nisi. Ut convallis quam pellentesque, euismod augue at, finibus nibh."@nl .
+  dct:description "Vivamus vitae elit eget ligula efficitur rhoncus. Donec ut urna consequat, tempor leo sed, iaculis erat. Fusce at quam nisi. Ut convallis quam pellentesque, euismod augue at, finibus nibh."@nl ;
+  dct:language "nl-NL" ;
+  dcat:distribution <https://example.org/datasets/10/distributions/1> .
+
+<https://example.org/datasets/10/distributions/1>
+  a dcat:Distribution ;
+  dct:title "PDF distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.pdf> ;
+  dcat:mediaType "application/pdf" .
 
 <https://example.org/datasets/11>
   a dcat:Dataset ;
@@ -115,7 +193,21 @@
   dct:created "2019-03-12"^^xsd:date ;
   dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10063401> ,
               <https://hdl.handle.net/20.500.11840/termmaster10063351> ,
-              <https://hdl.handle.net/20.500.11840/termmaster10061190> .
+              <https://hdl.handle.net/20.500.11840/termmaster10061190> ;
+  dcat:distribution <https://example.org/datasets/11/distributions/1> ,
+                    <https://example.org/datasets/11/distributions/2> .
+
+<https://example.org/datasets/11/distributions/1>
+  a dcat:Distribution ;
+  dct:title "SPARQL distribution of the dataset" ;
+  dcat:accessURL <https://example.org/sparql> ;
+  dcat:mediaType "application/sparql-query" .
+
+<https://example.org/datasets/11/distributions/2>
+  a dcat:Distribution ;
+  dct:title "N-Triples distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.nt> ;
+  dcat:mediaType "application/n-triples" .
 
 <https://example.org/datasets/12>
   a dcat:Dataset ;
@@ -125,7 +217,14 @@
   dct:description "Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac." ;
   dcat:keyword "Hendrerit", "Vestibulum" ;
   dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10054875> ,
-              <https://hdl.handle.net/20.500.11840/termmaster10055279> .
+              <https://hdl.handle.net/20.500.11840/termmaster10055279> ;
+  dcat:distribution <https://example.org/datasets/12/distributions/1> .
+
+<https://example.org/datasets/12/distributions/1>
+  a dcat:Distribution ;
+  dct:title "Turtle distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.ttl> ;
+  dcat:mediaType "text/turtle" .
 
 <https://example.org/datasets/13>
   a dcat:Dataset ;
@@ -137,7 +236,14 @@
   dct:description "Cras erat elit, finibus eget ipsum vel, gravida dapibus leo. Etiam sem erat, suscipit id eros sit amet, scelerisque ornare sem. Aenean commodo elementum neque ac accumsan." ;
   dcat:keyword "Fringilla" ;
   dct:created "2022-10-01T09:01:02Z"^^xsd:dateTime ;
-  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058073> .
+  dct:spatial <https://hdl.handle.net/20.500.11840/termmaster10058073> ;
+  dcat:distribution <https://example.org/datasets/13/distributions/1> .
+
+<https://example.org/datasets/13/distributions/1>
+  a dcat:Distribution ;
+  dct:title "ZIP distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.zip> ;
+  dcat:mediaType "application/zip" .
 
 <https://example.org/datasets/14>
   a dcat:Dataset ;
@@ -145,4 +251,11 @@
   dct:license <http://creativecommons.org/publicdomain/zero/1.0/deed.nl> ;
   dct:publisher <https://library.example.org/> ;
   dct:description "Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac." ;
-  dcat:keyword "Hendrerit", "Suspendisse" .
+  dcat:keyword "Hendrerit", "Suspendisse" ;
+  dcat:distribution <https://example.org/datasets/14/distributions/1> .
+
+<https://example.org/datasets/14/distributions/1>
+  a dcat:Distribution ;
+  dct:title "Microsoft Word distribution of the dataset" ;
+  dcat:downloadURL <https://example.org/files/dataset.doc> ;
+  dcat:mediaType "application/msword" .

--- a/apps/dataset-browser/fixtures/search/licenses.ttl
+++ b/apps/dataset-browser/fixtures/search/licenses.ttl
@@ -4,6 +4,10 @@
 
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
+<http://example.org/custom-license>
+  a foaf:Document;
+  foaf:name "Custom License" .
+
 <http://creativecommons.org/publicdomain/zero/1.0/>
   a foaf:Document;
   foaf:name "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication" .

--- a/apps/dataset-browser/fixtures/search/measurements.ttl
+++ b/apps/dataset-browser/fixtures/search/measurements.ttl
@@ -8,485 +8,611 @@
 # Dataset 1
 
 <https://example.org/datasets/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/1/measurements/1> ,
+                            <https://example.org/datasets/1/measurements/2> .
+
+<https://example.org/datasets/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/1/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/1/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/1/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/1/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/1/distributions/1/measurements/4> .
+
+<https://example.org/datasets/1/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/1/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/1/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/1/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 2
 
 <https://example.org/datasets/2>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/2/measurements/1> ,
+                            <https://example.org/datasets/2/measurements/2> .
+
+<https://example.org/datasets/2/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/2/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/2/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/2/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/2/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/2/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/2/distributions/1/measurements/4> .
+
+<https://example.org/datasets/2/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/2/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/2/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/2/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 3
 
 <https://example.org/datasets/3>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/3> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/3/measurements/1> ,
+                            <https://example.org/datasets/3/measurements/2> .
+
+<https://example.org/datasets/3/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/3> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/3/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 4
 
 <https://example.org/datasets/4>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/4/measurements/1> ,
+                            <https://example.org/datasets/4/measurements/2> .
+
+<https://example.org/datasets/4/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/4/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/4/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/4/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/4/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/4/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/4/distributions/1/measurements/4> .
+
+<https://example.org/datasets/4/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/4/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/4/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/4/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .
 
 # Dataset 5
 
 <https://example.org/datasets/5>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/5/measurements/1> ,
+                            <https://example.org/datasets/5/measurements/2> .
+
+<https://example.org/datasets/5/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/5/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean .
 
 <https://example.org/datasets/5/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/5/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/5/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/5/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/5/distributions/1/measurements/4> .
+
+<https://example.org/datasets/5/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/5/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/5/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/5/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .
 
 # Dataset 6
 
 <https://example.org/datasets/6>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/6/measurements/1> ,
+                            <https://example.org/datasets/6/measurements/2> .
+
+<https://example.org/datasets/6/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/6/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/6/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/6/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/6/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/6/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/6/distributions/1/measurements/4> .
+
+<https://example.org/datasets/6/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/6/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/6/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/6/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 7
 
 <https://example.org/datasets/7>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/7/measurements/1> ,
+                            <https://example.org/datasets/7/measurements/2> .
+
+<https://example.org/datasets/7/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/7/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/7/distributions/2>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/7/distributions/2/measurements/1> ,
+                            <https://example.org/datasets/7/distributions/2/measurements/2> ,
+                            <https://example.org/datasets/7/distributions/2/measurements/3> ,
+                            <https://example.org/datasets/7/distributions/2/measurements/4> .
+
+<https://example.org/datasets/7/distributions/2/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/7/distributions/2/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/7/distributions/2/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/7/distributions/2/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 8
 
 <https://example.org/datasets/8>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/8/measurements/1> ,
+                            <https://example.org/datasets/8/measurements/2> .
+
+<https://example.org/datasets/8/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/8/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/8/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/8/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/8/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/8/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/8/distributions/1/measurements/4> .
+
+<https://example.org/datasets/8/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/8/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/8/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/8/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 9
 
 <https://example.org/datasets/9>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/9> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/9> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/9/measurements/1> ,
+                            <https://example.org/datasets/9/measurements/2> .
+
+<https://example.org/datasets/9/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/9> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/9/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/9> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 10
 
 <https://example.org/datasets/10>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/10/measurements/1>,
+                            <https://example.org/datasets/10/measurements/2> .
+
+<https://example.org/datasets/10/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/10/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean .
 
 <https://example.org/datasets/10/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/10/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/10/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/10/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/10/distributions/1/measurements/4> .
+
+<https://example.org/datasets/10/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/10/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/10/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/10/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .
 
 # Dataset 11
 
 <https://example.org/datasets/11>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
+  dqv:hasQualityMeasurement <https://example.org/datasets/11/measurements/1> ,
+                            <https://example.org/datasets/11/measurements/2> .
+
+<https://example.org/datasets/11/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/11/measurements/2>
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/11> ;
     dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+    dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/11/distributions/2>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/11/distributions/2/measurements/1> ,
+                            <https://example.org/datasets/11/distributions/2/measurements/2> ,
+                            <https://example.org/datasets/11/distributions/2/measurements/3> ,
+                            <https://example.org/datasets/11/distributions/2/measurements/4> .
+
+<https://example.org/datasets/11/distributions/2/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/11/distributions/2/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/11/distributions/2/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/11/distributions/2/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "true"^^xsd:boolean .
 
 # Dataset 12
 
 <https://example.org/datasets/12>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/12/measurements/1> ,
+                            <https://example.org/datasets/12/measurements/2> .
+
+<https://example.org/datasets/12/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/12/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/12/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/12/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/12/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/12/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/12/distributions/1/measurements/4> .
+
+<https://example.org/datasets/12/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/12/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/12/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/12/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .
 
 # Dataset 13
 
 <https://example.org/datasets/13>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/13/measurements/1> ,
+                            <https://example.org/datasets/13/measurements/2> .
+
+<https://example.org/datasets/13/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/13/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean .
 
 <https://example.org/datasets/13/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/13/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/13/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/13/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/13/distributions/1/measurements/4> .
+
+<https://example.org/datasets/13/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/13/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/13/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/13/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .
 
 # Dataset 14
 
 <https://example.org/datasets/14>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14> ;
-    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/14/measurements/1> ,
+                            <https://example.org/datasets/14/measurements/2> .
+
+<https://example.org/datasets/14/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/14/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean .
 
 <https://example.org/datasets/14/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/online> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
+  dqv:hasQualityMeasurement <https://example.org/datasets/14/distributions/1/measurements/1> ,
+                            <https://example.org/datasets/14/distributions/1/measurements/2> ,
+                            <https://example.org/datasets/14/distributions/1/measurements/3> ,
+                            <https://example.org/datasets/14/distributions/1/measurements/4> .
+
+<https://example.org/datasets/14/distributions/1/measurements/1>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/online> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/14/distributions/1/measurements/2>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+  dqv:value "true"^^xsd:boolean .
+
+<https://example.org/datasets/14/distributions/1/measurements/3>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+  dqv:value "false"^^xsd:boolean .
+
+<https://example.org/datasets/14/distributions/1/measurements/4>
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+  dqv:value "false"^^xsd:boolean .

--- a/apps/dataset-browser/fixtures/search/measurements.ttl
+++ b/apps/dataset-browser/fixtures/search/measurements.ttl
@@ -1,6 +1,5 @@
 ###############################
 # Sample data for testing
-# The measurements are about the datasets and their 'best' distribution (e.g. N-Triples file, not SPARQL endpoint; CSV file, not PDF file)
 ###############################
 
 @prefix dqv: <http://www.w3.org/ns/dqv#> .

--- a/apps/dataset-browser/fixtures/search/measurements.ttl
+++ b/apps/dataset-browser/fixtures/search/measurements.ttl
@@ -24,7 +24,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -62,7 +62,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -115,7 +115,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -130,29 +130,6 @@
   ] , [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] .
-
-<https://example.org/datasets/4/distributions/2>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "false"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
     dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
     dqv:value "false"^^xsd:boolean
   ] .
@@ -176,7 +153,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -214,7 +191,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -248,34 +225,11 @@
     dqv:value "true"^^xsd:boolean
   ] .
 
-<https://example.org/datasets/7/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
-
 <https://example.org/datasets/7/distributions/2>
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -313,7 +267,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -366,7 +320,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -400,34 +354,11 @@
     dqv:value "true"^^xsd:boolean
   ] .
 
-<https://example.org/datasets/11/distributions/1>
-  dqv:hasQualityMeasurement [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] , [
-    a dqv:QualityMeasurement ;
-    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
-    dqv:value "true"^^xsd:boolean
-  ] .
-
 <https://example.org/datasets/11/distributions/2>
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -465,7 +396,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -503,7 +434,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;
@@ -541,7 +472,7 @@
   dqv:hasQualityMeasurement [
     a dqv:QualityMeasurement ;
     dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
-    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:isMeasurementOf <https://example.org/metrics/online> ;
     dqv:value "true"^^xsd:boolean
   ] , [
     a dqv:QualityMeasurement ;

--- a/apps/dataset-browser/fixtures/search/measurements.ttl
+++ b/apps/dataset-browser/fixtures/search/measurements.ttl
@@ -85,32 +85,32 @@
 # Dataset 3
 
 <https://example.org/datasets/3>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/3> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/1> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/3> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 # Dataset 4
 
 <https://example.org/datasets/4>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/4> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/4> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/4/distributions/1>
   dqv:hasQualityMeasurement [
@@ -161,17 +161,17 @@ dqv:hasQualityMeasurement [
 # Dataset 5
 
 <https://example.org/datasets/5>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/5> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "true"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/5> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "false"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/5/distributions/1>
   dqv:hasQualityMeasurement [
@@ -199,17 +199,17 @@ dqv:hasQualityMeasurement [
 # Dataset 6
 
 <https://example.org/datasets/6>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/6> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "true"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/6> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/6/distributions/1>
   dqv:hasQualityMeasurement [
@@ -237,17 +237,17 @@ dqv:hasQualityMeasurement [
 # Dataset 7
 
 <https://example.org/datasets/7>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/7> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/7> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/7/distributions/1>
   dqv:hasQualityMeasurement [
@@ -298,17 +298,17 @@ dqv:hasQualityMeasurement [
 # Dataset 8
 
 <https://example.org/datasets/8>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/8> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/8> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/8/distributions/1>
   dqv:hasQualityMeasurement [
@@ -336,32 +336,32 @@ dqv:hasQualityMeasurement [
 # Dataset 9
 
 <https://example.org/datasets/9>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/9> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "true"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/9> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/9> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/9> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 # Dataset 10
 
 <https://example.org/datasets/10>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/10> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "true"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/10> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "false"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/10/distributions/1>
   dqv:hasQualityMeasurement [
@@ -389,17 +389,17 @@ dqv:hasQualityMeasurement [
 # Dataset 11
 
 <https://example.org/datasets/11>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/11> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/11> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/11/distributions/1>
   dqv:hasQualityMeasurement [
@@ -450,17 +450,17 @@ dqv:hasQualityMeasurement [
 # Dataset 12
 
 <https://example.org/datasets/12>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/12> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/12> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/12/distributions/1>
   dqv:hasQualityMeasurement [
@@ -488,17 +488,17 @@ dqv:hasQualityMeasurement [
 # Dataset 13
 
 <https://example.org/datasets/13>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/13> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/13> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "false"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/13/distributions/1>
   dqv:hasQualityMeasurement [
@@ -526,17 +526,17 @@ dqv:hasQualityMeasurement [
 # Dataset 14
 
 <https://example.org/datasets/14>
-dqv:hasQualityMeasurement [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/14> ;
-  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
-  dqv:value "false"^^xsd:boolean
-] , [
-  a dqv:QualityMeasurement ;
-  dqv:computedOn <https://example.org/datasets/14> ;
-  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
-  dqv:value "true"^^xsd:boolean
-] .
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
 
 <https://example.org/datasets/14/distributions/1>
   dqv:hasQualityMeasurement [

--- a/apps/dataset-browser/fixtures/search/measurements.ttl
+++ b/apps/dataset-browser/fixtures/search/measurements.ttl
@@ -1,0 +1,562 @@
+###############################
+# Sample data for testing
+# The measurements are about the datasets and their 'best' distribution (e.g. N-Triples file, not SPARQL endpoint; CSV file, not PDF file)
+###############################
+
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Dataset 1
+
+<https://example.org/datasets/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+<https://example.org/datasets/1/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/1/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 2
+
+<https://example.org/datasets/2>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+<https://example.org/datasets/2/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/2/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 3
+
+<https://example.org/datasets/3>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/3> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/1> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+# Dataset 4
+
+<https://example.org/datasets/4>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/4> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/4/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+<https://example.org/datasets/4/distributions/2>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/4/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+# Dataset 5
+
+<https://example.org/datasets/5>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/5> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean
+] .
+
+<https://example.org/datasets/5/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/5/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+# Dataset 6
+
+<https://example.org/datasets/6>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/6> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/6/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/6/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 7
+
+<https://example.org/datasets/7>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/7> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/7/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+<https://example.org/datasets/7/distributions/2>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/7/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 8
+
+<https://example.org/datasets/8>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/8> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/8/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/8/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 9
+
+<https://example.org/datasets/9>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/9> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/9> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+# Dataset 10
+
+<https://example.org/datasets/10>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "true"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/10> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean
+] .
+
+<https://example.org/datasets/10/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/10/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+# Dataset 11
+
+<https://example.org/datasets/11>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/11> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/11/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+<https://example.org/datasets/11/distributions/2>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/11/distributions/2> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] .
+
+# Dataset 12
+
+<https://example.org/datasets/12>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/12> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/12/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/12/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+# Dataset 13
+
+<https://example.org/datasets/13>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/13> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "false"^^xsd:boolean
+] .
+
+<https://example.org/datasets/13/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/13/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .
+
+# Dataset 14
+
+<https://example.org/datasets/14>
+dqv:hasQualityMeasurement [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14> ;
+  dqv:isMeasurementOf <https://example.org/metrics/languages> ;
+  dqv:value "false"^^xsd:boolean
+] , [
+  a dqv:QualityMeasurement ;
+  dqv:computedOn <https://example.org/datasets/14> ;
+  dqv:isMeasurementOf <https://example.org/metrics/open-license> ;
+  dqv:value "true"^^xsd:boolean
+] .
+
+<https://example.org/datasets/14/distributions/1>
+  dqv:hasQualityMeasurement [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/downloadable> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/structured-format> ;
+    dqv:value "true"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/open-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] , [
+    a dqv:QualityMeasurement ;
+    dqv:computedOn <https://example.org/datasets/14/distributions/1> ;
+    dqv:isMeasurementOf <https://example.org/metrics/rdf-format> ;
+    dqv:value "false"^^xsd:boolean
+  ] .

--- a/apps/dataset-browser/fixtures/search/metrics.ttl
+++ b/apps/dataset-browser/fixtures/search/metrics.ttl
@@ -1,13 +1,11 @@
 ###############################
-# Sample data for testing
+# Definitions of metrics for measuring the data quality of descriptions of datasets and their distributions
 ###############################
 
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix ldqd: <http://www.w3.org/2016/05/ldqd#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-# Definitions of metrics for measuring the quality of descriptions of datasets and their distributions
 
 <https://example.org/metrics/open-license>
   a dqv:Metric ;
@@ -27,11 +25,11 @@
   dqv:expectedDataType xsd:boolean ;
   dqv:inDimension ldqd:availability .
 
-<https://example.org/metrics/downloadable>
+<https://example.org/metrics/online>
   a dqv:Metric ;
-  skos:prefLabel "Downloadable or accessible"@en ;
+  skos:prefLabel "Downloadable or accessible online"@en ;
   skos:definition "Checks whether a download URL or access URL is available in the distribution description"@en ;
-  skos:scopeNote "Does not check whether the actual distribution is downloadable"@en ;
+  skos:scopeNote "Does not check whether the actual distribution is downloadable or accessible"@en ;
   dqv:expectedDataType xsd:boolean ;
   dqv:inDimension ldqd:availability .
 

--- a/apps/dataset-browser/fixtures/search/metrics.ttl
+++ b/apps/dataset-browser/fixtures/search/metrics.ttl
@@ -11,6 +11,7 @@
 
 <https://example.org/metrics/open-license>
   a dqv:Metric ;
+  skos:prefLabel "Open license"@en ;
   skos:definition "Checks whether the license is available in the dataset description and is a standardized, open license"@en ;
   skos:scopeNote "Valid licenses: https?://creativecommons.org/publicdomain/*, https?://creativecommons.org/licenses/*, https?://opendatacommons.org/licenses/*, https?://rightsstatements.org/vocab/NoC-CR/1.0/, https?://rightsstatements.org/vocab/NoC-NC/1.0/, https?://rightsstatements.org/vocab/NoC-OKLR/1.0/, https?://rightsstatements.org/vocab/NoC-US/1.0/"@en ;
   dqv:expectedDataType xsd:boolean ;
@@ -18,6 +19,7 @@
 
 <https://example.org/metrics/languages>
   a dqv:Metric ;
+  skos:prefLabel "Languages"@en ;
   skos:definition "Checks whether language codes are available in the dataset description that make clear in which languages the dataset is available"@en ;
   skos:scopeNote "Does not check whether the languages codes are valid (e.g. according to https://www.rfc-editor.org/rfc/rfc5646)"@en ;
   skos:scopeNote "Does not check whether the languages codes in the dataset description are the same as or different from the language codes used in the distribution (consistency)"@en ;
@@ -27,6 +29,7 @@
 
 <https://example.org/metrics/downloadable>
   a dqv:Metric ;
+  skos:prefLabel "Downloadable or accessible"@en ;
   skos:definition "Checks whether a download URL or access URL is available in the distribution description"@en ;
   skos:scopeNote "Does not check whether the actual distribution is downloadable"@en ;
   dqv:expectedDataType xsd:boolean ;
@@ -34,6 +37,7 @@
 
 <https://example.org/metrics/structured-format>
   a dqv:Metric ;
+  skos:prefLabel "Structured format"@en ;
   skos:definition "Checks whether the format is available in the distribution description and is a structured format"@en ;
   skos:scopeNote "Does not check whether the actual distribution uses a structured format"@en ;
   skos:scopeNote "The format could be proprietary (e.g. Excel)"@en ;
@@ -43,6 +47,7 @@
 
 <https://example.org/metrics/open-format>
   a dqv:Metric ;
+  skos:prefLabel "Open format"@en ;
   skos:definition "Checks whether the format is available in the distribution description and is a standardized, open format"@en ;
   skos:scopeNote "Does not check whether the actual distribution uses a standardized, open format"@en ;
   skos:scopeNote "Valid formats: text/csv, application/json, application/xml, all RDF formats"@en ;
@@ -51,6 +56,7 @@
 
 <https://example.org/metrics/rdf-format>
   a dqv:Metric ;
+  skos:prefLabel "RDF format"@en ;
   skos:definition "Checks whether the format is available in the distribution description and is an RDF format"@en ;
   skos:scopeNote "Does not check whether the actual distribution uses an RDF format"@en ;
   skos:scopeNote "Valid formats: text/turtle, application/rdf+xml, application/trig, application/n-quads, application/n-triples, text/n3, application/ld+json, application/sparql-query"@en ;

--- a/apps/dataset-browser/fixtures/search/metrics.ttl
+++ b/apps/dataset-browser/fixtures/search/metrics.ttl
@@ -1,0 +1,58 @@
+###############################
+# Sample data for testing
+###############################
+
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix ldqd: <http://www.w3.org/2016/05/ldqd#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Definitions of metrics for measuring the quality of descriptions of datasets and their distributions
+
+<https://example.org/metrics/open-license>
+  a dqv:Metric ;
+  skos:definition "Checks whether the license is available in the dataset description and is a standardized, open license"@en ;
+  skos:scopeNote "Valid licenses: https?://creativecommons.org/publicdomain/*, https?://creativecommons.org/licenses/*, https?://opendatacommons.org/licenses/*, https?://rightsstatements.org/vocab/NoC-CR/1.0/, https?://rightsstatements.org/vocab/NoC-NC/1.0/, https?://rightsstatements.org/vocab/NoC-OKLR/1.0/, https?://rightsstatements.org/vocab/NoC-US/1.0/"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:licensing .
+
+<https://example.org/metrics/languages>
+  a dqv:Metric ;
+  skos:definition "Checks whether language codes are available in the dataset description that make clear in which languages the dataset is available"@en ;
+  skos:scopeNote "Does not check whether the languages codes are valid (e.g. according to https://www.rfc-editor.org/rfc/rfc5646)"@en ;
+  skos:scopeNote "Does not check whether the languages codes in the dataset description are the same as or different from the language codes used in the distribution (consistency)"@en ;
+  skos:scopeNote "Does not check whether the languages codes are also the codes that ought to be present"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:availability .
+
+<https://example.org/metrics/downloadable>
+  a dqv:Metric ;
+  skos:definition "Checks whether a download URL or access URL is available in the distribution description"@en ;
+  skos:scopeNote "Does not check whether the actual distribution is downloadable"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:availability .
+
+<https://example.org/metrics/structured-format>
+  a dqv:Metric ;
+  skos:definition "Checks whether the format is available in the distribution description and is a structured format"@en ;
+  skos:scopeNote "Does not check whether the actual distribution uses a structured format"@en ;
+  skos:scopeNote "The format could be proprietary (e.g. Excel)"@en ;
+  skos:scopeNote "Valid formats: application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, all CSV, JSON, XML and RDF formats"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:interoperability .
+
+<https://example.org/metrics/open-format>
+  a dqv:Metric ;
+  skos:definition "Checks whether the format is available in the distribution description and is a standardized, open format"@en ;
+  skos:scopeNote "Does not check whether the actual distribution uses a standardized, open format"@en ;
+  skos:scopeNote "Valid formats: text/csv, application/json, application/xml, all RDF formats"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:interoperability .
+
+<https://example.org/metrics/rdf-format>
+  a dqv:Metric ;
+  skos:definition "Checks whether the format is available in the distribution description and is an RDF format"@en ;
+  skos:scopeNote "Does not check whether the actual distribution uses an RDF format"@en ;
+  skos:scopeNote "Valid formats: text/turtle, application/rdf+xml, application/trig, application/n-quads, application/n-triples, text/n3, application/ld+json, application/sparql-query"@en ;
+  dqv:expectedDataType xsd:boolean ;
+  dqv:inDimension ldqd:interoperability .


### PR DESCRIPTION
This PR adds some mock data for the Dataset Browser. The data will allow us to present transparency measurements of datasets in the app. The Dataset Fetcher doesn't make use of this data yet - I still need to update it.