### PR TITLE
fix: made 'dataset' props optional

### DIFF
--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -14,7 +14,7 @@ export type Unknown = Thing & {type: 'Unknown'};
 export type Agent = Person | Organization | Unknown;
 
 export type Dataset = Thing & {
-  publisher?: Agent; // TBD: is this a required property?
+  publisher?: Agent;
 };
 
 export type PostalAddress = {
@@ -56,7 +56,7 @@ export type HeritageObject = {
   dateCreated?: TimeSpan;
   images?: Image[];
   owner?: Agent;
-  isPartOf: Dataset;
+  isPartOf?: Dataset;
 };
 
 export enum SortBy {

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -246,30 +246,34 @@ export class HeritageObjectFetcher {
         # Part of dataset
         ####################
 
-        ?object la:member_of ?dataset .
-
-        # Required property, but it may not exist in a specific language
         OPTIONAL {
-          ?dataset dct:title ?tmpTitle
-          FILTER(LANG(?tmpTitle) = "" || LANGMATCHES(LANG(?tmpTitle), "en"))
-        }
+          ?object la:member_of ?dataset .
 
-        # TBD: add multi-language support?
-        BIND(COALESCE(?tmpTitle, "(No name)"@en) AS ?datasetName).
+          ####################
+          # Name of dataset
+          ####################
 
-        ####################
-        # Publisher of dataset
-        ####################
+          OPTIONAL {
+            ?dataset dct:title ?datasetName
+            # TBD: how to handle languages?
+            FILTER(LANG(?datasetName) = "" || LANGMATCHES(LANG(?datasetName), "en"))
+          }
 
-        ?dataset dct:publisher ?publisher .
+          ####################
+          # Publisher of dataset
+          ####################
 
-        ?publisher foaf:name ?publisherName ;
-          rdf:type ?publisherTypeTemp .
+          OPTIONAL {
+            ?dataset dct:publisher ?publisher .
+            ?publisher foaf:name ?publisherName ;
+              rdf:type ?publisherTypeTemp .
 
-        VALUES (?publisherTypeTemp ?publisherType) {
-          (foaf:Organization cc:Organization)
-          (crm:E21_Person cc:Person)
-          (UNDEF UNDEF)
+            VALUES (?publisherTypeTemp ?publisherType) {
+              (foaf:Organization cc:Organization)
+              (crm:E21_Person cc:Person)
+              (UNDEF UNDEF)
+            }
+          }
         }
       }
     `;
@@ -325,7 +329,7 @@ export class HeritageObjectFetcher {
       dateCreated,
       images,
       owner,
-      isPartOf: dataset!, // Ignore 'Thing | undefined' warning - it's always of type 'Thing'
+      isPartOf: dataset,
     };
 
     const heritageObject = removeUndefinedValues<HeritageObject>(


### PR DESCRIPTION
The properties of a `Dataset` (e.g. its name and publisher) do not always exist in the data that data providers give us. Our code, however, assumes these properties are there. This PR makes the code a bit more liberal: if the props exist, we use them, otherwise we continue with the data that we have.

This is a small breaking change: [the `isPartOf` prop](https://github.com/colonial-heritage/colonial-collections/blob/fix-objects-dataset-optional/apps/researcher/src/lib/api/definitions.ts#L59) has now become optional.