### PR TITLE
refactor: new LRU cache, improved SPARQL query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9944,6 +9944,14 @@
         "globrex": "^0.1.2"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.0.1.tgz",
+      "integrity": "sha512-iNgFugVuQgBKrqeO/mpiTTgmBsTP0WL6yeuLfLs/Ctf0pI/ixGqIRm8sDCwMcXGe9WWvt2sGXI5mNqZbValmJg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -10717,7 +10725,7 @@
       "dependencies": {
         "@colonial-collections/iris": "*",
         "fetch-sparql-endpoint": "3.2.1",
-        "lru-cache": "9.0.1",
+        "tiny-lru": "11.0.1",
         "zod": "3.21.4"
       },
       "devDependencies": {
@@ -10733,14 +10741,6 @@
       },
       "engines": {
         "node": "18.x"
-      }
-    },
-    "packages/label-fetcher/node_modules/lru-cache": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.0.1.tgz",
-      "integrity": "sha512-C8QsKIN1UIXeOs3iWmiZ1lQY+EnKDojWd37fXy1aSbJvH4iSma1uy2OWuoB3m4SYRli5+CUjDv3Dij5DVoetmg==",
-      "engines": {
-        "node": "14 || >=16.14"
       }
     },
     "packages/tailwind-config": {

--- a/packages/label-fetcher/package.json
+++ b/packages/label-fetcher/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@colonial-collections/iris": "*",
     "fetch-sparql-endpoint": "3.2.1",
-    "lru-cache": "9.0.1",
+    "tiny-lru": "11.0.1",
     "zod": "3.21.4"
   },
   "devDependencies": {

--- a/packages/label-fetcher/src/label-fetcher.integration.test.ts
+++ b/packages/label-fetcher/src/label-fetcher.integration.test.ts
@@ -41,7 +41,10 @@ describe('getByIds', () => {
 
   it('returns the label of the provided IRI', async () => {
     await labelFetcher.loadByIris({
-      iris: ['http://www.wikidata.org/entity/Q33432813'],
+      iris: [
+        'http://www.wikidata.org/entity/Q33432813',
+        'http://www.wikidata.org/entity/Q1309',
+      ],
       predicates: ['http://www.w3.org/2000/01/rdf-schema#label'],
     });
 


### PR DESCRIPTION
This PR brings in a new, smaller LRU cache for the label fetcher and improves the SPARQL query that is used for fetching labels.