### PR TITLE
App router is available by default now

### DIFF
--- a/apps/dataset-browser/next.config.js
+++ b/apps/dataset-browser/next.config.js
@@ -6,7 +6,6 @@ const withMDX = require('@next/mdx')();
 const nextConfig = {
   transpilePackages: ['ui'],
   experimental: {
-    appDir: true,
     mdxRs: true,
   },
 };

--- a/apps/researcher/next.config.js
+++ b/apps/researcher/next.config.js
@@ -6,7 +6,6 @@ const withMDX = require('@next/mdx')();
 const nextConfig = {
   transpilePackages: ['ui'],
   experimental: {
-    appDir: true,
     mdxRs: true,
     serverActions: true,
   },


### PR DESCRIPTION
This will remove the build warning:

 ⚠ Invalid next.config.js options detected: 
 ⚠     The value at .experimental has an unexpected property, appDir, which is not in the list of allowed properties (appDocumentPreloading, adjustFontFallbacks, adjustFontFallbacksWithSizeAdjust, allowedRevalidateHeaderKeys, amp, clientRouterFilter, clientRouterFilterRedirects, clientRouterFilterAllowedRate, cpus, memoryBasedWorkersCount, craCompat, caseSensitiveRoutes, useDeploymentId, useDeploymentIdServerActions, deploymentId, disableOptimizedLoading, disablePostcssPresetEnv, esmExternals, serverActions, serverActionsBodySizeLimit, extensionAlias, externalDir, externalMiddlewareRewritesResolve, fallbackNodePolyfills, fetchCacheKeyPrefix, forceSwcTransforms, fullySpecified, gzipSize, incrementalCacheHandlerPath, isrFlushToDisk, isrMemoryCacheSize, largePageDataBytes, manualClientBasePath, middlewarePrefetch, nextScriptWorkers, optimizeCss, optimisticClientCache, outputFileTracingRoot, outputFileTracingExcludes, outputFileTracingIgnores, outputFileTracingIncludes, ppr, proxyTimeout, serverComponentsExternalPackages, scrollRestoration, sharedPool, sri, strictNextHead, swcMinify, swcPlugins, swcTraceProfiling, urlImports, workerThreads, webVitalsAttribution, mdxRs, typedRoutes, webpackBuildWorker, turbo, optimizePackageImports, optimizeServerReact, instrumentationHook, turbotrace, logging, serverMinification, serverSourceMaps).
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
 ⚠ App router is available by default now, `experimental.appDir` option can be safely removed.