### PR TITLE
Fix failing end-to-end tests

### DIFF
--- a/apps/dataset-browser/cypress/e2e/dataset.cy.ts
+++ b/apps/dataset-browser/cypress/e2e/dataset.cy.ts
@@ -37,6 +37,8 @@ describe('Dataset details page', () => {
       .then(url => {
         // Open the details page
         cy.getBySel('dataset-card-name').first().click();
+        // Wait for the page to load.
+        cy.location('pathname', {timeout: 60000}).should('include', '/dataset');
         // Go back to the list
         cy.getBySel('to-filtered-list-button').first().click();
 

--- a/apps/researcher/cypress/e2e/object.cy.ts
+++ b/apps/researcher/cypress/e2e/object.cy.ts
@@ -47,6 +47,8 @@ describe('Object details page', () => {
       .then(url => {
         // Open the details page
         cy.getBySel('object-card').first().click();
+        // Wait for the page to load.
+        cy.location('pathname', {timeout: 60000}).should('include', '/object');
         // Go back to the list
         cy.getBySel('to-filtered-list-button').first().click();
 


### PR DESCRIPTION
This end-to-end test fails regularly because the page is still loading. Fix this by waiting a bit longer. The first test in this file already does this and this test never fails.