### PR TITLE
fix: revalidate pages

### DIFF
--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -32,8 +32,8 @@ import {
 import {useTranslations} from 'next-intl';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 
-// Revalidate the page
-export const revalidate = 0;
+// Revalidate the page every n seconds
+export const revalidate = 60;
 
 // Set the order of the filters
 const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [

--- a/apps/researcher/src/app/[locale]/page.tsx
+++ b/apps/researcher/src/app/[locale]/page.tsx
@@ -33,8 +33,8 @@ import {useTranslations} from 'next-intl';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import Tabs from './tabs';
 
-// Revalidate the page
-export const revalidate = 0;
+// Revalidate the page every n seconds
+export const revalidate = 60;
 
 // Set the order of the filters
 const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -33,8 +33,8 @@ import {useTranslations} from 'next-intl';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import Tabs from '../tabs';
 
-// Revalidate the page
-export const revalidate = 0;
+// Revalidate the page every n seconds
+export const revalidate = 60;
 
 // Set the order of the filters
 const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [


### PR DESCRIPTION
This PR sets the `revalidate` property of each page to 60 seconds. This makes the app a bit snappier because results are being cached. The `revalidate` gave some issues before (e.g. stale cache) - if these persist we can revert this change.