### PR TITLE
Loading screen for the researcher

### DIFF
--- a/apps/researcher/src/app/[locale]/loading.tsx
+++ b/apps/researcher/src/app/[locale]/loading.tsx
@@ -1,0 +1,44 @@
+import {useLocale, NextIntlClientProvider} from 'next-intl';
+import Tabs from './tabs';
+
+export default async function Loading() {
+  const locale = useLocale();
+  const messages = (await import(`@/messages/${locale}/messages.json`)).default;
+
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={{
+        Tabs: messages.Tabs,
+      }}
+    >
+      <Tabs />
+
+      <div className="flex flex-col md:flex-row gap-6">
+        <aside
+          id="facets"
+          className="hidden md:flex w-full md:w-1/3 flex-row md:flex-col gap-10 overscroll-x-auto flex-nowrap border-white border-r-2"
+        ></aside>
+
+        <section className="w-full md:w-2/3 gap-6 flex flex-col">
+          <div className="flex flex-1 flex-col space-y-2 p-6">
+            <div className="bg-sand-100 h-4 w-3/4 rounded"></div>
+            <div className="bg-sand-100 h-4 w-1/2 rounded mt-12"></div>
+          </div>
+
+          <div className="group relative flex flex-col overflow-hidden drop-shadow-md bg-white min-h-[150px] animate-pulse opacity-80">
+            <div className="flex flex-1 flex-col space-y-2 p-6">
+              <div className="bg-sand-100 h-4 w-3/4 rounded"></div>
+            </div>
+          </div>
+
+          <div className="group relative flex flex-col overflow-hidden drop-shadow-md bg-white min-h-[150px] animate-pulse opacity-60">
+            <div className="flex flex-1 flex-col space-y-2 p-6">
+              <div className="bg-sand-100 h-4 w-1/4 rounded"></div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </NextIntlClientProvider>
+  );
+}

--- a/apps/researcher/src/app/[locale]/tabs.tsx
+++ b/apps/researcher/src/app/[locale]/tabs.tsx
@@ -1,16 +1,22 @@
-'use client';
-
 import classNames from 'classnames';
 import {ObjectIcon, PersonIcon} from '@/components/icons';
-import {usePathname} from 'next-intl/client';
 import {useTranslations} from 'next-intl';
