### PR TITLE
feat: facets for 'date created'

### DIFF
--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -73,7 +73,11 @@ export enum SortOrder {
 
 export const SortOrderEnum = z.nativeEnum(SortOrder);
 
-export type SearchResultFilter = Thing & {totalCount: number};
+export type SearchResultFilter = {
+  id: string | number;
+  name?: string | number; // Name may not exist (e.g. in a specific locale)
+  totalCount: number;
+};
 
 export type ProvenanceEvent = {
   id: string;

--- a/apps/researcher/src/lib/api/objects/definitions.ts
+++ b/apps/researcher/src/lib/api/objects/definitions.ts
@@ -20,5 +20,7 @@ export type SearchResult = {
     materials: SearchResultFilter[];
     creators: SearchResultFilter[];
     publishers: SearchResultFilter[];
+    dateCreatedStart: SearchResultFilter[];
+    dateCreatedEnd: SearchResultFilter[];
   };
 };

--- a/apps/researcher/src/lib/api/objects/searcher-request.ts
+++ b/apps/researcher/src/lib/api/objects/searcher-request.ts
@@ -2,10 +2,7 @@ export function buildAggregation(id: string) {
   const aggregation = {
     terms: {
       size: 1000, // TBD: what's a good size?
-      field: `${id}.keyword`,
-      // Sort by key in ascending order: ['Amersfoort', 'Delft', ...]
-      // TBD: this no longer works if we have IRIs of terms (e.g. subjects) instead of
-      // their current literals. We can only use this ordering for dates then
+      field: id,
       order: {_key: 'asc'},
     },
   };

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -415,6 +415,50 @@ describe('search', () => {
             name: 'Research Organisation',
           },
         ],
+        dateCreatedStart: [
+          {
+            totalCount: 1,
+            id: '1725',
+            name: '1725',
+          },
+          {
+            totalCount: 1,
+            id: '1889',
+            name: '1889',
+          },
+          {
+            totalCount: 1,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 1,
+            id: '1901',
+            name: '1901',
+          },
+        ],
+        dateCreatedEnd: [
+          {
+            totalCount: 1,
+            id: '1736',
+            name: '1736',
+          },
+          {
+            totalCount: 1,
+            id: '1890',
+            name: '1890',
+          },
+          {
+            totalCount: 1,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 1,
+            id: '1902',
+            name: '1902',
+          },
+        ],
       },
     });
   });
