### PR TITLE
Remove `.vscode` folder in sub directories

### DIFF
--- a/apps/dataset-browser/.vscode/settings.json
+++ b/apps/dataset-browser/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "typescript.tsdk": "../../node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
-}

--- a/apps/researcher/.vscode/settings.json
+++ b/apps/researcher/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "typescript.tsdk": "../../node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
-}


### PR DESCRIPTION
There is already a  `.vscode` folder at the root level. Next.js automatically added these sub-folders. It's now possible to remove them: https://github.com/vercel/next.js/issues/42213