### PR TITLE
Optimize images in the object list

### DIFF
--- a/apps/researcher/src/app/[locale]/(objects)/heritage-object-card.tsx
+++ b/apps/researcher/src/app/[locale]/(objects)/heritage-object-card.tsx
@@ -38,6 +38,14 @@ export default function HeritageObjectCard({heritageObject}: Props) {
               src={heritageObject.images[0].contentUrl}
               alt={heritageObject.name || ''}
               fill
+              // For min-width 1280px:
+              // The page container is max 1280px. So above 1280px the size is fixed to 200px
+              // For width 768px - 1280px:
+              // The list is 2/4 of the page. The image is 1/4 of the list.
+              // For max-width: 768px:
+              // The image is 1/4 of page.
+              sizes="(min-width: 1280px) 200px, (min-width: 768px) 17vw, 25vw"
+              quality={40}
               className="object-contain object-center"
             />
           </div>


### PR DESCRIPTION
In the current production, the first image is 214kb: https://dev.app.colonialcollections.nl/
If you optimize the size of the image, the image is 9.7kb: https://colonial-collections-researcher-git-im-62c720-colonial-heritage.vercel.app/nl
If you lower the qualify from Next.js default of 75% to 50%, the image will be 4.8kb https://colonial-collections-researcher-muhvzs1pb-colonial-heritage.vercel.app/nl
If you go to 40%, the image will be 4.1kb: https://colonial-collections-researcher-jdisgl0tj-colonial-heritage.vercel.app/nl 

After a discussion with Bas, we decided on the lowest settings. I will keep these test branches till after the merge, so you can easily compare the different settings.