@@ -603,6 +647,137 @@ describe('search', () => {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "dateCreatedStart" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        dateCreatedStart: '1901',
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        dateCreatedStart: [
+          {
+            totalCount: 0,
+            id: '1725',
+            name: '1725',
+          },
+          {
+            totalCount: 0,
+            id: '1889',
+            name: '1889',
+          },
+          {
+            totalCount: 0,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 1,
+            id: '1901',
+            name: '1901',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "dateCreatedEnd" filter matches', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        dateCreatedEnd: '1736',
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        dateCreatedEnd: [
+          {
+            totalCount: 1,
+            id: '1736',
+            name: '1736',
+          },
+          {
+            totalCount: 0,
+            id: '1890',
+            name: '1890',
+          },
+          {
+            totalCount: 0,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 0,
+            id: '1902',
+            name: '1902',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds heritage objects if "dateCreatedStart" and "dateCreatedEnd" filters match', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        dateCreatedStart: '1700',
+        dateCreatedEnd: '1800',
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        dateCreatedStart: [
+          {
+            totalCount: 1,
+            id: '1725',
+            name: '1725',
+          },
+          {
+            totalCount: 0,
+            id: '1889',
+            name: '1889',
+          },
+          {
+            totalCount: 0,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 0,
+            id: '1901',
+            name: '1901',
+          },
+        ],
+        dateCreatedEnd: [
+          {
+            totalCount: 1,
+            id: '1736',
+            name: '1736',
+          },
+          {
+            totalCount: 0,
+            id: '1890',
+            name: '1890',
+          },
+          {
+            totalCount: 0,
+            id: '1895',
+            name: '1895',
+          },
+          {
+            totalCount: 0,
+            id: '1902',
+            name: '1902',
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -725,16 +725,16 @@ describe('search', () => {
     });
   });
 
-  it('finds heritage objects if "dateCreatedStart" and "dateCreatedEnd" filters match', async () => {
+  it('finds heritage objects between "dateCreatedStart" and "dateCreatedEnd", inclusive', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedStart: '1700',
-        dateCreatedEnd: '1800',
+        dateCreatedStart: '1725',
+        dateCreatedEnd: '1895',
       },
     });
 
     expect(result).toMatchObject({
-      totalCount: 1,
+      totalCount: 3,
       filters: {
         dateCreatedStart: [
           {
@@ -743,12 +743,12 @@ describe('search', () => {
             name: '1725',
           },
           {
-            totalCount: 0,
+            totalCount: 1,
             id: '1889',
             name: '1889',
           },
           {
-            totalCount: 0,
+            totalCount: 1,
             id: '1895',
             name: '1895',
           },
@@ -765,12 +765,12 @@ describe('search', () => {
             name: '1736',
           },
           {
-            totalCount: 0,
+            totalCount: 1,
             id: '1890',
             name: '1890',
           },
           {
-            totalCount: 0,
+            totalCount: 1,
             id: '1895',
             name: '1895',
           },

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -418,45 +418,45 @@ describe('search', () => {
         dateCreatedStart: [
           {
             totalCount: 1,
-            id: '1725',
-            name: '1725',
+            id: 1725,
+            name: 1725,
           },
           {
             totalCount: 1,
-            id: '1889',
-            name: '1889',
+            id: 1889,
+            name: 1889,
           },
           {
             totalCount: 1,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 1,
-            id: '1901',
-            name: '1901',
+            id: 1901,
+            name: 1901,
           },
         ],
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: '1736',
-            name: '1736',
+            id: 1736,
+            name: 1736,
           },
           {
             totalCount: 1,
-            id: '1890',
-            name: '1890',
+            id: 1890,
+            name: 1890,
           },
           {
             totalCount: 1,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 1,
-            id: '1902',
-            name: '1902',
+            id: 1902,
+            name: 1902,
           },
         ],
       },
@@ -656,7 +656,7 @@ describe('search', () => {
   it('finds heritage objects if "dateCreatedStart" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedStart: '1901',
+        dateCreatedStart: 1901,
       },
     });
 
@@ -666,23 +666,23 @@ describe('search', () => {
         dateCreatedStart: [
           {
             totalCount: 0,
-            id: '1725',
-            name: '1725',
+            id: 1725,
+            name: 1725,
           },
           {
             totalCount: 0,
-            id: '1889',
-            name: '1889',
+            id: 1889,
+            name: 1889,
           },
           {
             totalCount: 0,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 1,
-            id: '1901',
-            name: '1901',
+            id: 1901,
+            name: 1901,
           },
         ],
       },
@@ -692,7 +692,7 @@ describe('search', () => {
   it('finds heritage objects if "dateCreatedEnd" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedEnd: '1736',
+        dateCreatedEnd: 1736,
       },
     });
 
@@ -702,23 +702,23 @@ describe('search', () => {
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: '1736',
-            name: '1736',
+            id: 1736,
+            name: 1736,
           },
           {
             totalCount: 0,
-            id: '1890',
-            name: '1890',
+            id: 1890,
+            name: 1890,
           },
           {
             totalCount: 0,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 0,
-            id: '1902',
-            name: '1902',
+            id: 1902,
+            name: 1902,
           },
         ],
       },
@@ -728,8 +728,8 @@ describe('search', () => {
   it('finds heritage objects between "dateCreatedStart" and "dateCreatedEnd", inclusive', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedStart: '1725',
-        dateCreatedEnd: '1895',
+        dateCreatedStart: 1725,
+        dateCreatedEnd: 1895,
       },
     });
 
@@ -739,45 +739,45 @@ describe('search', () => {
         dateCreatedStart: [
           {
             totalCount: 1,
-            id: '1725',
-            name: '1725',
+            id: 1725,
+            name: 1725,
           },
           {
             totalCount: 1,
-            id: '1889',
-            name: '1889',
+            id: 1889,
+            name: 1889,
           },
           {
             totalCount: 1,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 0,
-            id: '1901',
-            name: '1901',
+            id: 1901,
+            name: 1901,
           },
         ],
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: '1736',
-            name: '1736',
+            id: 1736,
+            name: 1736,
           },
           {
             totalCount: 1,
-            id: '1890',
-            name: '1890',
+            id: 1890,
+            name: 1890,
           },
           {
             totalCount: 1,
-            id: '1895',
-            name: '1895',
+            id: 1895,
+            name: 1895,
           },
           {
             totalCount: 0,
-            id: '1902',
-            name: '1902',
+            id: 1902,
+            name: 1902,
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -65,8 +65,8 @@ const searchOptionsSchema = z.object({
       materials: z.array(z.string()).optional().default([]),
       creators: z.array(z.string()).optional().default([]),
       publishers: z.array(z.string()).optional().default([]),
-      dateCreatedStart: z.string().optional(),
-      dateCreatedEnd: z.string().optional(),
+      dateCreatedStart: z.number().optional(),
+      dateCreatedEnd: z.number().optional(),
     })
     .optional(),
 });
@@ -93,7 +93,7 @@ const rawHeritageObjectSchema = z
 type RawHeritageObject = z.infer<typeof rawHeritageObjectSchema>;
 
 const rawBucketSchema = z.object({
-  key: z.string(),
+  key: z.string().or(z.number()),
   doc_count: z.number(),
 });
 
@@ -269,13 +269,13 @@ export class HeritageObjectSearcher {
 
   private buildRequest(options: SearchOptions) {
     const aggregations = {
-      owners: buildAggregation(RawKeys.Owner),
-      types: buildAggregation(RawKeys.AdditionalType),
-      subjects: buildAggregation(RawKeys.About),
-      locations: buildAggregation(RawKeys.CountryCreated),
-      materials: buildAggregation(RawKeys.Material),
-      creators: buildAggregation(RawKeys.Creator),
-      publishers: buildAggregation(RawKeys.Publisher),
+      owners: buildAggregation(`${RawKeys.Owner}.keyword`),
+      types: buildAggregation(`${RawKeys.AdditionalType}.keyword`),
+      subjects: buildAggregation(`${RawKeys.About}.keyword`),
+      locations: buildAggregation(`${RawKeys.CountryCreated}.keyword`),
+      materials: buildAggregation(`${RawKeys.Material}.keyword`),
+      creators: buildAggregation(`${RawKeys.Creator}.keyword`),
+      publishers: buildAggregation(`${RawKeys.Publisher}.keyword`),
       dateCreatedStart: buildAggregation(RawKeys.YearCreatedStart),
       dateCreatedEnd: buildAggregation(RawKeys.YearCreatedEnd),
     };
@@ -350,7 +350,7 @@ export class HeritageObjectSearcher {
       searchRequest.query.bool.filter.push({
         // @ts-expect-error:TS2345
         range: {
-          [`${RawKeys.YearCreatedStart}.keyword`]: {
+          [RawKeys.YearCreatedStart]: {
             gte: dateCreatedStart,
           },
         },
@@ -362,7 +362,7 @@ export class HeritageObjectSearcher {
       searchRequest.query.bool.filter.push({
         // @ts-expect-error:TS2345
         range: {
-          [`${RawKeys.YearCreatedEnd}.keyword`]: {
+          [RawKeys.YearCreatedEnd]: {
             lte: dateCreatedEnd,
           },
         },

--- a/packages/ui/list/SearchResultFilter.ts
+++ b/packages/ui/list/SearchResultFilter.ts
@@ -1,5 +1,5 @@
 export interface SearchResultFilter {
-  name?: string;
-  id: string;
+  name?: string | number;
+  id: string | number;
   totalCount: number;
 }

--- a/packages/ui/list/filter-set.tsx
+++ b/packages/ui/list/filter-set.tsx
@@ -99,7 +99,7 @@ function FilterOption({
       <input
         value={searchResultFilter.id}
         id={`${title}-${searchResultFilter.id}`}
-        name={searchResultFilter.id}
+        name={searchResultFilter.id.toString()}
         checked={selectedFilters.some(
           filterId => searchResultFilter.id === filterId
         )}
@@ -147,6 +147,7 @@ export function FilterSet({
     return searchResultFilters.filter(
       searchResultFilter =>
         searchResultFilter.name
+          ?.toString()
           ?.toLocaleLowerCase()
           .includes(query.toLocaleLowerCase())
     );


### PR DESCRIPTION
This PR adds two facets to the search functionality of the Research App: `dateCreatedStart` and `dateCreatedEnd`. These are based on the [UI design](https://gui-prototype.colonialcollections.nl/search.html) ('From year', 'Till year').

A note: the facet values consist of years, but the facets have the name 'date'. This is intentional: if we don't want to use years anymore and use some other time unit (e.g. centuries, groups of years, exact dates) then we don't have to rename the facets.