### PR TITLE
feat: facets

### DIFF
--- a/apps/researcher/src/lib/api/objects/definitions.ts
+++ b/apps/researcher/src/lib/api/objects/definitions.ts
@@ -19,5 +19,6 @@ export type SearchResult = {
     locations: SearchResultFilter[];
     materials: SearchResultFilter[];
     creators: SearchResultFilter[];
+    publishers: SearchResultFilter[];
   };
 };

--- a/apps/researcher/src/lib/api/objects/definitions.ts
+++ b/apps/researcher/src/lib/api/objects/definitions.ts
@@ -18,5 +18,6 @@ export type SearchResult = {
     subjects: SearchResultFilter[];
     locations: SearchResultFilter[];
     materials: SearchResultFilter[];
+    creators: SearchResultFilter[];
   };
 };

--- a/apps/researcher/src/lib/api/objects/definitions.ts
+++ b/apps/researcher/src/lib/api/objects/definitions.ts
@@ -17,5 +17,6 @@ export type SearchResult = {
     types: SearchResultFilter[];
     subjects: SearchResultFilter[];
     locations: SearchResultFilter[];
+    materials: SearchResultFilter[];
   };
 };

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -388,6 +388,33 @@ describe('search', () => {
             name: 'Vincent van Gogh',
           },
         ],
+        publishers: [
+          {
+            totalCount: 0,
+            id: 'Archive',
+            name: 'Archive',
+          },
+          {
+            totalCount: 1,
+            id: 'Library',
+            name: 'Library',
+          },
+          {
+            totalCount: 3,
+            id: 'Museum',
+            name: 'Museum',
+          },
+          {
+            totalCount: 1,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
+          },
+          {
+            totalCount: 1,
+            id: 'Research Organisation',
+            name: 'Research Organisation',
+          },
+        ],
       },
     });
   });
@@ -535,6 +562,47 @@ describe('search', () => {
             totalCount: 0,
             id: 'Vincent van Gogh',
             name: 'Vincent van Gogh',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "publishers" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        publishers: ['Library'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        publishers: [
+          {
+            totalCount: 0,
+            id: 'Archive',
+            name: 'Archive',
+          },
+          {
+            totalCount: 1,
+            id: 'Library',
+            name: 'Library',
+          },
+          {
+            totalCount: 0,
+            id: 'Museum',
+            name: 'Museum',
+          },
+          {
+            totalCount: 0,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
+          },
+          {
+            totalCount: 0,
+            id: 'Research Organisation',
+            name: 'Research Organisation',
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -371,6 +371,23 @@ describe('search', () => {
             name: 'Paper',
           },
         ],
+        creators: [
+          {
+            totalCount: 1,
+            id: 'Adriaan Boer',
+            name: 'Adriaan Boer',
+          },
+          {
+            totalCount: 1,
+            id: 'Geeske van Châtellerault',
+            name: 'Geeske van Châtellerault',
+          },
+          {
+            totalCount: 1,
+            id: 'Vincent van Gogh',
+            name: 'Vincent van Gogh',
+          },
+        ],
       },
     });
   });
