### PR TITLE
Frontend filter creator

### DIFF
--- a/apps/researcher/cypress/e2e/home.cy.ts
+++ b/apps/researcher/cypress/e2e/home.cy.ts
@@ -13,22 +13,22 @@ describe('Researcher homepage', () => {
 });
 
 describe('Object list filters', () => {
-  it('filters by one owner', () => {
+  it('filters by one creator', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
 
     cy.getBySel('selectedFilter').should('have.length', 1);
   });
 
-  it('filters by two owners', () => {
+  it('filters by two creators', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').eq(0).check();
       cy.get('[type="checkbox"]').eq(1).check();
     });
@@ -36,26 +36,26 @@ describe('Object list filters', () => {
     cy.getBySel('selectedFilter').should('have.length', 2);
   });
 
-  it('removes an owner filter by deselecting the filter in the sidebar', () => {
+  it('removes a creator filter by deselecting the filter in the sidebar', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
 
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').first().uncheck();
     });
 
     cy.getBySel('selectedFilter').should('have.length', 0);
   });
 
-  it('removes an owner filter by deselecting it in the selected filter bar', () => {
+  it('removes a creator filter by deselecting it in the selected filter bar', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
 
@@ -89,7 +89,7 @@ describe('Object list filters', () => {
     cy.getBySel('selectedFilter').should('have.text', searchText);
   });
 
-  it('filters multiple categories together (query, owners and types)', () => {
+  it('filters multiple categories together (query, creators and types)', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
@@ -99,7 +99,7 @@ describe('Object list filters', () => {
     cy.getBySel('typesFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
-    cy.getBySel('ownersFilter').within(() => {
+    cy.getBySel('creatorsFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
 

--- a/apps/researcher/src/app/[locale]/page.tsx
+++ b/apps/researcher/src/app/[locale]/page.tsx
@@ -32,7 +32,7 @@ export const revalidate = 60;
 
 // Set the order of the filters
 const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [
-  'owners',
+  'creators',
   'types',
   'subjects',
 ];

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -104,7 +104,6 @@
     "next": "Next"
   },
   "Filters": {
-    "ownersFilter": "Owners",
     "typesFilter": "Types",
     "subjectsFilter": "Subjects",
     "birthYearsFilter": "Birth years",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -111,6 +111,7 @@
     "birthPlacesFilter": "Birth places",
     "deathYearsFilter": "Death years",
     "deathPlacesFilter": "Death places",
+    "creatorsFilter": "Creators",
     "search": "Search for text",
     "filters": "Filters",
     "expandFilter": "Expand",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -111,6 +111,7 @@
     "birthPlacesFilter": "Geboorteplaatsen",
     "deathYearsFilter": "Overlijdensjaren",
     "deathPlacesFilter": "Overlijdensplaatsen",
+    "creatorsFilter": "Makers",
     "search": "Zoeken",
     "filters": "Filters",
     "expandFilter": "Uitklappen",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -104,7 +104,6 @@
     "next": "Volgende"
   },
  "Filters": {
-    "ownersFilter": "Eigenaren",
     "typesFilter": "Types",
     "subjectsFilter": "Onderwerpen",
     "birthYearsFilter": "Geboortejaren",

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -1,10 +1,12 @@
 import {z, Schema} from 'zod';
 import {SortBy} from './sort';
 
+const searchParamValueSeparator = '||';
+
 const searchParamFilterSchema = z
   .array(z.string())
   .default([])
-  .transform(filterValues => filterValues.join(','));
+  .transform(filterValues => filterValues.join(searchParamValueSeparator));
 
 function getSearchParamsSchema(defaultSortBy: string) {
   return z.object({
@@ -76,7 +78,10 @@ function fallback<T>(value: T) {
 const searchOptionsFilterSchema = z
   .string()
   .optional()
-  .transform(filterValue => filterValue?.split(',').filter(id => !!id))
+  .transform(
+    filterValue =>
+      filterValue?.split(searchParamValueSeparator).filter(id => !!id)
+  )
   .pipe(z.array(z.string()).optional().default([]));
 
 interface FromSearchParamsToSearchOptionsProps {


### PR DESCRIPTION
In this pull request, I have:

- Added the 'creator' filter
- Removed the 'owner' filter. I don't think we are using this filter. The end-to-end tests use this filter, so I updated the tests to use the creator filter instead.
- Updated the `searchParamValueSeparator`

When using the filters, the filter IDs are added to the search parameters in the URL. If there is more than one filter selected, the values are separated with a ','. I thought the IDs were URIs and thought ',' were relatively safe to use as a separator. But the IDs do contain ','. For now, I changed it to '||', these are not in the ids of publishers and materials.