+import {headers} from 'next/headers';
 
 export default function Tabs() {
   const t = useTranslations('Tabs');
-  const pathname = usePathname();
+
+  // The header 'x-invoke-path' always contains the language prefix even if the next-intl middleware removed it
+  const activePath = headers().get('x-invoke-path') || '';
+
   const tabs = [
-    {name: t('objects'), href: '/', icon: ObjectIcon},
-    {name: t('persons'), href: '/persons', icon: PersonIcon},
+    {name: t('objects'), current: /^\/[^/]+$/, href: '/', icon: ObjectIcon},
+    {
+      name: t('persons'),
+      current: /\/persons$/,
+      href: '/persons',
+      icon: PersonIcon,
+    },
   ];
 
   return (
@@ -18,7 +24,7 @@ export default function Tabs() {
       <div className="border-b border-gray-200">
         <nav className="-mb-px flex space-x-8" aria-label="Tabs">
           {tabs.map(tab => {
-            const isCurrentPathname = tab.href === pathname;
+            const isCurrentPathname = tab.current.test(activePath);
             return (
               <a
                 key={tab.name}

--- a/apps/researcher/src/app/[locale]/tabs.tsx
+++ b/apps/researcher/src/app/[locale]/tabs.tsx
@@ -2,18 +2,23 @@ import classNames from 'classnames';
 import {ObjectIcon, PersonIcon} from '@/components/icons';
 import {useTranslations} from 'next-intl';
 import {headers} from 'next/headers';
+import {locales} from '@/middleware';
 
 export default function Tabs() {
   const t = useTranslations('Tabs');
 
-  // The header 'x-invoke-path' always contains the language prefix even if the next-intl middleware removed it
-  const activePath = headers().get('x-invoke-path') || '';
+  const activePath = headers().get('x-pathname') || '/';
 
   const tabs = [
-    {name: t('objects'), current: /^\/[^/]+$/, href: '/', icon: ObjectIcon},
+    {
+      name: t('objects'),
+      isCurrentRegex: `^/(${locales.join('|')})?$`,
+      href: '/',
+      icon: ObjectIcon,
+    },
     {
       name: t('persons'),
-      current: /\/persons$/,
+      isCurrentRegex: `^(/(${locales.join('|')}))?/persons$`,
       href: '/persons',
       icon: PersonIcon,
     },
@@ -24,7 +29,9 @@ export default function Tabs() {
       <div className="border-b border-gray-200">
         <nav className="-mb-px flex space-x-8" aria-label="Tabs">
           {tabs.map(tab => {
-            const isCurrentPathname = tab.current.test(activePath);
+            const isCurrentPathname = new RegExp(tab.isCurrentRegex).test(
+              activePath
+            );
             return (
               <a
                 key={tab.name}

--- a/apps/researcher/src/middleware.ts
+++ b/apps/researcher/src/middleware.ts
@@ -1,4 +1,5 @@
 import createIntlMiddleware from 'next-intl/middleware';
+import type {NextRequest} from 'next/server';
 
 // Set the available locales here. These values should match a .json file in /messages.
 // The const `locales` cannot be set dynamically based on files in /messages,
@@ -6,18 +7,29 @@ import createIntlMiddleware from 'next-intl/middleware';
 // So you can't read the filesystem.
 export const locales = ['en', 'nl'];
 
-// The middleware intercepts requests to `/` and will redirect
-// to one of the configured locales instead (e.g. `/en`).
-// In the background a cookie is set that will remember the
-// locale of the last page that the user has visited.
-// The middleware furthermore passes the resolved locale
-// to components in your app.
-export default createIntlMiddleware({
-  locales,
-  defaultLocale: 'en',
-});
-
 export const config = {
   // Skip all internal paths
   matcher: ['/((?!api|_next|favicon.ico).*)'],
 };
+
+export default function middleware(request: NextRequest) {
+  // This middleware intercepts requests to `/` and will redirect
+  // to one of the configured locales instead (e.g. `/en`).
+  // In the background a cookie is set that will remember the
+  // locale of the last page that the user has visited.
+  // The middleware furthermore passes the resolved locale
+  // to components in your app.
+  const handleI18nRouting = createIntlMiddleware({
+    locales,
+    defaultLocale: 'en',
+  });
+
+  const response = handleI18nRouting(request);
+
+  // Store current request pathname in the response header,
+  // this can be used to set the active menu/tab item.
+  // See issue: https://github.com/vercel/next.js/issues/43704
+  response.headers.set('x-pathname', request.nextUrl.pathname);
+
+  return response;
+}


### PR DESCRIPTION
This is the first pull request about loading components. This pull request contains a loading screen for the researcher app. The following steps (out of the scope of this pull request) are the loading component after clicking on a filter and adding the loading screen to the dataset browser. It would be nice to finish this layout first so I can use it for the next steps.

@Doppen  I did not add "loading..." to the page header as suggested in the issue #15 . It felt busy. But you are more than welcome to play around with the loading component. I will wait for your approval before working on the loading after filtering.

It can be hard to see the loading screen, adding this locally to the page.tsx can help: `await new Promise(resolve => setTimeout(resolve, 2000));`

About the tabs: In the current production version of the researcher, after clicking on one tab, it will wait till the list is loaded before the related tab is active. I want the tab to be active sooner.

To fix this, I have added the Tabs component to the Next.js loading component. However, this did bring a new problem. Showing an active tab in a server component can be complex. See this issue: https://github.com/vercel/next.js/issues/43704.

That is why the Tabs component was a client component. But in the loading component, `usePathname` was undefined. So with this solution, the tabs were loading, but the active tab was only selected once the list was fully loaded. 

So I decided to go the server component route and select the active tab using headers and a regex, described in the nextjs issue: https://github.com/vercel/next.js/issues/43704