@@ -487,6 +504,37 @@ describe('search', () => {
             totalCount: 0,
             id: 'Paper',
             name: 'Paper',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "creators" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        creators: ['Adriaan Boer'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        creators: [
+          {
+            totalCount: 1,
+            id: 'Adriaan Boer',
+            name: 'Adriaan Boer',
+          },
+          {
+            totalCount: 0,
+            id: 'Geeske van Châtellerault',
+            name: 'Geeske van Châtellerault',
+          },
+          {
+            totalCount: 0,
+            id: 'Vincent van Gogh',
+            name: 'Vincent van Gogh',
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -349,6 +349,146 @@ describe('search', () => {
             name: 'Suriname',
           },
         ],
+        materials: [
+          {
+            totalCount: 2,
+            id: 'Canvas',
+            name: 'Canvas',
+          },
+          {
+            totalCount: 1,
+            id: 'Ink',
+            name: 'Ink',
+          },
+          {
+            totalCount: 2,
+            id: 'Oilpaint',
+            name: 'Oilpaint',
+          },
+          {
+            totalCount: 2,
+            id: 'Paper',
+            name: 'Paper',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "owners" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        owners: ['Library'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        owners: [
+          {totalCount: 1, id: 'Library', name: 'Library'},
+          {totalCount: 0, id: 'Museum', name: 'Museum'},
+          {
+            totalCount: 0,
+            id: 'Research Organisation',
+            name: 'Research Organisation',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "types" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        types: ['Painting'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        types: [
+          {totalCount: 0, id: 'Canvas Painting', name: 'Canvas Painting'},
+          {totalCount: 0, id: 'Drawing', name: 'Drawing'},
+          {totalCount: 1, id: 'Painting', name: 'Painting'},
+          {totalCount: 0, id: 'Photo', name: 'Photo'},
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "subjects" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        subjects: ['Castle'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        subjects: [
+          {totalCount: 1, id: 'Castle', name: 'Castle'},
+          {totalCount: 0, id: 'Celebrations', name: 'Celebrations'},
+          {totalCount: 1, id: 'Cottage', name: 'Cottage'},
+          {totalCount: 0, id: 'Palace', name: 'Palace'},
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "locations" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        locations: ['Malaysia'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        locations: [
+          {totalCount: 0, id: 'Indonesia', name: 'Indonesia'},
+          {totalCount: 1, id: 'Malaysia', name: 'Malaysia'},
+          {totalCount: 0, id: 'Suriname', name: 'Suriname'},
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "materials" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        materials: ['Canvas'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 2,
+      filters: {
+        materials: [
+          {
+            totalCount: 2,
+            id: 'Canvas',
+            name: 'Canvas',
+          },
+          {
+            totalCount: 0,
+            id: 'Ink',
+            name: 'Ink',
+          },
+          {
+            totalCount: 2,
+            id: 'Oilpaint',
+            name: 'Oilpaint',
+          },
+          {
+            totalCount: 0,
+            id: 'Paper',
+            name: 'Paper',
+          },
+        ],
       },
     });
   });

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -38,7 +38,6 @@ enum RawKeys {
   Image = 'https://colonialcollections nl/schema#image',
   Owner = 'https://colonialcollections nl/schema#owner',
   Publisher = 'https://colonialcollections nl/schema#publisher',
-  DateCreated = 'https://colonialcollections nl/schema#dateCreatedStart', // Earliest date of creation
   CountryCreated = 'https://colonialcollections nl/schema#countryCreated',
   IsPartOf = 'https://colonialcollections nl/schema#isPartOf',
 }
@@ -61,6 +60,7 @@ const searchOptionsSchema = z.object({
       types: z.array(z.string()).optional().default([]),
       subjects: z.array(z.string()).optional().default([]),
       locations: z.array(z.string()).optional().default([]),
+      materials: z.array(z.string()).optional().default([]),
     })
     .optional(),
 });
@@ -82,7 +82,6 @@ const rawHeritageObjectSchema = z
   .setKey(RawKeys.Image, z.array(z.string()).optional())
   .setKey(RawKeys.Owner, z.array(z.string()).optional())
   .setKey(RawKeys.Publisher, z.array(z.string()).optional())
-  .setKey(RawKeys.DateCreated, z.array(z.string()).optional())
   .setKey(RawKeys.IsPartOf, z.array(z.string()).min(1));
 
 type RawHeritageObject = z.infer<typeof rawHeritageObjectSchema>;
@@ -119,11 +118,13 @@ const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
         types: rawAggregationSchema,
         subjects: rawAggregationSchema,
         locations: rawAggregationSchema,
+        materials: rawAggregationSchema,
       }),
       owners: rawAggregationSchema,
       types: rawAggregationSchema,
       subjects: rawAggregationSchema,
       locations: rawAggregationSchema,
+      materials: rawAggregationSchema,
     }),
   })
 );
@@ -258,6 +259,7 @@ export class HeritageObjectSearcher {
       types: buildAggregation(RawKeys.AdditionalType),
       subjects: buildAggregation(RawKeys.About),
       locations: buildAggregation(RawKeys.CountryCreated),
+      materials: buildAggregation(RawKeys.Material),
     };
 
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
@@ -310,6 +312,7 @@ export class HeritageObjectSearcher {
       [RawKeys.AdditionalType, options.filters?.types],
       [RawKeys.About, options.filters?.subjects],
       [RawKeys.CountryCreated, options.filters?.locations],
+      [RawKeys.Material, options.filters?.materials],
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {
@@ -356,6 +359,11 @@ export class HeritageObjectSearcher {
       aggregations.locations.buckets
     );
 
+    const materialFilters = buildFilters(
+      aggregations.all.materials.buckets,
+      aggregations.materials.buckets
+    );
+
     const searchResult: SearchResult = {
       totalCount: hits.total.value,
       offset: options.offset!,
@@ -368,6 +376,7 @@ export class HeritageObjectSearcher {
         types: typeFilters,
         subjects: subjectFilters,
         locations: locationFilters,
+        materials: materialFilters,
       },
     };
 

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -62,6 +62,7 @@ const searchOptionsSchema = z.object({
       locations: z.array(z.string()).optional().default([]),
       materials: z.array(z.string()).optional().default([]),
       creators: z.array(z.string()).optional().default([]),
+      publishers: z.array(z.string()).optional().default([]),
     })
     .optional(),
 });
@@ -121,6 +122,7 @@ const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
         locations: rawAggregationSchema,
         materials: rawAggregationSchema,
         creators: rawAggregationSchema,
+        publishers: rawAggregationSchema,
       }),
       owners: rawAggregationSchema,
       types: rawAggregationSchema,
@@ -128,6 +130,7 @@ const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
       locations: rawAggregationSchema,
       materials: rawAggregationSchema,
       creators: rawAggregationSchema,
+      publishers: rawAggregationSchema,
     }),
   })
 );
