### PR TITLE
Revalidate '/communities' after new community is created

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -25,7 +25,7 @@ export default async function CommunityPage({params}: Props) {
     if ((err as ClerkAPIResponseError).status === 404) {
       // This could be a sign of a deleted community in the cache.
       // So, revalidate the communities page.
-      revalidatePath('/[locale]/communities');
+      revalidatePath('/[locale]/communities', 'page');
       return <ErrorMessage error={t('noEntity')} testId="no-entity" />;
     }
     return <ErrorMessage error={t('error')} />;

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -23,9 +23,9 @@ export default async function CommunityPage({params}: Props) {
     community = await getCommunityBySlug(params.slug);
   } catch (err) {
     if ((err as ClerkAPIResponseError).status === 404) {
-      // This could be a sign that the community has been deleted.
-      // In that case, we should revalidate the communities page.
-      revalidatePath('/communities');
+      // This could be a sign of a deleted community in the cache.
+      // So, revalidate the communities page.
+      revalidatePath('/[locale]/communities');
       return <ErrorMessage error={t('noEntity')} testId="no-entity" />;
     }
     return <ErrorMessage error={t('error')} />;

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {JoinCommunityButton, EditCommunityButton} from './buttons';
 import {getMemberships, getCommunityBySlug, isAdmin} from '@/lib/community';
 import ErrorMessage from '@/components/error-message';
 import {ClerkAPIResponseError} from '@clerk/shared';
+import {revalidatePath} from 'next/cache';
 
 interface Props {
   params: {
@@ -22,6 +23,9 @@ export default async function CommunityPage({params}: Props) {
     community = await getCommunityBySlug(params.slug);
   } catch (err) {
     if ((err as ClerkAPIResponseError).status === 404) {
+      // This could be a sign that the community has been deleted.
+      // In that case, we should revalidate the communities page.
+      revalidatePath('/communities');
       return <ErrorMessage error={t('noEntity')} testId="no-entity" />;
     }
     return <ErrorMessage error={t('error')} />;

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -22,7 +22,8 @@ export default async function CommunityPage({params}: Props) {
   try {
     community = await getCommunityBySlug(params.slug);
   } catch (err) {
-    if ((err as ClerkAPIResponseError).status === 404) {
+    const errorStatus = (err as ClerkAPIResponseError).status;
+    if (errorStatus === 404 || errorStatus === 410) {
       // This could be a sign of a deleted community in the cache.
       // So, revalidate the communities page.
       revalidatePath('/[locale]/communities', 'page');

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -20,7 +20,7 @@ async function MembershipCount({communityId, locale}: MembershipCountProps) {
   } catch (error) {
     // This could be a sign of a deleted community in the cache.
     // So, revalidate the communities page.
-    revalidatePath('/[locale]/communities');
+    revalidatePath('/[locale]/communities', 'page');
   }
 
   return t.rich('membershipCount', {

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -18,9 +18,9 @@ async function MembershipCount({communityId, locale}: MembershipCountProps) {
   try {
     memberships = await getMemberships(communityId);
   } catch (error) {
-    // This could be a sign that the community has been deleted.
-    // In that case, we should revalidate the communities page.
-    revalidatePath('/communities');
+    // This could be a sign of a deleted community in the cache.
+    // So, revalidate the communities page.
+    revalidatePath('/[locale]/communities');
   }
 
   return t.rich('membershipCount', {

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -4,6 +4,7 @@ import {useTranslations} from 'next-intl';
 import Link from 'next-intl/link';
 import Image from 'next/image';
 import {Suspense} from 'react';
+import {revalidatePath} from 'next/cache';
 
 interface MembershipCountProps {
   communityId: string;
@@ -12,7 +13,15 @@ interface MembershipCountProps {
 
 async function MembershipCount({communityId, locale}: MembershipCountProps) {
   const t = await getTranslator(locale, 'Communities');
-  const memberships = await getMemberships(communityId);
+
+  let memberships = [];
+  try {
+    memberships = await getMemberships(communityId);
+  } catch (error) {
+    // This could be a sign that the community has been deleted.
+    // In that case, we should revalidate the communities page.
+    revalidatePath('/communities');
+  }
 
   return t.rich('membershipCount', {
     count: memberships.length,

--- a/apps/researcher/src/app/[locale]/communities/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/page.tsx
@@ -5,6 +5,9 @@ import CommunityCard from './community-card';
 import {ClientListStore} from '@colonial-collections/list-store';
 import {Paginator, SearchField, OrderSelector} from 'ui/list';
 
+// 1 day = 60*60*24 = 86400
+export const revalidate = 86400;
+
 interface Props {
   params: {
     locale: string;

--- a/apps/researcher/src/app/[locale]/navigation.tsx
+++ b/apps/researcher/src/app/[locale]/navigation.tsx
@@ -189,7 +189,7 @@ export default function Navigation({locales}: Props) {
                       <SignedIn>
                         <OrganizationSwitcher
                           afterCreateOrganizationUrl={organization =>
-                            `/revalidate/?path=/communities&redirect=/communities/${organization.slug}`
+                            `/revalidate/?path=/[locale]/communities&redirect=/communities/${organization.slug}`
                           }
                           afterLeaveOrganizationUrl="/communities"
                           afterSelectOrganizationUrl={organization =>

--- a/apps/researcher/src/app/[locale]/navigation.tsx
+++ b/apps/researcher/src/app/[locale]/navigation.tsx
@@ -187,7 +187,15 @@ export default function Navigation({locales}: Props) {
                         );
                       })}
                       <SignedIn>
-                        <OrganizationSwitcher />
+                        <OrganizationSwitcher
+                          afterCreateOrganizationUrl={organization =>
+                            `/revalidate/?path=/communities&redirect=/communities/${organization.slug}`
+                          }
+                          afterLeaveOrganizationUrl="/communities"
+                          afterSelectOrganizationUrl={organization =>
+                            `/communities/${organization.slug}`
+                          }
+                        />
                         <UserButton afterSignOutUrl="/" />
                       </SignedIn>
                       <SignedOut>

--- a/apps/researcher/src/app/[locale]/revalidate/page.tsx
+++ b/apps/researcher/src/app/[locale]/revalidate/page.tsx
@@ -2,13 +2,13 @@ import {redirect} from 'next/navigation';
 import {revalidatePath} from 'next/cache';
 
 interface Props {
-  searchParams?: {
+  searchParams: {
     path?: string;
     redirect?: string;
   };
 }
 
-export default async function RevalidatePaths({searchParams = {}}: Props) {
+export default function RevalidatePath({searchParams}: Props) {
   if (searchParams.path) {
     revalidatePath(searchParams.path, 'page');
   }

--- a/apps/researcher/src/app/[locale]/revalidate/page.tsx
+++ b/apps/researcher/src/app/[locale]/revalidate/page.tsx
@@ -1,0 +1,21 @@
+import {redirect} from 'next/navigation';
+import {revalidatePath} from 'next/cache';
+
+interface Props {
+  searchParams?: {
+    path?: string;
+    redirect?: string;
+  };
+}
+
+export default async function RevalidatePaths({searchParams = {}}: Props) {
+  if (searchParams.path) {
+    revalidatePath(searchParams.path);
+  }
+
+  if (!searchParams.redirect) {
+    return redirect('/');
+  }
+
+  redirect(searchParams.redirect);
+}

--- a/apps/researcher/src/app/[locale]/revalidate/page.tsx
+++ b/apps/researcher/src/app/[locale]/revalidate/page.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default async function RevalidatePaths({searchParams = {}}: Props) {
   if (searchParams.path) {
-    revalidatePath(searchParams.path);
+    revalidatePath(searchParams.path, 'page');
   }
 
   if (!searchParams.redirect) {


### PR DESCRIPTION
In the current situation, a new community will not appear in the list after creating a community. This is because the page is cached.

To fix this problem, I created the `/revalidate` page. On this page, the list will be revalidated and then redirected.

This must be done on a page, not a callback function, because Clerk only gives an `afterCreateOrganizationUrl` option. I have seen some discussion in Discord to add a callback, but it is unavailable now.

I made this into a general `/revalidate` page so I can use the same logic after deleting an organization. But then I realized that there is no `afterDestroyOrganizationUrl`. I will ask this on the Clerk Discord.

For now, I have added `revalidatePath('/[locale]/communities')` on places that could indicate a deleted organization. So if a user deletes an organization, it will show up in the list, but after a refresh, it is gone. If this is not good enough, we must re-add `export const revalidate = 0;` to the list. But this scenario will only happen sometimes, and it would be a shame if we don't use the cache for a list that will only change a little.

If somehow this revalidate logic didn't trigger, I have added a `revalidate` with a value of one day.