### PR TITLE
fix: total hits

### DIFF
--- a/apps/dataset-browser/src/lib/datasets/fetcher.ts
+++ b/apps/dataset-browser/src/lib/datasets/fetcher.ts
@@ -323,6 +323,7 @@ export class DatasetFetcher {
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
 
     const searchRequest = {
+      track_total_hits: true,
       size: options.limit,
       from: options.offset,
       sort: [
@@ -342,7 +343,7 @@ export class DatasetFetcher {
           ],
           filter: [
             {
-              // Only return documents of type 'Dataset'
+              // Only return documents of a specific type
               terms: {
                 [`${RawDatasetKeys.Type}.keyword`]: [
                   'https://colonialcollections.nl/search#Dataset',

--- a/apps/researcher/src/lib/objects/fetcher.ts
+++ b/apps/researcher/src/lib/objects/fetcher.ts
@@ -313,6 +313,7 @@ export class HeritageObjectFetcher {
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
 
     const searchRequest = {
+      track_total_hits: true,
       size: options.limit,
       from: options.offset,
       sort: [
@@ -335,7 +336,7 @@ export class HeritageObjectFetcher {
               // Only return documents of a specific type
               terms: {
                 [`${RawKeys.Type}.keyword`]: [
-                  'https://colonialcollections.nl/search#Thing',
+                  'https://colonialcollections.nl/search#HeritageObject',
                 ],
               },
             },

--- a/apps/researcher/src/lib/persons/fetcher.ts
+++ b/apps/researcher/src/lib/persons/fetcher.ts
@@ -259,6 +259,7 @@ export class PersonFetcher {
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
 
     const searchRequest = {
+      track_total_hits: true,
       size: options.limit,
       from: options.offset,
       sort: [


### PR DESCRIPTION
This PR adds the `track_total_hits` property to requests to Elasticsearch. In reply, ES gives the actual total number of hits matching the query. This differs from the current number of hits, which is limited to 10,000 hits (= default max).