### PR TITLE
feat: expose dataset publisher

### DIFF
--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -9,10 +9,13 @@ export type Thing = {
 
 export type Term = Thing;
 export type Place = Thing;
-export type Dataset = Thing;
 export type Person = Thing & {type: 'Person'};
 export type Unknown = Thing & {type: 'Unknown'};
 export type Agent = Person | Organization | Unknown;
+
+export type Dataset = Thing & {
+  publisher?: Agent; // TBD: is this a required property?
+};
 
 export type PostalAddress = {
   id: string;

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -112,7 +112,15 @@ describe('getById', () => {
         id: 'https://museum.example.org/',
         name: 'Museum',
       },
-      isPartOf: {id: 'https://example.org/datasets/1', name: 'Dataset 1'},
+      isPartOf: {
+        id: 'https://example.org/datasets/1',
+        name: 'Dataset 1',
+        publisher: {
+          id: 'https://museum.example.org/',
+          type: 'Organization',
+          name: 'Museum',
+        },
+      },
     });
   });
 });

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
@@ -1,12 +1,8 @@
 import {ontologyUrl, Place, ProvenanceEvent, Term} from '../definitions';
-import {getPropertyValue, onlyOne} from '../rdf-helpers';
-import {
-  createThingsFromProperties,
-  createAgentsFromProperties,
-} from './rdf-helpers';
+import {getPropertyValue, onlyOne, removeUndefinedValues} from '../rdf-helpers';
+import {createThings, createAgents} from './rdf-helpers';
 import {SparqlEndpointFetcher} from 'fetch-sparql-endpoint';
 import {isIri} from '@colonial-collections/iris';
-import {merge} from '@hapi/hoek';
 import type {Readable} from 'node:stream';
 import {Resource, RdfObjectLoader} from 'rdf-object';
 import type {Stream} from '@rdfjs/types';