@@ -264,6 +267,7 @@ export class HeritageObjectSearcher {
       locations: buildAggregation(RawKeys.CountryCreated),
       materials: buildAggregation(RawKeys.Material),
       creators: buildAggregation(RawKeys.Creator),
+      publishers: buildAggregation(RawKeys.Publisher),
     };
 
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
@@ -318,6 +322,7 @@ export class HeritageObjectSearcher {
       [RawKeys.CountryCreated, options.filters?.locations],
       [RawKeys.Material, options.filters?.materials],
       [RawKeys.Creator, options.filters?.creators],
+      [RawKeys.Publisher, options.filters?.publishers],
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {
@@ -374,6 +379,11 @@ export class HeritageObjectSearcher {
       aggregations.creators.buckets
     );
 
+    const publisherFilters = buildFilters(
+      aggregations.all.publishers.buckets,
+      aggregations.publishers.buckets
+    );
+
     const searchResult: SearchResult = {
       totalCount: hits.total.value,
       offset: options.offset!,
@@ -388,6 +398,7 @@ export class HeritageObjectSearcher {
         locations: locationFilters,
         materials: materialFilters,
         creators: creatorFilters,
+        publishers: publisherFilters,
       },
     };
 

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -61,6 +61,7 @@ const searchOptionsSchema = z.object({
       subjects: z.array(z.string()).optional().default([]),
       locations: z.array(z.string()).optional().default([]),
       materials: z.array(z.string()).optional().default([]),
+      creators: z.array(z.string()).optional().default([]),
     })
     .optional(),
 });
@@ -119,12 +120,14 @@ const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
         subjects: rawAggregationSchema,
         locations: rawAggregationSchema,
         materials: rawAggregationSchema,
+        creators: rawAggregationSchema,
       }),
       owners: rawAggregationSchema,
       types: rawAggregationSchema,
       subjects: rawAggregationSchema,
       locations: rawAggregationSchema,
       materials: rawAggregationSchema,
+      creators: rawAggregationSchema,
     }),
   })
 );
@@ -260,6 +263,7 @@ export class HeritageObjectSearcher {
       subjects: buildAggregation(RawKeys.About),
       locations: buildAggregation(RawKeys.CountryCreated),
       materials: buildAggregation(RawKeys.Material),
+      creators: buildAggregation(RawKeys.Creator),
     };
 
     const sortByRawKey = sortByToRawKeys.get(options.sortBy!)!;
@@ -313,6 +317,7 @@ export class HeritageObjectSearcher {
       [RawKeys.About, options.filters?.subjects],
       [RawKeys.CountryCreated, options.filters?.locations],
       [RawKeys.Material, options.filters?.materials],
+      [RawKeys.Creator, options.filters?.creators],
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {
@@ -364,6 +369,11 @@ export class HeritageObjectSearcher {
       aggregations.materials.buckets
     );
 
+    const creatorFilters = buildFilters(
+      aggregations.all.creators.buckets,
+      aggregations.creators.buckets
+    );
+
     const searchResult: SearchResult = {
       totalCount: hits.total.value,
       offset: options.offset!,
@@ -377,6 +387,7 @@ export class HeritageObjectSearcher {
         subjects: subjectFilters,
         locations: locationFilters,
         materials: materialFilters,
+        creators: creatorFilters,
       },
     };
 


### PR DESCRIPTION
This PR makes available several facets for the search result page of the Research app, per the [UI designs](https://gui-prototype.colonialcollections.nl/search.html): 'Materials',  'Creators' and 'Data providers' ('publishers'). The structure of these facets is the same.

In a separate PR I'll add the final facet that the design requires, `Date of creation`. The structure of this facet will probably be a little different.