### PR TITLE
Set end-to-end tests timeouts to 10 minutes

### DIFF
--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -18,7 +18,7 @@ jobs:
         id: waitForPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 180
+          max_timeout: 600
           environment: Preview – colonial-collections-dataset-browser
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -18,7 +18,7 @@ jobs:
         id: waitForPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 180
+          max_timeout: 600
           environment: Preview – colonial-collections-researcher
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
closes #132 

I decided to upscale the timeout to 10 minutes. GitHub actions are free for open projects, so I can safely set this very high. 

Moving the deployment to Github actions was not easy together with Turborepo. And googling for solutions. I found that most people just use a high timeout. See, for example https://kontent.ai/blog/next-js-playwright-tests-github-action/