### PR TITLE
Downgrade "next" to 13.3.0

### DIFF
--- a/apps/dataset-browser/package.json
+++ b/apps/dataset-browser/package.json
@@ -28,7 +28,7 @@
     "@heroicons/react": "2.0.17",
     "@next/mdx": "13.3.1",
     "classnames": "2.3.2",
-    "next": "13.3.1",
+    "next": "13.3.0",
     "next-intl": "2.13.0-beta.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -27,7 +27,7 @@
     "@heroicons/react": "2.0.17",
     "@next/mdx": "13.3.1",
     "classnames": "2.3.2",
-    "next": "13.3.1",
+    "next": "13.3.0",
     "next-intl": "2.13.0-beta.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@heroicons/react": "2.0.17",
         "@next/mdx": "13.3.1",
         "classnames": "2.3.2",
-        "next": "13.3.1",
+        "next": "13.3.0",
         "next-intl": "2.13.0-beta.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -105,7 +105,7 @@
         "@heroicons/react": "2.0.17",
         "@next/mdx": "13.3.1",
         "classnames": "2.3.2",
-        "next": "13.3.1",
+        "next": "13.3.0",
         "next-intl": "2.13.0-beta.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1713,9 +1713,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.1.tgz",
-      "integrity": "sha512-UXPtriEc/pBP8luSLSCZBcbzPeVv+SSjs9cH/KygTbhmACye8/OOXRZO13Z2Wq1G0gLmEAIHQAOuF+vafPd2lw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
+      "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
       "cpu": [
         "arm64"
       ],
@@ -1728,9 +1728,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.1.tgz",
-      "integrity": "sha512-lT36yYxosCfLtplFzJWgo0hrPu6/do8+msgM7oQkPeohDNdhjtjFUgOOwdSnPublLR6Mo2Ym4P/wl5OANuD2bw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
+      "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
       "cpu": [
         "x64"
       ],
@@ -1743,9 +1743,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.1.tgz",
-      "integrity": "sha512-wRb76nLWJhonH8s3kxC/1tFguEkeOPayIwe9mkaz1G/yeS3OrjeyKMJsb4+Kdg0zbTo53bNCOl59NNtDM7yyyw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
+      "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
       "cpu": [
         "arm64"
       ],
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.1.tgz",
-      "integrity": "sha512-qz3BzjJRZ16Iq/jrp+pjiYOc0jTjHlfmxQmZk9x/+5uhRP6/eWQSTAPVJ33BMo6oK5O5N4644OgTAbzXzorecg==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
+      "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.1.tgz",
-      "integrity": "sha512-6mgkLmwlyWlomQmpl21I3hxgqE5INoW4owTlcLpNsd1V4wP+J46BlI/5zV5KWWbzjfncIqzXoeGs5Eg+1GHODA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
+      "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
       "cpu": [
         "x64"
       ],
@@ -1788,9 +1788,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.1.tgz",
-      "integrity": "sha512-uqm5sielhQmKJM+qayIhgZv1KlS5pqTdQ99b+Z7hMWryXS96qE0DftTmMZowBcUL6x7s2vSXyH5wPtO1ON7LBg==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
+      "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
       "cpu": [
         "x64"
       ],
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.1.tgz",
-      "integrity": "sha512-WomIiTj/v3LevltlibNQKmvrOymNRYL+a0dp5R73IwPWN5FvXWwSELN/kiNALig/+T3luc4qHNTyvMCp9L6U5Q==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
+      "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
       "cpu": [
         "arm64"
       ],
@@ -1818,9 +1818,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.1.tgz",
-      "integrity": "sha512-M+PoH+0+q658wRUbs285RIaSTYnGBSTdweH/0CdzDgA6Q4rBM0sQs4DHmO3BPP0ltCO/vViIoyG7ks66XmCA5g==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
+      "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
       "cpu": [
         "ia32"
       ],
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.1.tgz",
-      "integrity": "sha512-Sl1F4Vp5Z1rNXWZYqJwMuWRRol4bqOB6+/d7KqkgQ4AcafKPN1PZmpkCoxv4UFHtFNIB7EotnuIhtXu3zScicQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
+      "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
       "cpu": [
         "x64"
       ],
@@ -1944,9 +1944,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.0.tgz",
-      "integrity": "sha512-SjY/p4MmECVVEWspzSRpQEM3sjR17sP8PbGxELWrT+YZMBfiUyt1MRUNjMV23zohwlG2HYtCQOsCwsTHguXkyg==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -7727,12 +7727,12 @@
       }
     },
     "node_modules/next": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.3.1.tgz",
-      "integrity": "sha512-eByWRxPzKHs2oQz1yE41LX35umhz86ZSZ+mYyXBqn2IBi2hyUqxBA88avywdr4uyH+hCJczegGsDGWbzQA5Rqw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
+      "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
       "dependencies": {
-        "@next/env": "13.3.1",
-        "@swc/helpers": "0.5.0",
+        "@next/env": "13.3.0",
+        "@swc/helpers": "0.4.14",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -7742,18 +7742,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.3.1",
-        "@next/swc-darwin-x64": "13.3.1",
-        "@next/swc-linux-arm64-gnu": "13.3.1",
-        "@next/swc-linux-arm64-musl": "13.3.1",
-        "@next/swc-linux-x64-gnu": "13.3.1",
-        "@next/swc-linux-x64-musl": "13.3.1",
-        "@next/swc-win32-arm64-msvc": "13.3.1",
-        "@next/swc-win32-ia32-msvc": "13.3.1",
-        "@next/swc-win32-x64-msvc": "13.3.1"
+        "@next/swc-darwin-arm64": "13.3.0",
+        "@next/swc-darwin-x64": "13.3.0",
+        "@next/swc-linux-arm64-gnu": "13.3.0",
+        "@next/swc-linux-arm64-musl": "13.3.0",
+        "@next/swc-linux-x64-gnu": "13.3.0",
+        "@next/swc-linux-x64-musl": "13.3.0",
+        "@next/swc-win32-arm64-msvc": "13.3.0",
+        "@next/swc-win32-ia32-msvc": "13.3.0",
+        "@next/swc-win32-x64-msvc": "13.3.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7779,9 +7779,9 @@
       }
     },
     "node_modules/next/node_modules/@next/env": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.1.tgz",
-      "integrity": "sha512-EDtCoedIZC7JlUQ3uaQpSc4aVmyhbLHmQVALg7pFfQgOTjgSnn7mKtA0DiCMkYvvsx6aFb5octGMtWrOtGXW9A=="
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
+      "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",
@@ -10761,7 +10761,7 @@
       "dependencies": {
         "@heroicons/react": "2.0.17",
         "classnames": "2.3.2",
-        "next": "13.3.1",
+        "next": "13.3.0",
         "next-intl": "2.13.0-beta.2",
         "react": "18.2.0"
       },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@heroicons/react": "2.0.17",
     "classnames": "2.3.2",
-    "next": "13.3.1",
+    "next": "13.3.0",
     "next-intl": "2.13.0-beta.2",
     "react": "18.2.0"
   }


### PR DESCRIPTION
The production Vercel build shows an error similar to this issue:

https://github.com/vercel/next.js/issues/48872

For now, downgrade to a stable version of Next and follow this issue.