### PR TITLE
Add object to list

### DIFF
--- a/apps/researcher/src/app/[locale]/layout.tsx
+++ b/apps/researcher/src/app/[locale]/layout.tsx
@@ -43,7 +43,7 @@ export default async function RootLayout({children, params: {locale}}: Props) {
                 </li>
               </ul>
             </div>
-            <div className="max-w-[1800px] mx-auto h-full min-h-screen flex flex-col justify-stretch items-stretch gap-8 pb-40">
+            <div className="max-w-[1800px] mx-auto min-h-screen flex flex-col justify-stretch items-stretch gap-8 pb-40">
               <header className="w-full px-10 py-4 bg-neutral-50">
                 <Navigation locales={locales} />
               </header>

--- a/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
@@ -18,7 +18,7 @@ export async function addObjectToList({
   listItem,
   communityId,
 }: AddObjectToListProps) {
-  objectList.addObject(listItem);
+  await objectList.addObject(listItem);
   const community = await getCommunityBySlug(communityId);
   revalidatePath(`/[locale]/communities/${community.slug}`, 'page');
 }

--- a/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import {objectList} from '@colonial-collections/database';
+import {
+  InsertObjectItem,
+  SelectObjectList,
+} from '@colonial-collections/database';
+
+export async function getCommunityLists(
+  communityId: string
+): Promise<SelectObjectList[]> {
+  return objectList.getByCommunityId(communityId);
+}
+
+export async function addObjectToList(listItem: InsertObjectItem) {
+  return objectList.addObject(listItem);
+}

--- a/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
@@ -1,10 +1,12 @@
 'use server';
 
+import {getCommunityBySlug} from '@/lib/community';
 import {objectList} from '@colonial-collections/database';
 import {
   InsertObjectItem,
   SelectObjectList,
 } from '@colonial-collections/database';
+import {revalidatePath} from 'next/cache';
 
 export async function getCommunityLists(
   communityId: string
@@ -12,6 +14,16 @@ export async function getCommunityLists(
   return objectList.getByCommunityId(communityId);
 }
 
-export async function addObjectToList(listItem: InsertObjectItem) {
-  return objectList.addObject(listItem);
+interface AddObjectToListProps {
+  listItem: InsertObjectItem;
+  communityId: string;
+}
+
+export async function addObjectToList({
+  listItem,
+  communityId,
+}: AddObjectToListProps) {
+  objectList.addObject(listItem);
+  const community = await getCommunityBySlug(communityId);
+  revalidatePath(`/[locale]/communities/${community.slug}`, 'page');
 }

--- a/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/database-actions.ts
@@ -2,15 +2,10 @@
 
 import {getCommunityBySlug} from '@/lib/community';
 import {objectList} from '@colonial-collections/database';
-import {
-  InsertObjectItem,
-  SelectObjectList,
-} from '@colonial-collections/database';
+import {InsertObjectItem} from '@colonial-collections/database';
 import {revalidatePath} from 'next/cache';
 
-export async function getCommunityLists(
-  communityId: string
-): Promise<SelectObjectList[]> {
+export async function getCommunityLists(communityId: string) {
   return objectList.getByCommunityId(communityId);
 }
 

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
@@ -6,20 +6,25 @@ import {InsertObjectItem} from '@colonial-collections/database';
 import {revalidatePath} from 'next/cache';
 
 export async function getCommunityLists(communityId: string, objectId: string) {
-  return objectList.getByCommunityId(communityId, {includeObjectIri: objectId});
+  return objectList.getByCommunityId(communityId, {objectIri: objectId});
 }
 
 interface AddObjectToListProps {
-  listItem: InsertObjectItem;
+  objectItem: InsertObjectItem;
   communityId: string;
 }
 
 export async function addObjectToList({
-  listItem,
+  objectItem,
   communityId,
 }: AddObjectToListProps) {
-  await objectList.addObject(listItem);
-  const community = await getCommunityBySlug(communityId);
+  const addObjectPromise = objectList.addObject(objectItem);
+  const getCommunityPromise = getCommunityBySlug(communityId);
+  const [community] = await Promise.all([
+    getCommunityPromise,
+    addObjectPromise,
+  ]);
+
   revalidatePath(`/[locale]/communities/${community.slug}`, 'page');
 }
 

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
@@ -5,8 +5,8 @@ import {objectList} from '@colonial-collections/database';
 import {InsertObjectItem} from '@colonial-collections/database';
 import {revalidatePath} from 'next/cache';
 
-export async function getCommunityLists(communityId: string) {
-  return objectList.getByCommunityId(communityId);
+export async function getCommunityLists(communityId: string, objectId: string) {
+  return objectList.getByCommunityId(communityId, {includeObjectIri: objectId});
 }
 
 interface AddObjectToListProps {
@@ -19,6 +19,12 @@ export async function addObjectToList({
   communityId,
 }: AddObjectToListProps) {
   await objectList.addObject(listItem);
+  const community = await getCommunityBySlug(communityId);
+  revalidatePath(`/[locale]/communities/${community.slug}`, 'page');
+}
+
+export async function removeObjectFromList(id: number, communityId: string) {
+  await objectList.removeObject(id);
   const community = await getCommunityBySlug(communityId);
   revalidatePath(`/[locale]/communities/${community.slug}`, 'page');
 }

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
@@ -2,7 +2,7 @@
 
 import {getCommunityBySlug} from '@/lib/community';
 import {objectList} from '@colonial-collections/database';
-import {InsertObjectItem as ObjectItem} from '@colonial-collections/database';
+import {ObjectItemBeingCreated} from '@colonial-collections/database';
 import {revalidatePath} from 'next/cache';
 
 export async function getCommunityLists(communityId: string, objectId: string) {
@@ -10,7 +10,7 @@ export async function getCommunityLists(communityId: string, objectId: string) {
 }
 
 interface AddObjectToListProps {
-  objectItem: ObjectItem;
+  objectItem: ObjectItemBeingCreated;
   communityId: string;
 }
 

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-actions.ts
@@ -2,7 +2,7 @@
 
 import {getCommunityBySlug} from '@/lib/community';
 import {objectList} from '@colonial-collections/database';
-import {InsertObjectItem} from '@colonial-collections/database';
+import {InsertObjectItem as ObjectItem} from '@colonial-collections/database';
 import {revalidatePath} from 'next/cache';
 
 export async function getCommunityLists(communityId: string, objectId: string) {
@@ -10,7 +10,7 @@ export async function getCommunityLists(communityId: string, objectId: string) {
 }
 
 interface AddObjectToListProps {
-  objectItem: InsertObjectItem;
+  objectItem: ObjectItem;
   communityId: string;
 }
 

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import {useTranslations} from 'next-intl';
+import {Fragment, useState, useEffect} from 'react';
+import {Menu, Transition} from '@headlessui/react';
+import {ChevronDownIcon} from '@heroicons/react/20/solid';
+import {useUser} from '@clerk/nextjs';
+import {getCommunityLists, addObjectToList} from './database-actions';
+import {SelectObjectList} from '@colonial-collections/database';
+import {useNotifications} from 'ui';
+
+interface CommunityMenuItemsProps {
+  communityId: string;
+  objectId: string;
+  userId: string;
+}
+
+function CommunityMenuItems({
+  communityId,
+  objectId,
+  userId,
+}: CommunityMenuItemsProps) {
+  const [objectLists, setObjectLists] = useState<SelectObjectList[]>([]);
+  const t = useTranslations('ObjectDetails');
+  const {addNotification} = useNotifications();
+
+  async function addObjectToListClick(objectList: SelectObjectList) {
+    try {
+      await addObjectToList({
+        objectIri: objectId,
+        objectListId: objectList.id,
+        createdBy: userId,
+      });
+
+      addNotification({
+        id: 'objectAddedToList',
+        message: t.rich('objectAddedToList', {
+          name: () => <em>{objectList.name}</em>,
+        }),
+        type: 'success',
+      });
+    } catch (err) {
+      if ((err as Error).message.includes('Duplicate entry')) {
+        addNotification({
+          id: 'objectAlreadyInList',
+          message: t('objectAlreadyInList'),
+          type: 'warning',
+        });
+      } else {
+        addNotification({
+          id: 'objectNotAddedToList',
+          message: t('objectNotAddedToList'),
+          type: 'error',
+        });
+      }
+    }
+  }
+
+  useEffect(() => {
+    async function getLists() {
+      const lists = await getCommunityLists(communityId);
+      setObjectLists(lists);
+    }
+    getLists();
+  }, [communityId]);
+
+  if (!objectLists.length) {
+    return (
+      <div className="px-4 py-2 text-sm text-gray-400 italic">
+        {t('noListsInCommunity')}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {objectLists.map(objectList => (
+        <Menu.Item key={objectList.id}>
+          <button
+            onClick={() => addObjectToListClick(objectList)}
+            className="block px-4 py-2 text-sm w-full text-left text-gray-700"
+          >
+            {objectList.name}
+          </button>
+        </Menu.Item>
+      ))}
+    </div>
+  );
+}
+
+interface ObjectListsMenuProps {
+  objectId: string;
+}
+
+export default function ObjectListsMenu({objectId}: ObjectListsMenuProps) {
+  const t = useTranslations('ObjectDetails');
+  const {user} = useUser();
+
+  if (!user || !user.organizationMemberships.length) {
+    return null;
+  }
+
+  const communities = user.organizationMemberships.map(m => m.organization);
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <div>
+        <Menu.Button className="p-1 sm:py-2 sm:px-3 rounded-xl text-xs bg-greenGrey-100 text-greenGrey-800 flex items-center gap-1">
+          {t('addToListButton')}
+          <ChevronDownIcon
+            className="-mr-1 h-5 w-5 text-gray-400"
+            aria-hidden="true"
+          />
+        </Menu.Button>
+      </div>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          {communities.map(community => (
+            <div key={community.id}>
+              <div className="font-semibold	 px-2 pt-2">{community.name}</div>
+              <CommunityMenuItems
+                userId={user.id}
+                communityId={community.id}
+                objectId={objectId}
+              />
+            </div>
+          ))}
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -11,7 +11,7 @@ import {
   addObjectToList,
   removeObjectFromList,
 } from './object-lists-actions';
-import {SelectObjectList} from '@colonial-collections/database';
+import {ObjectList} from '@colonial-collections/database';
 import {useNotifications} from 'ui';
 
 interface CommunityMenuItemsProps {
@@ -25,11 +25,11 @@ function CommunityMenuItems({
   objectId,
   userId,
 }: CommunityMenuItemsProps) {
-  const [objectLists, setObjectLists] = useState<SelectObjectList[]>([]);
+  const [objectLists, setObjectLists] = useState<ObjectList[]>([]);
   const t = useTranslations('ObjectDetails');
   const {addNotification} = useNotifications();
 
-  async function listClick(objectList: SelectObjectList) {
+  async function listClick(objectList: ObjectList) {
     const isEmptyList = !objectList.objects!.length;
 
     if (isEmptyList) {

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -30,30 +30,12 @@ function CommunityMenuItems({
   const {addNotification} = useNotifications();
 
   async function listClick(objectList: SelectObjectList) {
-    const objectInList = !!objectList.objects!.length;
+    const isEmptyList = !objectList.objects!.length;
 
-    if (objectInList) {
-      try {
-        await removeObjectFromList(objectList.objects![0].id, communityId);
-
-        addNotification({
-          id: 'objectRemovedFromList',
-          message: t.rich('objectRemovedFromList', {
-            name: () => <em>{objectList.name}</em>,
-          }),
-          type: 'success',
-        });
-      } catch (err) {
-        addNotification({
-          id: 'errorObjectRemovedFromList',
-          message: t('errorObjectRemovedFromList'),
-          type: 'error',
-        });
-      }
-    } else {
+    if (isEmptyList) {
       try {
         await addObjectToList({
-          listItem: {
+          objectItem: {
             objectIri: objectId,
             objectListId: objectList.id,
             createdBy: userId,
@@ -72,6 +54,24 @@ function CommunityMenuItems({
         addNotification({
           id: 'errorObjectAddedToList',
           message: t('errorObjectAddedToList'),
+          type: 'error',
+        });
+      }
+    } else {
+      try {
+        await removeObjectFromList(objectList.objects![0].id, communityId);
+
+        addNotification({
+          id: 'objectRemovedFromList',
+          message: t.rich('objectRemovedFromList', {
+            name: () => <em>{objectList.name}</em>,
+          }),
+          type: 'success',
+        });
+      } catch (err) {
+        addNotification({
+          id: 'errorObjectRemovedFromList',
+          message: t('errorObjectRemovedFromList'),
           type: 'error',
         });
       }
@@ -127,7 +127,9 @@ export default function ObjectListsMenu({objectId}: ObjectListsMenuProps) {
     return null;
   }
 
-  const communities = user.organizationMemberships.map(m => m.organization);
+  const communities = user.organizationMemberships.map(
+    membership => membership.organization
+  );
 
   return (
     <Menu as="div" className="relative inline-block text-left">

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -27,9 +27,12 @@ function CommunityMenuItems({
   async function addObjectToListClick(objectList: SelectObjectList) {
     try {
       await addObjectToList({
-        objectIri: objectId,
-        objectListId: objectList.id,
-        createdBy: userId,
+        listItem: {
+          objectIri: objectId,
+          objectListId: objectList.id,
+          createdBy: userId,
+        },
+        communityId,
       });
 
       addNotification({

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -44,9 +44,12 @@ function CommunityMenuItems({
       });
     } catch (err) {
       if ((err as Error).message.includes('Duplicate entry')) {
+        console.log(err);
         addNotification({
           id: 'objectAlreadyInList',
-          message: t('objectAlreadyInList'),
+          message: t.rich('objectAlreadyInList', {
+            name: () => <em>{objectList.name}</em>,
+          }),
           type: 'warning',
         });
       } else {

--- a/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/object-lists-menu.tsx
@@ -155,7 +155,7 @@ export default function ObjectListsMenu({objectId}: ObjectListsMenuProps) {
         <Menu.Items className="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           {communities.map(community => (
             <div key={community.id}>
-              <div className="font-semibold	 px-2 pt-2">{community.name}</div>
+              <div className="font-semibold px-2 pt-2">{community.name}</div>
               <CommunityMenuItems
                 userId={user.id}
                 communityId={community.id}

--- a/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
@@ -18,6 +18,9 @@ import {
 import useCurrentPublisher from './useCurrentPublisher';
 import {env} from 'node:process';
 import {formatDateCreated} from './format-date-created';
+import ObjectListsMenu from './object-lists-menu';
+import {SignedIn} from '@clerk/nextjs';
+import {Notifications} from 'ui';
 
 // Revalidate the page
 export const revalidate = 0;
@@ -106,16 +109,9 @@ export default async function Details({params}: Props) {
           </ToFilteredListButton>
         </div>
         <div className="sm:flex justify-end gap-4 hidden">
-          <button className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-sand-100 hover:bg-sand-200 transition text-sand-800 flex items-center gap-1">
-            {t('bookmarkButton')}
-          </button>
-          <button className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-sand-100 hover:bg-sand-200 transition text-sand-800 flex items-center gap-1">
-            {t('shareButton')}
-          </button>
-          <select className="p-1 sm:py-2 sm:px-3 rounded-xl text-xs bg-sand-100  text-sand-800 flex items-center gap-1">
-            <option className="p-2">{t('addToListButton')}</option>
-            <option className="p-2">{t('createNewListButton')}</option>
-          </select>
+          <SignedIn>
+            <ObjectListsMenu objectId={id} />
+          </SignedIn>
         </div>
       </div>
 
@@ -126,6 +122,8 @@ export default async function Details({params}: Props) {
         >
           {object.name}
         </h1>
+
+        <Notifications />
 
         <div className="text-neutral-500 text-sm flex flex-col sm:flex-row justify-between items-start sm:items-center">
           <div className="flex flex-row justify-start  gap-1 ">

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -84,7 +84,11 @@
     "currentPublisher": "Current location of object",
     "noOrganizationFound": "No organization found.",
     "dateCreated": "Date Made",
-    "dateCreatedSubTitle": "When was the object made? Could be an exact date or a range."
+    "dateCreatedSubTitle": "When was the object made? Could be an exact date or a range.",
+    "noListsInCommunity": "No lists",
+    "objectAddedToList": "Object added to list <name></name>.",
+    "objectAlreadyInList": "Object already in list <name></name>.",
+    "objectNotAddedToList": "There was a problem adding the object to the list. Please try again later."
   },
   "PersonDetails": {
     "backButton": "Back to results",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -87,8 +87,9 @@
     "dateCreatedSubTitle": "When was the object made? Could be an exact date or a range.",
     "noListsInCommunity": "No lists",
     "objectAddedToList": "Object added to list <name></name>.",
-    "objectAlreadyInList": "Object already in list <name></name>.",
-    "objectNotAddedToList": "There was a problem adding the object to the list. Please try again later."
+    "errorObjectAddedToList": "There was a problem adding the object to the list. Please try again later.",
+    "objectRemovedFromList": "Object removed from list <name></name>.",
+    "errorObjectRemovedFromList": "There was a problem removing the object from the list. Please try again later."
   },
   "PersonDetails": {
     "backButton": "Back to results",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -84,7 +84,11 @@
     "currentPublisher": "Huidige locatie van object",
     "noOrganizationFound": "Geen organisatie gevonden.",
     "dateCreated": "Datum van creatie",
-    "dateCreatedSubTitle": "Wanneer is het voorwerp gemaakt? Dit kan een exacte datum of een datumbereik zijn."
+    "dateCreatedSubTitle": "Wanneer is het voorwerp gemaakt? Dit kan een exacte datum of een datumbereik zijn.",
+    "noListsInCommunity": "Geen lijsten",
+    "objectAddedToList": "Object toegevoegd aan lijst <name></name>.",
+     "objectAlreadyInList": "Object staat al in lijst <name></name>.",
+     "objectNotAddedToList": "Er is een probleem opgetreden bij het toevoegen van het object aan de lijst. Probeer het later opnieuw."
   },
   "PersonDetails": {
     "backButton": "Terug naar resultaten",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -87,8 +87,9 @@
     "dateCreatedSubTitle": "Wanneer is het voorwerp gemaakt? Dit kan een exacte datum of een datumbereik zijn.",
     "noListsInCommunity": "Geen lijsten",
     "objectAddedToList": "Object toegevoegd aan lijst <name></name>.",
-    "objectAlreadyInList": "Object staat al in lijst <name></name>.",
-    "objectNotAddedToList": "Er is een probleem opgetreden bij het toevoegen van het object aan de lijst. Probeer het later opnieuw."
+    "errorObjectAddedToList": "Er is een probleem opgetreden bij het toevoegen van het object aan de lijst. Probeer het later opnieuw.",
+    "objectRemovedFromList": "Object verwijderd van lijst <name></name>.",
+    "errorObjectRemovedFromList": "Er is een probleem opgetreden bij het verwijderen van het object van de lijst. Probeer het later opnieuw."
   },
   "PersonDetails": {
     "backButton": "Terug naar resultaten",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -87,8 +87,8 @@
     "dateCreatedSubTitle": "Wanneer is het voorwerp gemaakt? Dit kan een exacte datum of een datumbereik zijn.",
     "noListsInCommunity": "Geen lijsten",
     "objectAddedToList": "Object toegevoegd aan lijst <name></name>.",
-     "objectAlreadyInList": "Object staat al in lijst <name></name>.",
-     "objectNotAddedToList": "Er is een probleem opgetreden bij het toevoegen van het object aan de lijst. Probeer het later opnieuw."
+    "objectAlreadyInList": "Object staat al in lijst <name></name>.",
+    "objectNotAddedToList": "Er is een probleem opgetreden bij het toevoegen van het object aan de lijst. Probeer het later opnieuw."
   },
   "PersonDetails": {
     "backButton": "Terug naar resultaten",

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,1 +1,2 @@
 export * as objectList from './src/object-list';
+export * from './src/db/types';

--- a/packages/database/migrations/0003_object_list_id_not_null.sql
+++ b/packages/database/migrations/0003_object_list_id_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `object_item` MODIFY COLUMN `object_list_id` int NOT NULL;

--- a/packages/database/migrations/0004_object_item_change_primary_key.sql
+++ b/packages/database/migrations/0004_object_item_change_primary_key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `object_item` ADD `id` serial AUTO_INCREMENT NOT NULL;--> statement-breakpoint
+ALTER TABLE `object_item` DROP PRIMARY KEY;--> statement-breakpoint
+ALTER TABLE `object_item` ADD PRIMARY KEY(`id`);

--- a/packages/database/migrations/meta/0003_snapshot.json
+++ b/packages/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,165 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "6dcd4a54-7745-42cd-b50f-37cf73c96c19",
+  "prevId": "f2311843-75be-4ca1-be64-e5620a7b268b",
+  "tables": {
+    "object_item": {
+      "name": "object_item",
+      "columns": {
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_iri": {
+          "name": "object_iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_list_id": {
+          "name": "object_list_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "id": {
+          "name": "id",
+          "columns": [
+            "object_id"
+          ],
+          "isUnique": false
+        },
+        "object_list_id": {
+          "name": "object_list_id",
+          "columns": [
+            "object_list_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "object_item_object_id": {
+          "name": "object_item_object_id",
+          "columns": [
+            "object_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "object_item_object_id_object_list_id_unique": {
+          "name": "object_item_object_id_object_list_id_unique",
+          "columns": [
+            "object_id",
+            "object_list_id"
+          ]
+        }
+      }
+    },
+    "object_list": {
+      "name": "object_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "community_id": {
+          "name": "community_id",
+          "columns": [
+            "community_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "object_list_id": {
+          "name": "object_list_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/database/migrations/meta/0004_snapshot.json
+++ b/packages/database/migrations/meta/0004_snapshot.json
@@ -1,0 +1,172 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "ca3beccc-2f44-41c8-b5bd-4a580d9afcf2",
+  "prevId": "6dcd4a54-7745-42cd-b50f-37cf73c96c19",
+  "tables": {
+    "object_item": {
+      "name": "object_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_iri": {
+          "name": "object_iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_list_id": {
+          "name": "object_list_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "id": {
+          "name": "id",
+          "columns": [
+            "object_id"
+          ],
+          "isUnique": false
+        },
+        "object_list_id": {
+          "name": "object_list_id",
+          "columns": [
+            "object_list_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "object_item_id": {
+          "name": "object_item_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "object_item_object_id_object_list_id_unique": {
+          "name": "object_item_object_id_object_list_id_unique",
+          "columns": [
+            "object_id",
+            "object_list_id"
+          ]
+        }
+      }
+    },
+    "object_list": {
+      "name": "object_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "community_id": {
+          "name": "community_id",
+          "columns": [
+            "community_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "object_list_id": {
+          "name": "object_list_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1695393273717,
       "tag": "0002_object_list_name_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1695717398044,
+      "tag": "0003_object_list_id_not_null",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1695717398044,
       "tag": "0003_object_list_id_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1696425284032,
+      "tag": "0004_object_item_change_primary_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -38,7 +38,8 @@ export const objectListsRelations = relations(objectLists, ({many}) => ({
 export const objectItems = mysqlTable(
   'object_item',
   {
-    objectId: varchar('object_id', {length: 32}).primaryKey(),
+    id: serial('id').primaryKey(),
+    objectId: varchar('object_id', {length: 32}).notNull(),
     objectIri: text('object_iri').notNull(),
     objectListId: int('object_list_id').notNull(),
     createdAt: timestamp('created_at')
@@ -50,7 +51,7 @@ export const objectItems = mysqlTable(
     createdBy: varchar('created_by', {length: 50}).notNull(),
   },
   item => ({
-    id: index('id').on(item.objectId),
+    objectId: index('id').on(item.objectId),
     objectListId: index('object_list_id').on(item.objectListId),
     unique: unique().on(item.objectId, item.objectListId),
   })

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -40,7 +40,7 @@ export const objectItems = mysqlTable(
   {
     objectId: varchar('object_id', {length: 32}).primaryKey(),
     objectIri: text('object_iri').notNull(),
-    objectListId: int('object_list_id'),
+    objectListId: int('object_list_id').notNull(),
     createdAt: timestamp('created_at')
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),

--- a/packages/database/src/db/types.ts
+++ b/packages/database/src/db/types.ts
@@ -1,13 +1,13 @@
 import {InferSelectModel, InferInsertModel} from 'drizzle-orm';
 import {objectLists, objectItems} from './schema';
 
-export interface SelectObjectList extends InferSelectModel<typeof objectLists> {
+export interface ObjectList extends InferSelectModel<typeof objectLists> {
   objects?: InferSelectModel<typeof objectItems>[];
 }
-export type InsertObjectList = InferInsertModel<typeof objectLists>;
+export type ObjectListsBeingCreated = InferInsertModel<typeof objectLists>;
 
-export type SelectObjectItem = InferSelectModel<typeof objectItems>;
-export type InsertObjectItem = Omit<
+export type ObjectItem = InferSelectModel<typeof objectItems>;
+export type ObjectItemBeingCreated = Omit<
   InferInsertModel<typeof objectItems>,
   'objectId'
 >;

--- a/packages/database/src/db/types.ts
+++ b/packages/database/src/db/types.ts
@@ -1,7 +1,9 @@
 import {InferSelectModel, InferInsertModel} from 'drizzle-orm';
 import {objectLists, objectItems} from './schema';
 
-export type SelectObjectList = InferSelectModel<typeof objectLists>;
+export interface SelectObjectList extends InferSelectModel<typeof objectLists> {
+  objects?: InferSelectModel<typeof objectItems>[];
+}
 export type InsertObjectList = InferInsertModel<typeof objectLists>;
 
 export type SelectObjectItem = InferSelectModel<typeof objectItems>;

--- a/packages/database/src/db/types.ts
+++ b/packages/database/src/db/types.ts
@@ -1,0 +1,11 @@
+import {InferSelectModel, InferInsertModel} from 'drizzle-orm';
+import {objectLists, objectItems} from './schema';
+
+export type SelectObjectList = InferSelectModel<typeof objectLists>;
+export type InsertObjectList = InferInsertModel<typeof objectLists>;
+
+export type SelectObjectItem = InferSelectModel<typeof objectItems>;
+export type InsertObjectItem = Omit<
+  InferInsertModel<typeof objectItems>,
+  'objectId'
+>;

--- a/packages/database/src/object-list.ts
+++ b/packages/database/src/object-list.ts
@@ -66,16 +66,20 @@ export async function create({
 }
 
 interface AddObjectProps {
-  listId: number;
+  objectListId: number;
   objectIri: string;
-  userId: string;
+  createdBy: string;
 }
 
-export async function addObject({listId, objectIri, userId}: AddObjectProps) {
+export async function addObject({
+  objectListId,
+  objectIri,
+  createdBy,
+}: AddObjectProps) {
   const objectItem = insertObjectItemSchema.parse({
-    listId,
+    objectListId,
     objectIri,
-    createdBy: userId,
+    createdBy,
     objectId: iriToHash(objectIri),
   });
 

--- a/packages/database/src/object-list.ts
+++ b/packages/database/src/object-list.ts
@@ -9,12 +9,12 @@ import {SelectObjectList} from './db/types';
 interface Option {
   withObjects?: boolean;
   limitObjects?: number;
-  includeObjectIri?: string;
+  objectIri?: string;
 }
 
 export async function getByCommunityId(
   communityId: string,
-  {withObjects, limitObjects, includeObjectIri}: Option = {withObjects: false}
+  {withObjects, limitObjects, objectIri}: Option = {withObjects: false}
   // Explicitly set the return type, or else `objects` will not be included.
 ): Promise<SelectObjectList[]> {
   const options: DBQueryConfig = {};
@@ -25,8 +25,8 @@ export async function getByCommunityId(
     };
   }
 
-  if (includeObjectIri) {
-    const objectId = iriToHash(includeObjectIri);
+  if (objectIri) {
+    const objectId = iriToHash(objectIri);
     options.with = {
       objects: {
         where: (objectItems, {eq}) => eq(objectItems.objectId, objectId),

--- a/packages/database/src/object-list.ts
+++ b/packages/database/src/object-list.ts
@@ -9,11 +9,12 @@ import {SelectObjectList} from './db/types';
 interface Option {
   withObjects?: boolean;
   limitObjects?: number;
+  includeObjectIri?: string;
 }
 
 export async function getByCommunityId(
   communityId: string,
-  {withObjects, limitObjects}: Option = {withObjects: false}
+  {withObjects, limitObjects, includeObjectIri}: Option = {withObjects: false}
   // Explicitly set the return type, or else `objects` will not be included.
 ): Promise<SelectObjectList[]> {
   const options: DBQueryConfig = {};
@@ -21,6 +22,15 @@ export async function getByCommunityId(
   if (withObjects) {
     options.with = {
       objects: limitObjects ? {limit: limitObjects} : true,
+    };
+  }
+
+  if (includeObjectIri) {
+    const objectId = iriToHash(includeObjectIri);
+    options.with = {
+      objects: {
+        where: (objectItems, {eq}) => eq(objectItems.objectId, objectId),
+      },
     };
   }
 
@@ -82,4 +92,8 @@ export async function addObject({
   });
 
   return db.insert(objectItems).values(objectItem);
+}
+
+export async function removeObject(id: number) {
+  return db.delete(objectItems).where(eq(objectItems.id, id));
 }

--- a/packages/database/src/object-list.ts
+++ b/packages/database/src/object-list.ts
@@ -4,7 +4,7 @@ import {sql} from 'drizzle-orm';
 import {db} from './db/connection';
 import {iriToHash} from './iri-to-hash';
 import {DBQueryConfig, eq} from 'drizzle-orm';
-import {SelectObjectList} from './db/types';
+import {ObjectList} from './db/types';
 
 interface Option {
   withObjects?: boolean;
@@ -16,7 +16,7 @@ export async function getByCommunityId(
   communityId: string,
   {withObjects, limitObjects, objectIri}: Option = {withObjects: false}
   // Explicitly set the return type, or else `objects` will not be included.
-): Promise<SelectObjectList[]> {
+): Promise<ObjectList[]> {
   const options: DBQueryConfig = {};
 
   if (withObjects) {

--- a/packages/database/src/object-list.ts
+++ b/packages/database/src/object-list.ts
@@ -1,23 +1,21 @@
 import {objectLists, objectItems} from './db/schema';
 import {insertObjectItemSchema, insertObjectListSchema} from './db/validation';
-import {InferSelectModel, sql} from 'drizzle-orm';
+import {sql} from 'drizzle-orm';
 import {db} from './db/connection';
 import {iriToHash} from './iri-to-hash';
 import {DBQueryConfig, eq} from 'drizzle-orm';
+import {SelectObjectList} from './db/types';
 
 interface Option {
   withObjects?: boolean;
   limitObjects?: number;
 }
 
-interface ObjectList extends InferSelectModel<typeof objectLists> {
-  objects?: InferSelectModel<typeof objectItems>[];
-}
-
 export async function getByCommunityId(
   communityId: string,
   {withObjects, limitObjects}: Option = {withObjects: false}
-): Promise<ObjectList[]> {
+  // Explicitly set the return type, or else `objects` will not be included.
+): Promise<SelectObjectList[]> {
   const options: DBQueryConfig = {};
 
   if (withObjects) {

--- a/packages/ui/notifications.tsx
+++ b/packages/ui/notifications.tsx
@@ -5,10 +5,16 @@ import {XMarkIcon} from '@heroicons/react/24/outline';
 import {ReactNode, useEffect} from 'react';
 import {usePathname} from 'next/navigation';
 
+const typeColors = {
+  success: 'greenGrey',
+  warning: 'yellow',
+  error: 'red',
+};
+
 type Notification = {
   id: string;
   message: ReactNode;
-  type: 'success'; // For now we only have success notifications, but we could add more types later
+  type: 'success' | 'warning' | 'error';
 };
 
 interface State {
@@ -49,20 +55,23 @@ export function Notifications() {
 
   return (
     <div className="my-6">
-      {notifications.map(notification => (
-        <div
-          key={notification.id}
-          className="justify-between items-center bg-greenGrey-50 border-greenGrey-100 text-greenGrey-800 border p-4 rounded-xl flex my-2"
-        >
-          <div>{notification.message}</div>
-          <button
-            onClick={() => removeNotification(notification)}
-            className="hover:bg-greenGrey-200 p-1 rounded"
+      {notifications.map(notification => {
+        const typeColor = typeColors[notification.type];
+        return (
+          <div
+            key={notification.id}
+            className={`justify-between items-center bg-${typeColor}-50 border-${typeColor}-100 text-${typeColor}-800 border p-4 rounded-xl flex my-2`}
           >
-            <XMarkIcon className="w-4 h-4" />
-          </button>
-        </div>
-      ))}
+            <div>{notification.message}</div>
+            <button
+              onClick={() => removeNotification(notification)}
+              className={`hover:bg-${typeColor}-200 p-1 rounded`}
+            >
+              <XMarkIcon className="w-4 h-4" />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
This pull request will add a dropdown to the object detail page. The user can choose a list to add the object to. After adding the object, the object is shown on the community page.

The design of the object list dropdown I made myself, and maybe needs some changes later.

I made two schema changes:

1: `objectItem.listId` could be null. An `objectItem` without a list makes no sense, so I made this property not null.
2: The `objectItem.objectId` (hashed URI) was the primary key. But objectId is not unique because objects can be added to multiple lists. So, I have added  `objectItem.id` with an auto-increment and made this the primary key. 