@@ -320,22 +316,15 @@ export class ProvenanceEventsFetcher {
     const description = getPropertyValue(rawProvenanceEvent, 'cc:description');
     const startsAfter = getPropertyValue(rawProvenanceEvent, 'cc:startsAfter');
     const endsBefore = getPropertyValue(rawProvenanceEvent, 'cc:endsBefore');
-
-    const types = createThingsFromProperties<Term>(
-      rawProvenanceEvent,
-      'cc:additionalType'
-    );
-
+    const types = createThings<Term>(rawProvenanceEvent, 'cc:additionalType');
     const location = onlyOne(
-      createThingsFromProperties<Place>(rawProvenanceEvent, 'cc:location')
+      createThings<Place>(rawProvenanceEvent, 'cc:location')
     );
-
     const transferredFromAgent = onlyOne(
-      createAgentsFromProperties(rawProvenanceEvent, 'cc:transferredFrom')
+      createAgents(rawProvenanceEvent, 'cc:transferredFrom')
     );
-
     const transferredToAgent = onlyOne(
-      createAgentsFromProperties(rawProvenanceEvent, 'cc:transferredTo')
+      createAgents(rawProvenanceEvent, 'cc:transferredTo')
     );
 
     const provenanceEventWithUndefinedValues: ProvenanceEvent = {
@@ -351,9 +340,9 @@ export class ProvenanceEventsFetcher {
       transferredTo: transferredToAgent,
     };
 
-    const provenanceEvent = merge({}, provenanceEventWithUndefinedValues, {
-      nullOverride: false,
-    });
+    const provenanceEvent = removeUndefinedValues<ProvenanceEvent>(
+      provenanceEventWithUndefinedValues
+    );
 
     return provenanceEvent;
   }

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -34,19 +34,19 @@ beforeAll(async () => {
       cc:isPartOf ex:dataset1, ex:dataset2 .
 
     ex:subject1 a cc:Term ;
-      cc:name "Term 1" .
+      cc:name "Term" .
 
     ex:subject2 a cc:Term .
 
     ex:creator1 a cc:Person ;
-      cc:name "Person 1" .
+      cc:name "Person" .
 
     ex:creator2 a cc:Organization ;
-      cc:name "Organization 2" .
+      cc:name "Organization" .
 
     ex:creator3 a cc:Organization .
 
-    ex:creator4 cc:name "Organization 4" .
+    ex:creator4 cc:name "Organization" .
 
     ex:image1 a cc:Image ;
       cc:contentUrl <https://example.org/image1.jpg> .
@@ -73,14 +73,14 @@ beforeAll(async () => {
       cc:publisher ex:publisher1 .
 
     ex:publisher1 a cc:Organization ;
-      cc:name "Organization 1" .
+      cc:name "Publishing organization" .
 
     ex:dataset2 a cc:Dataset ;
       cc:name "Dataset 2" ;
       cc:publisher ex:publisher2 .
 
-    ex:publisher2 a cc:Organization ;
-      cc:name "Organization 2" .
+    ex:publisher2 a cc:Person ;
+      cc:name "Publishing person" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -101,7 +101,7 @@ describe('createThings', () => {
     const things = createThings(resource, 'cc:subject');
 
     expect(things).toStrictEqual([
-      {id: 'https://example.org/subject1', name: 'Term 1'},
+      {id: 'https://example.org/subject1', name: 'Term'},
       {id: 'https://example.org/subject2', name: undefined},
     ]);
   });
@@ -118,11 +118,11 @@ describe('createAgents', () => {
     const agents = createAgents(resource, 'cc:creator');
 
     expect(agents).toStrictEqual([
-      {type: 'Person', id: 'https://example.org/creator1', name: 'Person 1'},
+      {type: 'Person', id: 'https://example.org/creator1', name: 'Person'},
       {
         type: 'Organization',
         id: 'https://example.org/creator2',
-        name: 'Organization 2',
+        name: 'Organization',
       },
       {
         type: 'Organization',
@@ -132,7 +132,7 @@ describe('createAgents', () => {
       {
         type: 'Unknown',
         id: 'https://example.org/creator4',
-        name: 'Organization 4',
+        name: 'Organization',
       },
     ]);
   });
@@ -209,16 +209,16 @@ describe('createDataset', () => {
         publisher: {
           type: 'Organization',
           id: 'https://example.org/publisher1',
-          name: 'Organization 1',
+          name: 'Publishing organization',
         },
       },
       {
         id: 'https://example.org/dataset2',
         name: 'Dataset 2',
         publisher: {
-          type: 'Organization',
+          type: 'Person',
           id: 'https://example.org/publisher2',
-          name: 'Organization 2',
+          name: 'Publishing person',
         },
       },
     ]);

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -1,9 +1,10 @@
 import {ontologyUrl} from '../definitions';
 import {
-  createAgentsFromProperties,
-  createImagesFromProperties,
-  createThingsFromProperties,
-  createTimeSpansFromProperties,
+  createAgents,
+  createDatasets,
+  createImages,
+  createThings,
+  createTimeSpans,
 } from './rdf-helpers';
 import {describe, expect, it} from '@jest/globals';
 import {RdfObjectLoader, Resource} from 'rdf-object';
@@ -29,7 +30,8 @@ beforeAll(async () => {
       cc:subject ex:subject1, ex:subject2 ;
       cc:creator ex:creator1, ex:creator2, ex:creator3, ex:creator4 ;
       cc:image ex:image1, ex:image2, ex:image3 ;
-      cc:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 .
+      cc:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 ;
+      cc:isPartOf ex:dataset1, ex:dataset2 .
 
     ex:subject1 a cc:Term ;
       cc:name "Term 1" .
@@ -65,6 +67,20 @@ beforeAll(async () => {
     # No start date
     ex:dateCreated3 a cc:TimeSpan ;
       cc:endDate "1900"^^xsd:gYear .
+
+    ex:dataset1 a cc:Dataset ;
+      cc:name "Dataset 1" ;
+      cc:publisher ex:publisher1 .
+
+    ex:publisher1 a cc:Organization ;
+      cc:name "Organization 1" .
+
+    ex:dataset2 a cc:Dataset ;
+      cc:name "Dataset 2" ;
+      cc:publisher ex:publisher2 .
+
+    ex:publisher2 a cc:Organization ;
+      cc:name "Organization 2" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -74,15 +90,15 @@ beforeAll(async () => {
   resource = loader.resources['https://example.org/object1'];
 });
 
-describe('createThingsFromProperties', () => {
-  it('returns undefined if properties do not exist', async () => {
-    const things = createThingsFromProperties(resource, 'cc:unknown');
+describe('createThings', () => {
+  it('returns undefined if properties do not exist', () => {
+    const things = createThings(resource, 'cc:unknown');
 
     expect(things).toBeUndefined();
   });
 
-  it('returns things if properties exist', async () => {
-    const things = createThingsFromProperties(resource, 'cc:subject');
+  it('returns things if properties exist', () => {
+    const things = createThings(resource, 'cc:subject');
 
     expect(things).toStrictEqual([
       {id: 'https://example.org/subject1', name: 'Term 1'},
@@ -91,15 +107,15 @@ describe('createThingsFromProperties', () => {
   });
 });
 
-describe('createAgentsFromProperties', () => {
-  it('returns undefined if properties do not exist', async () => {
-    const agents = createAgentsFromProperties(resource, 'cc:unknown');
+describe('createAgents', () => {
+  it('returns undefined if properties do not exist', () => {
+    const agents = createAgents(resource, 'cc:unknown');
 
     expect(agents).toBeUndefined();
   });
 
-  it('returns agents if properties exist', async () => {
-    const agents = createAgentsFromProperties(resource, 'cc:creator');
+  it('returns agents if properties exist', () => {
+    const agents = createAgents(resource, 'cc:creator');
 
     expect(agents).toStrictEqual([
       {type: 'Person', id: 'https://example.org/creator1', name: 'Person 1'},
@@ -122,15 +138,15 @@ describe('createAgentsFromProperties', () => {
   });
 });
 
-describe('createImagesFromProperties', () => {
-  it('returns undefined if properties do not exist', async () => {
-    const images = createImagesFromProperties(resource, 'cc:unknown');
+describe('createImages', () => {
+  it('returns undefined if properties do not exist', () => {
+    const images = createImages(resource, 'cc:unknown');
 
     expect(images).toBeUndefined();
   });
 
-  it('returns images if properties exist', async () => {
-    const images = createImagesFromProperties(resource, 'cc:image');
+  it('returns images if properties exist', () => {
+    const images = createImages(resource, 'cc:image');
 
     expect(images).toStrictEqual([
       {
@@ -146,15 +162,15 @@ describe('createImagesFromProperties', () => {
   });
 });
 
-describe('createTimeSpanFromProperties', () => {
-  it('returns undefined if properties do not exist', async () => {
-    const timeSpans = createTimeSpansFromProperties(resource, 'cc:unknown');
+describe('createTimeSpan', () => {
+  it('returns undefined if properties do not exist', () => {
+    const timeSpans = createTimeSpans(resource, 'cc:unknown');
 
     expect(timeSpans).toBeUndefined();
   });
 
-  it('returns time spans if properties exist', async () => {
-    const timeSpans = createTimeSpansFromProperties(resource, 'cc:dateCreated');
+  it('returns time spans if properties exist', () => {
+    const timeSpans = createTimeSpans(resource, 'cc:dateCreated');
 
     expect(timeSpans).toStrictEqual([
       {
@@ -171,6 +187,39 @@ describe('createTimeSpanFromProperties', () => {
         id: 'https://example.org/dateCreated3',
         startDate: undefined,
         endDate: new Date('1900-01-01'),
+      },
+    ]);
+  });
+});
+
+describe('createDataset', () => {
+  it('returns undefined if properties do not exist', () => {
+    const datasets = createDatasets(resource, 'cc:unknown');
+
+    expect(datasets).toBeUndefined();
+  });
+
+  it('returns datasets if properties exist', () => {
+    const datasets = createDatasets(resource, 'cc:isPartOf');
+
+    expect(datasets).toStrictEqual([
+      {
+        id: 'https://example.org/dataset1',
+        name: 'Dataset 1',
+        publisher: {
+          type: 'Organization',
+          id: 'https://example.org/publisher1',
+          name: 'Organization 1',
+        },
+      },
+      {
+        id: 'https://example.org/dataset2',
+        name: 'Dataset 2',
+        publisher: {
+          type: 'Organization',
+          id: 'https://example.org/publisher2',
+          name: 'Organization 2',
+        },
       },
     ]);
   });

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
       cc:creator ex:creator1, ex:creator2, ex:creator3, ex:creator4 ;
       cc:image ex:image1, ex:image2, ex:image3 ;
       cc:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 ;
-      cc:isPartOf ex:dataset1, ex:dataset2 .
+      cc:isPartOf ex:dataset1, ex:dataset2, ex:dataset3 .
 
     ex:subject1 a cc:Term ;
       cc:name "Term" .
@@ -81,6 +81,10 @@ beforeAll(async () => {
 
     ex:publisher2 a cc:Person ;
       cc:name "Publishing person" .
+
+    # No publisher
+    ex:dataset3 a cc:Dataset ;
+      cc:name "Dataset 3" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -220,6 +224,11 @@ describe('createDataset', () => {
           id: 'https://example.org/publisher2',
           name: 'Publishing person',
         },
+      },
+      {
+        id: 'https://example.org/dataset3',
+        name: 'Dataset 3',
+        publisher: undefined,
       },
     ]);
   });

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -51,12 +51,12 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Museum',
-            name: 'Museum',
+          owner: {type: 'Organization', id: 'Museum', name: 'Museum'},
+          isPartOf: {
+            id: 'https://example.org/datasets/1',
+            name: 'Dataset 1',
+            publisher: {type: 'Organization', id: 'Museum', name: 'Museum'},
           },
-          isPartOf: {id: 'https://example.org/datasets/1', name: 'Dataset 1'},
         },
         {
           id: 'https://example.org/objects/2',
@@ -81,7 +81,15 @@ describe('search', () => {
             id: 'Research Organisation',
             name: 'Research Organisation',
           },
-          isPartOf: {id: 'https://example.org/datasets/13', name: 'Dataset 13'},
+          isPartOf: {
+            id: 'https://example.org/datasets/13',
+            name: 'Dataset 13',
+            publisher: {
+              type: 'Organization',
+              id: 'Research Organisation',
+              name: 'Research Organisation',
+            },
+          },
         },
         {
           id: 'https://example.org/objects/3',
@@ -99,17 +107,21 @@ describe('search', () => {
             {id: 'Ink', name: 'Ink'},
             {id: 'Paper', name: 'Paper'},
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Library',
-            name: 'Library',
+          owner: {type: 'Organization', id: 'Library', name: 'Library'},
+          isPartOf: {
+            id: 'https://example.org/datasets/10',
+            name: '(No name)',
+            publisher: {type: 'Organization', id: 'Library', name: 'Library'},
           },
-          isPartOf: {id: 'https://example.org/datasets/10', name: '(No name)'},
         },
         {
           id: 'https://example.org/objects/4',
           identifier: '3456',
-          isPartOf: {id: 'https://example.org/datasets/1', name: 'Dataset 1'},
+          isPartOf: {
+            id: 'https://example.org/datasets/1',
+            name: 'Dataset 1',
+            publisher: undefined,
+          },
         },
         {
           id: 'https://example.org/objects/5',
@@ -140,12 +152,12 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Museum',
-            name: 'Museum',
+          owner: {type: 'Organization', id: 'Museum', name: 'Museum'},
+          isPartOf: {
+            id: 'https://example.org/datasets/1',
+            name: 'Dataset 1',
+            publisher: {type: 'Organization', id: 'Museum', name: 'Museum'},
           },
-          isPartOf: {id: 'https://example.org/datasets/1', name: 'Dataset 1'},
         },
       ],
       filters: {

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -11,11 +11,12 @@ import {
   Term,
 } from '../definitions';
 import {SearchResult} from './definitions';
+import {removeUndefinedValues} from '../rdf-helpers';
 import {buildAggregation} from './searcher-request';
 import {buildFilters} from './searcher-result';
 import {getIrisFromObject} from '@colonial-collections/iris';
 import {LabelFetcher} from '@colonial-collections/label-fetcher';
-import {merge, reach} from '@hapi/hoek';
+import {reach} from '@hapi/hoek';
 import {z} from 'zod';
 
 const constructorOptionsSchema = z.object({
@@ -186,6 +187,7 @@ export class HeritageObjectSearcher {
     const dataset: Dataset = {
       id: datasetIri,
       name: this.labelFetcher.getByIri({iri: datasetIri}),
+      publisher: owner, // TODO: update ES by indexing the publisher
     };
 
     // Replace 'names' with IRIs as soon as we have IRIs
@@ -241,9 +243,9 @@ export class HeritageObjectSearcher {
       isPartOf: dataset,
     };
 
-    const heritageObject = merge({}, heritageObjectWithUndefinedValues, {
-      nullOverride: false,
-    });
+    const heritageObject = removeUndefinedValues<HeritageObject>(
+      heritageObjectWithUndefinedValues
+    );
 
     return heritageObject;
   }

--- a/apps/researcher/src/lib/api/organizations/fetcher.ts
+++ b/apps/researcher/src/lib/api/organizations/fetcher.ts
@@ -1,10 +1,9 @@
 import {ontologyUrl, Organization} from '../definitions';
-import {onlyOne} from '../rdf-helpers';
-import {createAddressesFromProperties} from './rdf-helpers';
+import {onlyOne, removeUndefinedValues} from '../rdf-helpers';
+import {createAddresses} from './rdf-helpers';
 import {getPropertyValue} from '../rdf-helpers';
 import {SparqlEndpointFetcher} from 'fetch-sparql-endpoint';
 import {isIri} from '@colonial-collections/iris';
-import {merge} from '@hapi/hoek';
 import type {Readable} from 'node:stream';
 import {RdfObjectLoader} from 'rdf-object';
 import type {Stream} from '@rdfjs/types';
@@ -93,9 +92,7 @@ export class OrganizationFetcher {
 
     const name = getPropertyValue(rawOrganization, 'cc:name');
     const url = getPropertyValue(rawOrganization, 'cc:url');
-    const address = onlyOne(
-      createAddressesFromProperties(rawOrganization, 'cc:address')
-    );
+    const address = onlyOne(createAddresses(rawOrganization, 'cc:address'));
 
     const organizationWithUndefinedValues: Organization = {
       type: 'Organization',
@@ -105,10 +102,9 @@ export class OrganizationFetcher {
       address,
     };
 
-    // Remove undefined values, if any
-    const organization = merge({}, organizationWithUndefinedValues, {
-      nullOverride: false,
-    });
+    const organization = removeUndefinedValues<Organization>(
+      organizationWithUndefinedValues
+    );
 
     return organization;
   }

--- a/apps/researcher/src/lib/api/organizations/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/organizations/rdf-helpers.test.ts
@@ -1,5 +1,5 @@
 import {ontologyUrl} from '../definitions';
-import {createAddressesFromProperties} from './rdf-helpers';
+import {createAddresses} from './rdf-helpers';
 import {describe, expect, it} from '@jest/globals';
 import {RdfObjectLoader, Resource} from 'rdf-object';
 import streamifyString from 'streamify-string';
@@ -43,15 +43,15 @@ beforeAll(async () => {
   resource = loader.resources['https://example.org/organization1'];
 });
 
-describe('createAddressesFromProperties', () => {
-  it('returns undefined if property does not exist', async () => {
-    const addresses = createAddressesFromProperties(resource, 'cc:unknown');
+describe('createAddresses', () => {
+  it('returns undefined if property does not exist', () => {
+    const addresses = createAddresses(resource, 'cc:unknown');
 
     expect(addresses).toBeUndefined();
   });
 
-  it('returns addresses if property exists', async () => {
-    const addresses = createAddressesFromProperties(resource, 'cc:address');
+  it('returns addresses if property exists', () => {
+    const addresses = createAddresses(resource, 'cc:address');
 
     expect(addresses).toStrictEqual([
       {

--- a/apps/researcher/src/lib/api/organizations/rdf-helpers.ts
+++ b/apps/researcher/src/lib/api/organizations/rdf-helpers.ts
@@ -2,26 +2,22 @@ import {PostalAddress} from '../definitions';
 import {getPropertyValue} from '../rdf-helpers';
 import type {Resource} from 'rdf-object';
 
-function createAddressFromProperties(resource: Resource) {
+function createAddress(addressResource: Resource) {
+  // Ignore TS 'undefined' warnings - the properties always exist
   const postalAddress: PostalAddress = {
-    id: resource.value,
-    streetAddress: getPropertyValue(resource, 'cc:streetAddress')!,
-    postalCode: getPropertyValue(resource, 'cc:postalCode')!,
-    addressLocality: getPropertyValue(resource, 'cc:addressLocality')!,
-    addressCountry: getPropertyValue(resource, 'cc:addressCountry')!,
+    id: addressResource.value,
+    streetAddress: getPropertyValue(addressResource, 'cc:streetAddress')!,
+    postalCode: getPropertyValue(addressResource, 'cc:postalCode')!,
+    addressLocality: getPropertyValue(addressResource, 'cc:addressLocality')!,
+    addressCountry: getPropertyValue(addressResource, 'cc:addressCountry')!,
   };
 
   return postalAddress;
 }
 
-export function createAddressesFromProperties(
-  resource: Resource,
-  propertyName: string
-) {
+export function createAddresses(resource: Resource, propertyName: string) {
   const properties = resource.properties[propertyName];
-  const addresses = properties.map(property =>
-    createAddressFromProperties(property)
-  );
+  const addresses = properties.map(property => createAddress(property));
 
   return addresses.length > 0 ? addresses : undefined;
 }

--- a/apps/researcher/src/lib/api/rdf-helpers.ts
+++ b/apps/researcher/src/lib/api/rdf-helpers.ts
@@ -1,7 +1,17 @@
+import {applyToDefaults} from '@hapi/hoek';
 import type {Resource} from 'rdf-object';
 
-export function getPropertyValue(resource: Resource, propertyName: string) {
+export function getProperty(resource: Resource, propertyName: string) {
   const property = resource.property[propertyName];
+  if (property === undefined) {
+    return undefined;
+  }
+
+  return property;
+}
+
+export function getPropertyValue(resource: Resource, propertyName: string) {
+  const property = getProperty(resource, propertyName);
   if (property === undefined) {
     return undefined;
   }
@@ -21,4 +31,12 @@ export function onlyOne<T>(items: T[] | undefined) {
     return items.shift(); // Undefined if array is empty
   }
   return undefined;
+}
+
+export function removeUndefinedValues<T>(objectWithUndefinedValues: object) {
+  const object = applyToDefaults({}, objectWithUndefinedValues, {
+    nullOverride: false, // Ignore null values
+  });
+
+  return object as T;
 }


### PR DESCRIPTION
This PR adds the `publisher` of the dataset to the `HeritageObject`. You can then use the `id` of the publisher to fetch the contact details of the publisher via `Organizations.getById()`.

This resolves [this comment](https://github.com/colonial-heritage/colonial-collections/pull/191#issuecomment-1673330104).

The PR also fixes quite a number of inconsistencies and improves the names of helper functions. These changes shouldn't affect the APIs that the frontend uses.