### PR TITLE
Community description

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
@@ -3,21 +3,34 @@
 import {joinCommunity, updateDescription} from '@/lib/community';
 import {revalidatePath} from 'next/cache';
 
-interface UpdateDescriptionActionProps {
+interface UpdateDescriptionAndRevalidateProps {
   communityId: string;
   communitySlug: string;
   description: string;
 }
 
-export async function updateDescriptionAction({
+export async function updateDescriptionAndRevalidate({
   communityId,
   communitySlug,
   description,
-}: UpdateDescriptionActionProps) {
+}: UpdateDescriptionAndRevalidateProps) {
   await updateDescription({communityId, description});
   revalidatePath(`/[locale]/communities/${communitySlug}`, 'page');
   revalidatePath('/[locale]/communities', 'page');
 }
 
-// Export as server actions.
-export {joinCommunity as joinCommunityAction};
+interface JoinCommunityAndRevalidateProps {
+  communityId: string;
+  communitySlug: string;
+  userId: string;
+}
+
+export async function joinCommunityAndRevalidate({
+  communityId,
+  communitySlug,
+  userId,
+}: JoinCommunityAndRevalidateProps) {
+  await joinCommunity({communityId, userId});
+  revalidatePath(`/[locale]/communities/${communitySlug}`, 'page');
+  revalidatePath('/[locale]/communities', 'page');
+}

--- a/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
@@ -1,6 +1,23 @@
 'use server';
 
-import {joinCommunity} from '@/lib/community';
+import {joinCommunity, editDescription} from '@/lib/community';
+import {revalidatePath} from 'next/cache';
+
+interface editDescriptionActionProps {
+  communityId: string;
+  communitySlug: string;
+  description: string;
+}
+
+async function editDescriptionAction({
+  communityId,
+  communitySlug,
+  description,
+}: editDescriptionActionProps) {
+  await editDescription({communityId, description});
+  revalidatePath(`/[locale]/communities/${communitySlug}`, 'page');
+  revalidatePath('/[locale]/communities', 'page');
+}
 
 // Export as server actions.
-export {joinCommunity};
+export {joinCommunity, editDescriptionAction};

--- a/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
@@ -20,4 +20,4 @@ export async function updateDescriptionAction({
 }
 
 // Export as server actions.
-export {joinCommunity};
+export {joinCommunity as joinCommunityAction};

--- a/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/actions.ts
@@ -1,23 +1,23 @@
 'use server';
 
-import {joinCommunity, editDescription} from '@/lib/community';
+import {joinCommunity, updateDescription} from '@/lib/community';
 import {revalidatePath} from 'next/cache';
 
-interface editDescriptionActionProps {
+interface UpdateDescriptionActionProps {
   communityId: string;
   communitySlug: string;
   description: string;
 }
 
-async function editDescriptionAction({
+export async function updateDescriptionAction({
   communityId,
   communitySlug,
   description,
-}: editDescriptionActionProps) {
-  await editDescription({communityId, description});
+}: UpdateDescriptionActionProps) {
+  await updateDescription({communityId, description});
   revalidatePath(`/[locale]/communities/${communitySlug}`, 'page');
   revalidatePath('/[locale]/communities', 'page');
 }
 
 // Export as server actions.
-export {joinCommunity, editDescriptionAction};
+export {joinCommunity};

--- a/apps/researcher/src/app/[locale]/communities/[slug]/buttons.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/buttons.tsx
@@ -4,7 +4,7 @@ import {useState} from 'react';
 import {useTranslations} from 'next-intl';
 import {useClerk, useUser} from '@clerk/nextjs';
 import {useTransition} from 'react';
-import {joinCommunity} from './actions';
+import {joinCommunityAction} from './actions';
 
 interface Props {
   communityId: string;
@@ -34,7 +34,7 @@ export function JoinCommunityButton({communityId}: Props) {
     setIsClicked(true);
     startTransition(async () => {
       try {
-        await joinCommunity({
+        await joinCommunityAction({
           organizationId: communityId,
           userId: user!.id,
         });

--- a/apps/researcher/src/app/[locale]/communities/[slug]/buttons.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/buttons.tsx
@@ -4,14 +4,15 @@ import {useState} from 'react';
 import {useTranslations} from 'next-intl';
 import {useClerk, useUser} from '@clerk/nextjs';
 import {useTransition} from 'react';
-import {joinCommunityAction} from './actions';
+import {joinCommunityAndRevalidate} from './actions';
 
 interface Props {
   communityId: string;
+  communitySlug: string;
 }
 
 // If logged in and not part of the community, show the join button
-export function JoinCommunityButton({communityId}: Props) {
+export function JoinCommunityButton({communityId, communitySlug}: Props) {
   const {isLoaded, isSignedIn, user} = useUser();
   const [isClicked, setIsClicked] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -34,8 +35,9 @@ export function JoinCommunityButton({communityId}: Props) {
     setIsClicked(true);
     startTransition(async () => {
       try {
-        await joinCommunityAction({
-          organizationId: communityId,
+        await joinCommunityAndRevalidate({
+          communityId,
+          communitySlug,
           userId: user!.id,
         });
       } catch (err) {

--- a/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
@@ -3,7 +3,7 @@
 import {useForm, SubmitHandler} from 'react-hook-form';
 import {useTranslations} from 'next-intl';
 import {useSlideOut, useNotifications} from 'ui';
-import {editDescriptionAction} from './actions';
+import {updateDescriptionAction} from './actions';
 
 interface Props {
   communityId: string;
@@ -43,10 +43,10 @@ export default function EditDescriptionForm({
 
   const onSubmit: SubmitHandler<FormValues> = async descriptionFormValues => {
     try {
-      await editDescriptionAction(descriptionFormValues);
+      await updateDescriptionAction(descriptionFormValues);
       addNotification({
         id: 'add-object-list-success',
-        message: <>{t('descriptionSuccessfullyEdited')}</>,
+        message: <>{t('descriptionUpdated')}</>,
         type: 'success',
       });
       setIsVisible(slideOutId, false);

--- a/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
@@ -3,7 +3,7 @@
 import {useForm, SubmitHandler} from 'react-hook-form';
 import {useTranslations} from 'next-intl';
 import {useSlideOut, useNotifications} from 'ui';
-import {updateDescriptionAction} from './actions';
+import {updateDescriptionAndRevalidate} from './actions';
 
 interface Props {
   communityId: string;
@@ -43,7 +43,7 @@ export default function EditDescriptionForm({
 
   const onSubmit: SubmitHandler<FormValues> = async descriptionFormValues => {
     try {
-      await updateDescriptionAction(descriptionFormValues);
+      await updateDescriptionAndRevalidate(descriptionFormValues);
       addNotification({
         id: 'add-object-list-success',
         message: <>{t('descriptionUpdated')}</>,

--- a/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/edit-description-form.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {useForm, SubmitHandler} from 'react-hook-form';
+import {useTranslations} from 'next-intl';
+import {useSlideOut, useNotifications} from 'ui';
+import {editDescriptionAction} from './actions';
+
+interface Props {
+  communityId: string;
+  communitySlug: string;
+  slideOutId: string;
+  description?: string;
+}
+
+interface FormValues {
+  description: string;
+  communityId: string;
+  communitySlug: string;
+}
+
+export default function EditDescriptionForm({
+  slideOutId,
+  communityId,
+  communitySlug,
+  description,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: {errors, isSubmitting},
+  } = useForm({
+    defaultValues: {
+      description: description ?? '',
+      communityId,
+      communitySlug,
+    },
+  });
+
+  const t = useTranslations('Community');
+  const {setIsVisible} = useSlideOut();
+  const {addNotification} = useNotifications();
+
+  const onSubmit: SubmitHandler<FormValues> = async descriptionFormValues => {
+    try {
+      await editDescriptionAction(descriptionFormValues);
+      addNotification({
+        id: 'add-object-list-success',
+        message: <>{t('descriptionSuccessfullyEdited')}</>,
+        type: 'success',
+      });
+      setIsVisible(slideOutId, false);
+    } catch (err) {
+      setError('root.serverError', {
+        message: t('serverError'),
+      });
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex-col gap-6 flex w-full max-w-3xl"
+    >
+      {errors.root?.serverError.message && (
+        <div className="rounded-md bg-red-50 p-4 mt-3">
+          <div className="ml-3">
+            <h3 className="text-sm leading-5 font-medium text-red-800">
+              {errors.root.serverError.message}
+            </h3>
+          </div>
+        </div>
+      )}
+      <div className="flex flex-col sm:flex-row gap-4 ">
+        <div className="flex flex-col w-full">
+          <label className="flex flex-col text-sm">
+            <strong>{t('labelDescription')}</strong>
+          </label>
+          <textarea
+            id="description"
+            {...register('description', {
+              maxLength: 2000,
+            })}
+            rows={4}
+            className="border border-greenGrey-200 rounded p-2 w-full"
+          />
+          <p>
+            {errors.description && t(`description_${errors.description.type}`)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="w-full lg:w-2/3 flex gap-2">
+          <button
+            disabled={isSubmitting}
+            type="submit"
+            className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-greenGrey-100 hover:bg-greenGrey-200 transition text-greenGrey-800 flex items-center gap-1"
+          >
+            {t('changeDescriptionSaveButton')}
+          </button>
+          <button
+            onClick={() => setIsVisible(slideOutId, false)}
+            className="p-1 sm:py-2 sm:px-3 rounded-full text-xs border border-greenGrey-300 hover:bg-greenGrey-200 transition text-greenGrey-800 flex items-center gap-1"
+          >
+            {t('changeDescriptionCancelButton')}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -96,7 +96,7 @@ export default async function CommunityPage({params}: Props) {
             <div className="w-full flex flex-col md:flex-row justify-center px-4">
               <SlideOutClosed id={slideOutDescriptionId}>
                 <div className="mb-4 max-w-3xl text-left whitespace-pre-line">
-                  {community.publicMetadata?.description}
+                  {community.description}
                 </div>
               </SlideOutClosed>
               <SlideOut id={slideOutDescriptionId}>
@@ -104,7 +104,7 @@ export default async function CommunityPage({params}: Props) {
                   slideOutId={slideOutDescriptionId}
                   communityId={community.id}
                   communitySlug={community.slug!}
-                  description={community.publicMetadata?.description}
+                  description={community.description}
                 />
               </SlideOut>
             </div>
@@ -188,9 +188,9 @@ export default async function CommunityPage({params}: Props) {
                 key={membership.id}
               >
                 <div className="w-10">
-                  {membership.publicUserData?.profileImageUrl && (
+                  {membership.imageUrl && (
                     <Image
-                      src={membership.publicUserData.profileImageUrl}
+                      src={membership.imageUrl}
                       alt=""
                       className="w-full rounded-full"
                       width={40}
@@ -200,8 +200,7 @@ export default async function CommunityPage({params}: Props) {
                 </div>
                 <div className="flex flex-col">
                   <div className="">
-                    {membership.publicUserData?.firstName}{' '}
-                    {membership.publicUserData?.lastName}
+                    {membership.firstName} {membership.lastName}
                   </div>
                   <div className="text-neutral-600">
                     {/* Place country name here */}

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -10,7 +10,8 @@ import {revalidatePath} from 'next/cache';
 import {objectList} from '@colonial-collections/database';
 import ObjectCard from './object';
 import AddObjectListForm from '@/components/add-object-list-form';
-import {SlideOutButton, SlideOut, Notifications} from 'ui';
+import {SlideOutButton, SlideOut, SlideOutClosed, Notifications} from 'ui';
+import EditDescriptionForm from './edit-description-form';
 
 interface Props {
   params: {
@@ -20,6 +21,11 @@ interface Props {
 }
 
 const slideOutFormId = 'add-object-list';
+const slideOutDescriptionId = 'edit-community-description';
+
+// Don't cache this page, so we always get the latest community data from the third-party Clerk.
+// With 'force-dynamic', the description in the Clerk metadata will change after editing.
+export const dynamic = 'force-dynamic';
 
 export default async function CommunityPage({params}: Props) {
   const t = await getTranslator(params.locale, 'Community');
@@ -87,14 +93,30 @@ export default async function CommunityPage({params}: Props) {
                 {community.name}
               </span>
             </h1>
-
             <div className="w-full flex flex-col md:flex-row justify-center px-4">
-              <div className="mb-4 max-w-3xl text-left">
-                {/*Place the description here*/}
-              </div>
-              <div className="flex flex-col items-start md:justify-center md:items-center w-full mb-4">
-                <JoinCommunityButton communityId={community.id} />
-              </div>
+              <SlideOutClosed id={slideOutDescriptionId}>
+                <div className="mb-4 max-w-3xl text-left whitespace-pre-line">
+                  {community.publicMetadata?.description}
+                </div>
+              </SlideOutClosed>
+              <SlideOut id={slideOutDescriptionId}>
+                <EditDescriptionForm
+                  slideOutId={slideOutDescriptionId}
+                  communityId={community.id}
+                  communitySlug={community.slug!}
+                  description={community.publicMetadata?.description}
+                />
+              </SlideOut>
+            </div>
+            <div className="flex flex-col items-start md:justify-center md:items-center w-full mb-4">
+              <JoinCommunityButton communityId={community.id} />
+              <SlideOutButton
+                hideIfOpen
+                id={slideOutDescriptionId}
+                className="flex items-center py-2 px-3 rounded-full bg-sand-100 text-sand-900 hover:bg-white transition text-xs"
+              >
+                {t('editDescriptionButton')}
+              </SlideOutButton>
             </div>
           </div>
 

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -109,7 +109,10 @@ export default async function CommunityPage({params}: Props) {
               </SlideOut>
             </div>
             <div className="flex flex-col items-start md:justify-center md:items-center w-full mb-4">
-              <JoinCommunityButton communityId={community.id} />
+              <JoinCommunityButton
+                communityId={community.id}
+                communitySlug={params.slug}
+              />
               <SlideOutButton
                 hideIfOpen
                 id={slideOutDescriptionId}

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -88,8 +88,8 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
           ),
         })}
       </h1>
-      <div className="text-center p-4">
-        {/* TODO add community description */}
+      <div className="text-center m-4 line-clamp-3">
+        {community.publicMetadata?.description}
       </div>
 
       <div className="flex border-stone-300 border-t text-sm text-stone-600">

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -89,7 +89,7 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
         })}
       </h1>
       <div className="text-center m-4 line-clamp-3 grow">
-        {community.publicMetadata?.description}
+        {community.description}
       </div>
 
       <div className="flex border-stone-300 border-t text-sm text-stone-600">

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -64,7 +64,7 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
   return (
     <Link
       href={`/communities/${community.slug}`}
-      className="rounded-lg mb-20 bg-[#f3eee2] hover:bg-[#f1e9d7] text-stone-800 transition"
+      className="rounded-lg mb-20 bg-[#f3eee2] hover:bg-[#f1e9d7] text-stone-800 transition flex flex-col"
     >
       <div className="-mt-20 w-full flex justify-center">
         <Image
@@ -88,7 +88,7 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
           ),
         })}
       </h1>
-      <div className="text-center m-4 line-clamp-3">
+      <div className="text-center m-4 line-clamp-3 grow">
         {community.publicMetadata?.description}
       </div>
 

--- a/apps/researcher/src/lib/community.test.ts
+++ b/apps/researcher/src/lib/community.test.ts
@@ -1,40 +1,6 @@
 import {describe, expect, it} from '@jest/globals';
 import {auth} from '@clerk/nextjs';
-import {isAdmin, sort, SortBy} from './community';
-import {OrganizationMembership} from '@clerk/nextjs/dist/types/server';
-
-const basicOrganization = {
-  id: 'organization1',
-  name: 'Organization 1',
-  slug: 'organization-1',
-  imageUrl: 'https://example.com/image.png',
-  createdAt: 1690000000000,
-  updatedAt: 1690000000000,
-  logoUrl: null,
-  createdBy: 'me',
-  publicMetadata: null,
-  privateMetadata: {},
-  maxAllowedMemberships: 100,
-  adminDeleteEnabled: true,
-};
-
-const basicMembership = {
-  id: 'membership1',
-  role: 'admin',
-  publicUserData: {
-    identifier: 'me',
-    userId: 'me',
-    firstName: 'John',
-    lastName: 'Doe',
-    profileImageUrl: 'https://example.com/image.png',
-    imageUrl: 'https://example.com/image.png',
-  },
-  publicMetadata: {},
-  privateMetadata: {},
-  createdAt: 1690000000000,
-  updatedAt: 1690000000000,
-  organization: basicOrganization,
-};
+import {isAdmin, Membership, sort, SortBy} from './community';
 
 jest.mock('@clerk/nextjs', () => ({
   auth: jest.fn().mockImplementation(() => ({
@@ -44,54 +10,50 @@ jest.mock('@clerk/nextjs', () => ({
 
 describe('isAdmin', () => {
   it('returns true if user is an admin', () => {
-    const memberships: ReadonlyArray<OrganizationMembership> = [
+    const memberships: ReadonlyArray<Membership> = [
       {
-        ...basicMembership,
         id: 'membership1',
         role: 'admin',
-        publicUserData: {
-          ...basicMembership.publicUserData,
-          userId: 'me',
-        },
+        userId: 'me',
+        firstName: 'John',
+        lastName: 'Doe',
+        imageUrl: 'https://example.com/image.png',
       },
       {
-        ...basicMembership,
         id: 'membership2',
         role: 'basic_member',
-        publicUserData: {
-          ...basicMembership.publicUserData,
-          userId: 'me',
-        },
+        userId: 'notMe',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        imageUrl: 'https://example.com/image.png',
       },
     ];
     expect(isAdmin(memberships)).toEqual(true);
   });
 
   it('returns false if user is not an admin', () => {
-    const memberships: ReadonlyArray<OrganizationMembership> = [
+    const memberships: ReadonlyArray<Membership> = [
       {
-        ...basicMembership,
         id: 'membership1',
         role: 'basic_member',
-        publicUserData: {
-          ...basicMembership.publicUserData,
-          userId: 'me',
-        },
+        userId: 'me',
+        firstName: 'John',
+        lastName: 'Doe',
+        imageUrl: 'https://example.com/image.png',
       },
     ];
     expect(isAdmin(memberships)).toEqual(false);
   });
 
   it('returns false if user is not a member', () => {
-    const memberships: ReadonlyArray<OrganizationMembership> = [
+    const memberships: ReadonlyArray<Membership> = [
       {
-        ...basicMembership,
         id: 'membership1',
         role: 'basic_member',
-        publicUserData: {
-          ...basicMembership.publicUserData,
-          userId: 'notMe',
-        },
+        userId: 'notMe',
+        firstName: 'John',
+        lastName: 'Doe',
+        imageUrl: 'https://example.com/image.png',
       },
     ];
     expect(isAdmin(memberships)).toEqual(false);
@@ -102,18 +64,21 @@ describe('isAdmin', () => {
       userId: undefined,
     }));
 
-    const memberships: ReadonlyArray<OrganizationMembership> = [
+    const memberships: ReadonlyArray<Membership> = [
       {
-        ...basicMembership,
         id: 'membership1',
         role: 'admin',
+        userId: 'notMe',
+        firstName: 'John',
+        lastName: 'Doe',
+        imageUrl: 'https://example.com/image.png',
       },
     ];
     expect(isAdmin(memberships)).toEqual(false);
   });
 
   it('returns false if there are no memberships', () => {
-    const memberships: OrganizationMembership[] = [];
+    const memberships: Membership[] = [];
     expect(isAdmin(memberships)).toEqual(false);
   });
 });
@@ -121,33 +86,38 @@ describe('isAdmin', () => {
 describe('sort', () => {
   const communities = [
     {
-      ...basicOrganization,
       id: 'community2',
       name: 'Community 2',
+      slug: 'community-2',
+      imageUrl: 'https://example.com/image.png',
       createdAt: 1690000000000,
     },
     {
-      ...basicOrganization,
       id: 'community1',
       name: 'Community 1',
+      slug: 'community-1',
+      imageUrl: 'https://example.com/image.png',
       createdAt: 1600000000000,
     },
     {
-      ...basicOrganization,
       id: 'community4',
       name: 'Community 4',
+      slug: 'community-4',
+      imageUrl: 'https://example.com/image.png',
       createdAt: 1680000000000,
     },
     {
-      ...basicOrganization,
       id: 'community3',
       name: 'Community 3',
+      slug: 'community-3',
+      imageUrl: 'https://example.com/image.png',
       createdAt: 1650000000000,
     },
     {
-      ...basicOrganization,
       id: 'community5',
       name: 'Community 5',
+      slug: 'community-5',
+      imageUrl: 'https://example.com/image.png',
       createdAt: 1670000000000,
     },
   ];
@@ -156,107 +126,137 @@ describe('sort', () => {
     const sortedCommunities = sort(communities, SortBy.NameAsc);
 
     const expectedSortedCommunities = [
-      expect.objectContaining({
+      {
         id: 'community1',
         name: 'Community 1',
+        slug: 'community-1',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community2',
         name: 'Community 2',
+        slug: 'community-2',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community3',
         name: 'Community 3',
+        slug: 'community-3',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community4',
         name: 'Community 4',
+        slug: 'community-4',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community5',
         name: 'Community 5',
+        slug: 'community-5',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-      }),
+      },
     ];
 
-    expect(sortedCommunities).toEqual(expectedSortedCommunities);
+    expect(sortedCommunities).toStrictEqual(expectedSortedCommunities);
   });
 
   it('sorts communities by name in descending order', () => {
     const sortedCommunities = sort(communities, SortBy.NameDesc);
 
     const expectedSortedCommunities = [
-      expect.objectContaining({
+      {
         id: 'community5',
         name: 'Community 5',
+        slug: 'community-5',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community4',
         name: 'Community 4',
+        slug: 'community-4',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community3',
         name: 'Community 3',
+        slug: 'community-3',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community2',
         name: 'Community 2',
+        slug: 'community-2',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community1',
         name: 'Community 1',
+        slug: 'community-1',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-      }),
+      },
     ];
 
-    expect(sortedCommunities).toEqual(expectedSortedCommunities);
+    expect(sortedCommunities).toStrictEqual(expectedSortedCommunities);
   });
 
   it('sorts communities by creation date in descending order', () => {
     const sortedCommunities = sort(communities, SortBy.CreatedAtDesc);
 
     const expectedSortedCommunities = [
-      expect.objectContaining({
+      {
         id: 'community2',
         name: 'Community 2',
+        slug: 'community-2',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community4',
         name: 'Community 4',
+        slug: 'community-4',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community5',
         name: 'Community 5',
+        slug: 'community-5',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community3',
         name: 'Community 3',
+        slug: 'community-3',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-      }),
-      expect.objectContaining({
+      },
+      {
         id: 'community1',
         name: 'Community 1',
+        slug: 'community-1',
+        imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-      }),
+      },
     ];
 
-    expect(sortedCommunities).toEqual(expectedSortedCommunities);
+    expect(sortedCommunities).toStrictEqual(expectedSortedCommunities);
   });
 
   it('returns the list unsorted if sortBy is an incorrect value', () => {
     const sortedCommunities = sort(communities, 'incorrect' as SortBy);
 
-    expect(sortedCommunities).toEqual(communities);
+    expect(sortedCommunities).toStrictEqual(communities);
   });
 });

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -104,3 +104,17 @@ export async function joinCommunity({
     role: 'basic_member',
   });
 }
+
+export async function editDescription({
+  communityId,
+  description,
+}: {
+  communityId: string;
+  description: string;
+}) {
+  return clerkClient.organizations.updateOrganizationMetadata(communityId, {
+    publicMetadata: {
+      description,
+    },
+  });
+}

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -4,7 +4,7 @@ import {OrganizationMembership, Organization} from '@clerk/backend/dist/types';
 export interface Community {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   slug: string;
   imageUrl: string;
   createdAt: number;
@@ -23,8 +23,7 @@ function organizationToCommunity(organization: Organization): Community {
   return {
     id: organization.id,
     name: organization.name,
-    description:
-      (organization.publicMetadata!.description as string | undefined) || '',
+    description: organization.publicMetadata!.description as string | undefined,
     slug: organization.slug!,
     imageUrl: organization.imageUrl,
     createdAt: organization.createdAt,

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -34,18 +34,19 @@ function organizationToCommunity(organization: Organization): Community {
 function organizationMembershipToCommunityMembership(
   membership: OrganizationMembership
 ): Membership {
-  if (!membership.publicUserData) {
-    throw new Error('publicUserData is undefined');
-  }
+  // There are some assumptions made in this function:
+  // - The membership has a `publicUserData` field. Even though it is optional in the Clerk type `OrganizationMembership`.
+  // - The `publicUserData` has the fields `userId` and `imageUrl`.
+  // - The `publicUserData` has the fields `firstName` and `lastName`.
+  //   These are optional in the Clerk type `OrganizationMembershipPublicUserData` but set to required in the Clerk settings for this application.
 
   return {
     id: membership.id,
     role: membership.role,
-    userId: membership.publicUserData.userId,
-    // First and last name are set to required in Clerk.
-    firstName: membership.publicUserData.firstName!,
-    lastName: membership.publicUserData.lastName!,
-    imageUrl: membership.publicUserData.imageUrl,
+    userId: membership.publicUserData!.userId,
+    firstName: membership.publicUserData!.firstName!,
+    lastName: membership.publicUserData!.lastName!,
+    imageUrl: membership.publicUserData!.imageUrl,
   };
 }
 

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -143,16 +143,13 @@ export function isAdmin(memberships: ReadonlyArray<Membership>): boolean {
 }
 
 interface JoinCommunityProps {
-  organizationId: string;
+  communityId: string;
   userId: string;
 }
 
-export async function joinCommunity({
-  organizationId,
-  userId,
-}: JoinCommunityProps) {
+export async function joinCommunity({communityId, userId}: JoinCommunityProps) {
   await clerkClient.organizations.createOrganizationMembership({
-    organizationId,
+    organizationId: communityId,
     userId,
     role: 'basic_member',
   });

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -1,24 +1,81 @@
 import {clerkClient, auth} from '@clerk/nextjs';
 import {OrganizationMembership, Organization} from '@clerk/backend/dist/types';
 
-export type Community = Organization;
+export interface Community {
+  id: string;
+  name: string;
+  description: string;
+  slug: string;
+  imageUrl: string;
+  createdAt: number;
+}
+
+export interface Membership {
+  id: string;
+  role: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  imageUrl: string;
+}
+
+function organizationToCommunity(organization: Organization): Community {
+  return {
+    id: organization.id,
+    name: organization.name,
+    description:
+      (organization.publicMetadata!.description as string | undefined) || '',
+    slug: organization.slug!,
+    imageUrl: organization.imageUrl,
+    createdAt: organization.createdAt,
+  };
+}
+
+function organizationMembershipToCommunityMembership(
+  membership: OrganizationMembership
+): Membership {
+  if (!membership.publicUserData) {
+    throw new Error(
+      'organizationMembershipToCommunityMembership: publicUserData is undefined'
+    );
+  }
+
+  return {
+    id: membership.id,
+    role: membership.role,
+    userId: membership.publicUserData.userId,
+    // First and last name are set to required in Clerk.
+    firstName: membership.publicUserData.firstName!,
+    lastName: membership.publicUserData.lastName!,
+    imageUrl: membership.publicUserData.imageUrl,
+  };
+}
 
 export async function getCommunityBySlug(slug: string) {
-  return clerkClient.organizations.getOrganization({
+  const organization = await clerkClient.organizations.getOrganization({
     slug,
   });
+
+  return organizationToCommunity(organization);
 }
 
 export async function getCommunityById(id: string) {
-  return clerkClient.organizations.getOrganization({
+  const organization = await clerkClient.organizations.getOrganization({
     organizationId: id,
   });
+
+  return organizationToCommunity(organization);
 }
 
 export async function getMemberships(communityId: string) {
-  return clerkClient.organizations.getOrganizationMembershipList({
-    organizationId: communityId,
-  });
+  const organizationMembership =
+    await clerkClient.organizations.getOrganizationMembershipList({
+      organizationId: communityId,
+    });
+
+  return organizationMembership.map(
+    organizationMembershipToCommunityMembership
+  );
 }
 
 export enum SortBy {
@@ -30,7 +87,7 @@ export enum SortBy {
 
 export const defaultSortBy = SortBy.CreatedAtDesc;
 
-export function sort(communities: Organization[], sortBy: SortBy) {
+export function sort(communities: Community[], sortBy: SortBy) {
   // TODO: Implement sorting by membership count.
   // This can be done as soon as the `Community` includes membership count.
   return [...communities].sort((a, b) => {
@@ -59,7 +116,7 @@ export async function getCommunities({
   limit = 24,
   offset = 0,
 }: GetCommunitiesProps) {
-  const communities = await clerkClient.organizations.getOrganizationList({
+  const organizations = await clerkClient.organizations.getOrganizationList({
     limit,
     offset,
     query,
@@ -70,21 +127,18 @@ export async function getCommunities({
     includeMembersCount: true,
   });
 
+  const communities = organizations.map(organizationToCommunity);
+
   return sort(communities, sortBy);
 }
 
-export function isAdmin(
-  memberships: ReadonlyArray<OrganizationMembership>
-): boolean {
+export function isAdmin(memberships: ReadonlyArray<Membership>): boolean {
   const {userId} = auth();
 
   return (
     !!userId &&
     memberships.some(membership => {
-      return (
-        membership.publicUserData?.userId === userId &&
-        membership.role === 'admin'
-      );
+      return membership.userId === userId && membership.role === 'admin';
     })
   );
 }

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -35,9 +35,7 @@ function organizationMembershipToCommunityMembership(
   membership: OrganizationMembership
 ): Membership {
   if (!membership.publicUserData) {
-    throw new Error(
-      'organizationMembershipToCommunityMembership: publicUserData is undefined'
-    );
+    throw new Error('publicUserData is undefined');
   }
 
   return {
@@ -159,7 +157,7 @@ export async function joinCommunity({
   });
 }
 
-export async function editDescription({
+export async function updateDescription({
   communityId,
   description,
 }: {

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -23,7 +23,8 @@ function organizationToCommunity(organization: Organization): Community {
   return {
     id: organization.id,
     name: organization.name,
-    description: organization.publicMetadata!.description as string | undefined,
+    // The type of `publicMetadata` is `{ [k: string]: unknown } | null `. Redeclare custom metadata `description`.
+    description: organization.publicMetadata?.description as string | undefined,
     slug: organization.slug!,
     imageUrl: organization.imageUrl,
     createdAt: organization.createdAt,

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -163,7 +163,7 @@
     "labelDescription":"Description",
     "changeDescriptionSaveButton": "Save",
     "changeDescriptionCancelButton": "Cancel",
-    "descriptionSuccessfullyEdited": "Description has been updated",
+    "descriptionUpdated": "Description has been updated",
     "descriptionServerError": "Something went wrong while updating the description. Please try again later.",
     "description_maxLength": "Description has a maximum of 2000 characters"
   },

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -158,7 +158,14 @@
     "objectListsSubTitle": "This community has {count, plural, =0 {0 lists} =1 {1 list} other {# lists}}",
     "membersTitle": "Members",
     "error": "Something went wrong while fetching the community. Please try again later.",
-    "addObjectListButton": "Add list"
+    "addObjectListButton": "Add list",
+    "editDescriptionButton": "Edit description",
+    "labelDescription":"Description",
+    "changeDescriptionSaveButton": "Save",
+    "changeDescriptionCancelButton": "Cancel",
+    "descriptionSuccessfullyEdited": "Description has been updated",
+    "descriptionServerError": "Something went wrong while updating the description. Please try again later.",
+    "description_maxLength": "Description has a maximum of 2000 characters"
   },
   "AddObjectListForm": {
     "title": "Add list",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -158,7 +158,14 @@
     "objectListsSubTitle": "Deze community heeft {count, plural, =0 {0 lijsten} =1 {1 lijst} other {# lijsten}}",
     "membersTitle": "Leden",
     "error": "Er is een fout opgetreden bij het ophalen van de community. Probeer het later opnieuw.",
-    "addObjectListButton": "Lijst toevoegen"
+    "addObjectListButton": "Lijst toevoegen",
+    "editDescriptionButton": "Beschrijving aanpassen",
+    "labelDescription":"Beschrijving",
+    "changeDescriptionSaveButton": "Opslaan",
+    "changeDescriptionCancelButton": "Annuleren",
+    "descriptionSuccessfullyEdited": "Beschrijving is succesvol aangepast",
+    "descriptionServerError": "Er is iets misgegaan bij het aanpassen van de beschrijving. Probeer het later opnieuw.",
+    "description_maxLength": "Beschrijving mag maximaal 2000 tekens bevatten"
   },
   "AddObjectListForm": {
     "title": "Lijst toevoegen",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -163,7 +163,7 @@
     "labelDescription":"Beschrijving",
     "changeDescriptionSaveButton": "Opslaan",
     "changeDescriptionCancelButton": "Annuleren",
-    "descriptionSuccessfullyEdited": "Beschrijving is succesvol aangepast",
+    "descriptionUpdated": "Beschrijving is aangepast",
     "descriptionServerError": "Er is iets misgegaan bij het aanpassen van de beschrijving. Probeer het later opnieuw.",
     "description_maxLength": "Beschrijving mag maximaal 2000 tekens bevatten"
   },

--- a/packages/ui/slide-out.tsx
+++ b/packages/ui/slide-out.tsx
@@ -29,15 +29,20 @@ export const useSlideOut = create<SlideOutState>((set, get) => ({
 
 interface SlideOutButtonProps {
   id: string;
+  hideIfOpen?: Boolean;
   children: ReactNode;
 }
 
 export function SlideOutButton({
   id,
+  hideIfOpen = false,
   children,
   ...buttonProps
 }: SlideOutButtonProps & ButtonHTMLAttributes<HTMLButtonElement>) {
   const {setIsVisible, isVisible} = useSlideOut();
+
+  if (hideIfOpen && isVisible(id)) return null;
+
   return (
     <button {...buttonProps} onClick={() => setIsVisible(id, !isVisible(id))}>
       {children}
@@ -60,4 +65,10 @@ export function SlideOut({id, children}: SlideOutProps) {
   }, [id, pathname, setIsVisible]);
 
   return isVisible(id) ? <>{children}</> : null;
+}
+
+// Use this component to render content when the slide out is closed
+export function SlideOutClosed({id, children}: SlideOutProps) {
+  const {isVisible} = useSlideOut();
+  return !isVisible(id) ? <>{children}</> : null;
 }


### PR DESCRIPTION
In this pull request, the communities get descriptions. You can see the description on the community overview and details page. The community is saved as pubic metadata in Clerk.

Things to note:

- I have also added a custom type for Community and Memberships in this pull request. As discussed in previous pull requests.
- I had to set the community page to `export const dynamic = 'force-dynamic';` ([docs](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic)). The Clerk requests were cached, and updated descriptions or member lists were not visible.
- I have set the max length of the description to 2000. Metadata is limited to 8kb maximum, so there is still room for other properties if we need it.