### PR TITLE
Update logic search-params based on updated assumptions

### DIFF
--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  Type as SearchParamTypes,
+  Type as SearchParamType,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -39,7 +39,7 @@ export const revalidate = 60;
 
 interface FacetProps {
   name: keyof SearchResult['filters'];
-  searchParamType: SearchParamTypes;
+  searchParamType: SearchParamType;
   Component: ElementType;
 }
 

--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  SearchParamTypes,
+  Type as SearchParamTypes,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -91,7 +91,7 @@ export default async function Home({searchParams = {}}: Props) {
     },
     filterKeys: facets.map(({name, searchParamType}) => ({
       name,
-      searchParamType,
+      type: searchParamType,
     })),
     searchParams,
   });

--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
+  SearchParamTypes,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -31,38 +32,43 @@ import {
   SubMenuDialog,
 } from 'ui';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
+import {ElementType} from 'react';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
 
-// Set the order of the filters
-const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [
-  'publishers',
-  'spatialCoverages',
-  'genres',
-  'licenses',
+interface FacetProps {
+  name: keyof SearchResult['filters'];
+  searchParamType: SearchParamTypes;
+  Component: ElementType;
+}
+
+const facets: ReadonlyArray<FacetProps> = [
+  {name: 'publishers', searchParamType: 'array', Component: FilterSet},
+  {name: 'spatialCoverages', searchParamType: 'array', Component: FilterSet},
+  {name: 'genres', searchParamType: 'array', Component: FilterSet},
+  {name: 'licenses', searchParamType: 'array', Component: FilterSet},
 ];
 
 interface FacetMenuProps {
   filters: SearchResult['filters'];
-  filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']>;
 }
 
-function FacetMenu({filterKeysOrder, filters}: FacetMenuProps) {
+function FacetMenu({filters}: FacetMenuProps) {
   const t = useTranslations('Filters');
 
   return (
     <>
       <SearchFieldWithLabel />
-      {filterKeysOrder.map(
-        filterKey =>
-          !!filters[filterKey]?.length && (
-            <FilterSet
-              key={filterKey}
-              title={t(`${filterKey}Filter`)}
-              searchResultFilters={filters[filterKey]}
-              filterKey={filterKey}
-              testId={`${filterKey}Filter`}
+      {facets.map(
+        ({name, Component}) =>
+          !!filters[name]?.length && (
+            <Component
+              key={name}
+              title={t(`${name}Filter`)}
+              searchResultFilters={filters[name]}
+              filterKey={name}
+              testId={`${name}Filter`}
             />
           )
       )}
@@ -83,6 +89,10 @@ export default async function Home({searchParams = {}}: Props) {
       defaultSortBy: SortBy.Relevance,
       sortMapping: sortMapping,
     },
+    filterKeys: facets.map(({name, searchParamType}) => ({
+      name,
+      searchParamType,
+    })),
     searchParams,
   });
   const sortBy = getClientSortBy({
@@ -135,10 +145,7 @@ export default async function Home({searchParams = {}}: Props) {
             id="facets"
             className="hidden md:flex w-full md:w-1/3 flex-row md:flex-col gap-10 overscroll-x-auto flex-nowrap border-white border-r-2"
           >
-            <FacetMenu
-              filters={searchResult.filters}
-              filterKeysOrder={filterKeysOrder}
-            />
+            <FacetMenu filters={searchResult.filters} />
           </aside>
 
           <section className="w-full md:w-2/3 gap-6 flex flex-col">
@@ -153,10 +160,7 @@ export default async function Home({searchParams = {}}: Props) {
                 />
               </SubMenuButton>
               <SubMenuDialog title={t('filters')}>
-                <FacetMenu
-                  filters={searchResult.filters}
-                  filterKeysOrder={filterKeysOrder}
-                />
+                <FacetMenu filters={searchResult.filters} />
               </SubMenuDialog>
             </SmallScreenSubMenu>
             <PageHeader>
@@ -174,9 +178,10 @@ export default async function Home({searchParams = {}}: Props) {
                 </div>
               </div>
               <SelectedFilters
-                filters={filterKeysOrder.map(filterKey => ({
-                  searchResultFilters: searchResult!.filters[filterKey] ?? [],
-                  filterKey,
+                filters={facets.map(filterKey => ({
+                  searchResultFilters:
+                    searchResult!.filters[filterKey.name] ?? [],
+                  filterKey: filterKey.name,
                 }))}
               />
             </PageHeader>

--- a/apps/researcher/src/app/[locale]/page.tsx
+++ b/apps/researcher/src/app/[locale]/page.tsx
@@ -104,7 +104,6 @@ export default async function Home({searchParams = {}}: Props) {
   try {
     searchResult = await heritageObjects.search(searchOptions);
   } catch (err) {
-    console.log(err);
     hasError = true;
     console.error(err);
   }

--- a/apps/researcher/src/app/[locale]/page.tsx
+++ b/apps/researcher/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  Type as SearchParamTypes,
+  Type as SearchParamType,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -34,7 +34,7 @@ export const revalidate = 60;
 
 interface FacetProps {
   name: keyof SearchResult['filters'];
-  searchParamType: SearchParamTypes;
+  searchParamType: SearchParamType;
   Component: ElementType;
 }
 
@@ -104,6 +104,7 @@ export default async function Home({searchParams = {}}: Props) {
   try {
     searchResult = await heritageObjects.search(searchOptions);
   } catch (err) {
+    console.log(err);
     hasError = true;
     console.error(err);
   }

--- a/apps/researcher/src/app/[locale]/page.tsx
+++ b/apps/researcher/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  SearchParamTypes,
+  Type as SearchParamTypes,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -86,7 +86,7 @@ export default async function Home({searchParams = {}}: Props) {
     },
     filterKeys: facets.map(({name, searchParamType}) => ({
       name,
-      searchParamType,
+      type: searchParamType,
     })),
     searchParams,
   });

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  SearchParamTypes,
+  Type as SearchParamTypes,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -92,7 +92,7 @@ export default async function Home({searchParams = {}}: Props) {
     },
     filterKeys: facets.map(({name, searchParamType}) => ({
       name,
-      searchParamType,
+      type: searchParamType,
     })),
     searchParams,
   });

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -8,7 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
-  Type as SearchParamTypes,
+  Type as SearchParamType,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -40,7 +40,7 @@ export const revalidate = 60;
 
 interface FacetProps {
   name: keyof SearchResult['filters'];
-  searchParamType: SearchParamTypes;
+  searchParamType: SearchParamType;
   Component: ElementType;
 }
 

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -8,6 +8,7 @@ import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   defaultSortBy,
+  SearchParamTypes,
 } from '@colonial-collections/list-store';
 import {
   SearchResult,
@@ -32,38 +33,43 @@ import {
 } from 'ui';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import Tabs from '../tabs';
+import {ElementType} from 'react';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
 
-// Set the order of the filters
-const filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']> = [
-  'birthYears',
-  'birthPlaces',
-  'deathYears',
-  'deathPlaces',
-];
-
-export interface FacetMenuProps {
-  filters: SearchResult['filters'];
-  filterKeysOrder: ReadonlyArray<keyof SearchResult['filters']>;
+interface FacetProps {
+  name: keyof SearchResult['filters'];
+  searchParamType: SearchParamTypes;
+  Component: ElementType;
 }
 
-function FacetMenu({filterKeysOrder, filters}: FacetMenuProps) {
+const facets: ReadonlyArray<FacetProps> = [
+  {name: 'birthYears', searchParamType: 'array', Component: FilterSet},
+  {name: 'birthPlaces', searchParamType: 'array', Component: FilterSet},
+  {name: 'deathYears', searchParamType: 'array', Component: FilterSet},
+  {name: 'deathPlaces', searchParamType: 'array', Component: FilterSet},
+];
+
+interface FacetMenuProps {
+  filters: SearchResult['filters'];
+}
+
+function FacetMenu({filters}: FacetMenuProps) {
   const t = useTranslations('Filters');
 
   return (
     <>
       <SearchFieldWithLabel />
-      {filterKeysOrder.map(
-        filterKey =>
-          !!filters[filterKey]?.length && (
-            <FilterSet
-              key={filterKey}
-              title={t(`${filterKey}Filter`)}
-              searchResultFilters={filters[filterKey]}
-              filterKey={filterKey}
-              testId={`${filterKey}Filter`}
+      {facets.map(
+        ({name, Component}) =>
+          !!filters[name]?.length && (
+            <Component
+              key={name}
+              title={t(`${name}Filter`)}
+              searchResultFilters={filters[name]}
+              filterKey={name}
+              testId={`${name}Filter`}
             />
           )
       )}
@@ -84,8 +90,13 @@ export default async function Home({searchParams = {}}: Props) {
       defaultSortBy: SortBy.Relevance,
       sortMapping: sortMapping,
     },
+    filterKeys: facets.map(({name, searchParamType}) => ({
+      name,
+      searchParamType,
+    })),
     searchParams,
   });
+
   const sortBy = getClientSortBy({
     sortMapping,
     sortPair: {
@@ -138,10 +149,7 @@ export default async function Home({searchParams = {}}: Props) {
               id="facets"
               className="hidden md:flex w-full md:w-1/3 flex-row md:flex-col gap-10 overscroll-x-auto flex-nowrap border-white border-r-2"
             >
-              <FacetMenu
-                filters={searchResult.filters}
-                filterKeysOrder={filterKeysOrder}
-              />
+              <FacetMenu filters={searchResult.filters} />
             </aside>
 
             <section className="w-full md:w-2/3 gap-6 flex flex-col">
@@ -156,10 +164,7 @@ export default async function Home({searchParams = {}}: Props) {
                   />
                 </SubMenuButton>
                 <SubMenuDialog title={t('filters')}>
-                  <FacetMenu
-                    filters={searchResult.filters}
-                    filterKeysOrder={filterKeysOrder}
-                  />
+                  <FacetMenu filters={searchResult.filters} />
                 </SubMenuDialog>
               </SmallScreenSubMenu>
               <PageHeader>
@@ -177,9 +182,10 @@ export default async function Home({searchParams = {}}: Props) {
                   </div>
                 </div>
                 <SelectedFilters
-                  filters={filterKeysOrder.map(filterKey => ({
-                    searchResultFilters: searchResult!.filters[filterKey] ?? [],
-                    filterKey,
+                  filters={facets.map(filterKey => ({
+                    searchResultFilters:
+                      searchResult!.filters[filterKey.name] ?? [],
+                    filterKey: filterKey.name,
                   }))}
                 />
               </PageHeader>

--- a/packages/list-store/src/search-params.test.ts
+++ b/packages/list-store/src/search-params.test.ts
@@ -2,6 +2,7 @@ import {
   getUrlWithSearchParams,
   fromSearchParamsToSearchOptions,
   getClientSortBy,
+  SearchParamTypes,
 } from './search-params';
 import {SortBy, defaultSortBy} from './sort';
 import {describe, expect, it} from '@jest/globals';
@@ -36,6 +37,18 @@ const sortMapping = {
   },
 };
 
+interface FilterKey {
+  name: string;
+  searchParamType: SearchParamTypes;
+}
+
+const filterKeys: FilterKey[] = [
+  {name: 'types', searchParamType: 'array'},
+  {name: 'locations', searchParamType: 'array'},
+  {name: 'dateCreatedStart', searchParamType: 'number'},
+  {name: 'dateCreatedEnd', searchParamType: 'number'},
+];
+
 const sortOptions = {
   SortByEnum,
   SortOrderEnum,
@@ -68,15 +81,14 @@ describe('getUrlWithSearchParams', () => {
     expect(getUrlWithSearchParams(options)).toBe('/');
   });
 
-  it('returns "/" with empty filter arrays', () => {
+  it('returns "/" with empty filters', () => {
     const options = {
       query: '',
       defaultSortBy,
       filters: {
-        licenses: [],
-        publishers: [],
-        spatialCoverages: [],
-        genres: [],
+        types: [],
+        locations: [],
+        dateCreatedStart: undefined,
       },
     };
 
@@ -114,15 +126,15 @@ describe('getUrlWithSearchParams', () => {
     const options = {
       defaultSortBy,
       filters: {
-        licenses: ['filter1'],
-        publishers: ['filter2'],
-        spatialCoverages: ['filter3'],
-        genres: ['filter4'],
+        types: ['filter1'],
+        locations: ['filter2', 'filter3'],
+        dateCreatedStart: 1600,
+        dateCreatedEnd: 1700,
       },
     };
 
     expect(getUrlWithSearchParams(options)).toBe(
-      '/?licenses=filter1&publishers=filter2&spatialCoverages=filter3&genres=filter4'
+      '/?types=filter1&locations=filter2&locations=filter3&dateCreatedStart=1600&dateCreatedEnd=1700'
     );
   });
 
@@ -133,15 +145,15 @@ describe('getUrlWithSearchParams', () => {
       sortBy: SortBy.NameDesc,
       defaultSortBy,
       filters: {
-        licenses: ['filter1', 'filter2'],
-        publishers: ['filter3'],
-        spatialCoverages: ['filter4'],
-        genres: ['filter5'],
+        types: ['filter1'],
+        locations: ['filter2', 'filter3'],
+        dateCreatedStart: 1600,
+        dateCreatedEnd: 1700,
       },
     };
 
     expect(getUrlWithSearchParams(options)).toBe(
-      '/?query=my+query&offset=20&sortBy=nameDesc&licenses=filter1%2Cfilter2&publishers=filter3&spatialCoverages=filter4&genres=filter5'
+      '/?query=my+query&offset=20&sortBy=nameDesc&types=filter1&locations=filter2&locations=filter3&dateCreatedStart=1600&dateCreatedEnd=1700'
     );
   });
 });
@@ -149,7 +161,11 @@ describe('getUrlWithSearchParams', () => {
 describe('fromSearchParamsToSearchOptions', () => {
   it('returns default search options if there are no search params', () => {
     expect(
-      fromSearchParamsToSearchOptions({sortOptions, searchParams: {}})
+      fromSearchParamsToSearchOptions({
+        sortOptions,
+        searchParams: {},
+        filterKeys: [],
+      })
     ).toStrictEqual({
       filters: {},
       offset: 0,
@@ -167,7 +183,11 @@ describe('fromSearchParamsToSearchOptions', () => {
     };
 
     expect(
-      fromSearchParamsToSearchOptions({sortOptions, searchParams})
+      fromSearchParamsToSearchOptions({
+        sortOptions,
+        searchParams,
+        filterKeys: [],
+      })
     ).toStrictEqual({
       filters: {},
       offset: 0,
@@ -185,7 +205,11 @@ describe('fromSearchParamsToSearchOptions', () => {
     };
 
     expect(
-      fromSearchParamsToSearchOptions({sortOptions, searchParams})
+      fromSearchParamsToSearchOptions({
+        sortOptions,
+        searchParams,
+        filterKeys: [],
+      })
     ).toStrictEqual({
       filters: {},
       offset: 0,
@@ -201,19 +225,25 @@ describe('fromSearchParamsToSearchOptions', () => {
       query: 'My query',
       offset: '12',
       sortBy: SortBy.NameAsc,
-      owners: 'owner1,owner2',
-      types: 'type',
-      subjects: 'subject',
+      types: ['type1', 'type2'],
+      locations: 'location1',
+      dateCreatedStart: '1500',
+      dateCreatedEnd: '1550',
     };
 
     expect(
-      fromSearchParamsToSearchOptions({sortOptions, searchParams})
+      fromSearchParamsToSearchOptions({
+        sortOptions,
+        searchParams,
+        filterKeys,
+      })
     ).toStrictEqual({
       query: 'My query',
       filters: {
-        owners: ['owner1', 'owner2'],
-        types: ['type'],
-        subjects: ['subject'],
+        types: ['type1', 'type2'],
+        locations: ['location1'],
+        dateCreatedStart: 1500,
+        dateCreatedEnd: 1550,
       },
       offset: 12,
       sortBy: 'name',

--- a/packages/list-store/src/search-params.test.ts
+++ b/packages/list-store/src/search-params.test.ts
@@ -2,7 +2,7 @@ import {
   getUrlWithSearchParams,
   fromSearchParamsToSearchOptions,
   getClientSortBy,
-  SearchParamTypes,
+  FromSearchParamsToSearchOptionsProps,
 } from './search-params';
 import {SortBy, defaultSortBy} from './sort';
 import {describe, expect, it} from '@jest/globals';
@@ -37,16 +37,11 @@ const sortMapping = {
   },
 };
 
-interface FilterKey {
-  name: string;
-  searchParamType: SearchParamTypes;
-}
-
-const filterKeys: FilterKey[] = [
-  {name: 'types', searchParamType: 'array'},
-  {name: 'locations', searchParamType: 'array'},
-  {name: 'dateCreatedStart', searchParamType: 'number'},
-  {name: 'dateCreatedEnd', searchParamType: 'number'},
+const filterKeys: FromSearchParamsToSearchOptionsProps['filterKeys'] = [
+  {name: 'types', type: 'array'},
+  {name: 'locations', type: 'array'},
+  {name: 'dateCreatedStart', type: 'number'},
+  {name: 'dateCreatedEnd', type: 'number'},
 ];
 
 const sortOptions = {

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -59,13 +59,6 @@ export function getUrlWithSearchParams({
     });
   }
 
-  // Remove irrelevant values from the search params.
-  Object.keys(searchParams).forEach(key => {
-    if (searchParams[key] === '' || searchParams[key].length === 0) {
-      delete searchParams[key];
-    }
-  });
-
   const urlSearchParams = new URLSearchParams();
 
   // Append the search params one by one to the URLSearchParams object. So the same key can be added multiple times.

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -90,7 +90,7 @@ function fallback<T>(value: T) {
 }
 
 export interface FromSearchParamsToSearchOptionsProps {
-  // `searchParams` is a key value object based on the url search params.
+  // `searchParams` is a key-value object based on the URLs search params.
   searchParams: {
     [filter: string]: string | string[];
   };

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -3,7 +3,7 @@ import {SortBy} from './sort';
 
 export type Type = 'string' | 'array' | 'number';
 
-// Only strings are allowed in the search params
+// Only strings are allowed in the search params.
 const searchParamFilterSchema = z
   .array(z.string())
   .or(z.array(z.number().transform(value => `${value}`)))
@@ -17,12 +17,12 @@ function getSearchParamsSchema(defaultSortBy: string) {
     offset: z
       .number()
       .default(0)
-      // Don't add the default offset of 0 to the search params
+      // Don't add the default offset of 0 to the search params.
       .transform(offset => (offset > 0 ? `${offset}` : '')),
     sortBy: z
       .string()
       .default(defaultSortBy)
-      // Don't add the default sort to the search params
+      // Don't add the default sort to the search params.
       .transform(sortBy => (sortBy === defaultSortBy ? '' : sortBy)),
   });
 }
@@ -59,7 +59,7 @@ export function getUrlWithSearchParams({
     });
   }
 
-  // Only add relevant values to the search params.
+  // Remove irrelevant values from the search params.
   Object.keys(searchParams).forEach(key => {
     if (searchParams[key] === '' || searchParams[key].length === 0) {
       delete searchParams[key];
@@ -73,7 +73,7 @@ export function getUrlWithSearchParams({
     if (Array.isArray(filterValue)) {
       filterValue.forEach(singleValue => {
         if (singleValue !== '') {
-          // This will result in a query string like: '?key=value1&key=value2'
+          // This will result in a query string like: '?key=value1&key=value2'.
           urlSearchParams.append(filterKey, singleValue);
         }
       });
@@ -99,7 +99,6 @@ function fallback<T>(value: T) {
 export interface FromSearchParamsToSearchOptionsProps {
   // `searchParams` is a key value object based on the url search params.
   searchParams: {
-    // Search params are always strings or arrays of strings. Note that numbers are also strings, so we need to transform them to numbers.
     [filter: string]: string | string[];
   };
   // The searchOption `sortBy` and `sortOrder` are enums values.

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -1,10 +1,15 @@
 import {z, Schema} from 'zod';
 import {SortBy} from './sort';
 
+export type SearchParamTypes = 'string' | 'array' | 'number';
+
+// Only strings are allowed in the search params
 const searchParamFilterSchema = z
   .array(z.string())
-  .default([])
-  .transform(filterValues => filterValues.join(','));
+  .or(z.array(z.number().transform(value => `${value}`)))
+  .or(z.string())
+  .or(z.number().transform(value => `${value}`))
+  .default('');
 
 function getSearchParamsSchema(defaultSortBy: string) {
   return z.object({
@@ -26,7 +31,7 @@ interface ClientSearchOptions {
   query?: string;
   offset?: number;
   sortBy?: string;
-  filters?: {[filterKey: string]: string[] | undefined};
+  filters?: {[filterKey: string]: string[] | string | number | undefined};
   baseUrl?: string;
   defaultSortBy: string;
 }
@@ -39,13 +44,12 @@ export function getUrlWithSearchParams({
   defaultSortBy,
   baseUrl = '/',
 }: ClientSearchOptions): string {
-  const searchParams: {[key: string]: string} = getSearchParamsSchema(
-    defaultSortBy
-  ).parse({
-    query,
-    offset,
-    sortBy,
-  });
+  const searchParams: {[key: string]: string | string[]} =
+    getSearchParamsSchema(defaultSortBy).parse({
+      query,
+      offset,
+      sortBy,
+    });
 
   if (filters) {
     Object.keys(filters).forEach(filterKey => {
@@ -55,11 +59,28 @@ export function getUrlWithSearchParams({
     });
   }
 
-  // Only add relevant values to the search params. Remove all keys with empty strings as values
-  Object.keys(searchParams).forEach(key =>
-    searchParams[key] === '' ? delete searchParams[key] : {}
-  );
-  const encodedSearchParams = new URLSearchParams(searchParams).toString();
+  // Only add relevant values to the search params.
+  Object.keys(searchParams).forEach(key => {
+    if (searchParams[key] === '' || searchParams[key].length === 0) {
+      delete searchParams[key];
+    }
+  });
+
+  const urlSearchParams = new URLSearchParams();
+
+  // Append the search params one by one to the URLSearchParams object. So key can be added multiple times.
+  Object.entries(searchParams).forEach(([filterKey, filterValue]) => {
+    if (Array.isArray(filterValue) && filterValue.length > 0) {
+      filterValue.forEach(singleValue =>
+        // This will result in a query string like: '?key=value1&key=value2'
+        urlSearchParams.append(filterKey, singleValue)
+      );
+    } else if (typeof filterValue === 'string' && filterValue !== '') {
+      urlSearchParams.append(filterKey, filterValue);
+    }
+  });
+
+  const encodedSearchParams = urlSearchParams.toString();
 
   if (encodedSearchParams) {
     return baseUrl + '?' + encodedSearchParams;
@@ -73,16 +94,11 @@ function fallback<T>(value: T) {
   return z.any().transform(() => value);
 }
 
-const searchOptionsFilterSchema = z
-  .string()
-  .optional()
-  .transform(filterValue => filterValue?.split(',').filter(id => !!id))
-  .pipe(z.array(z.string()).optional().default([]));
-
 interface FromSearchParamsToSearchOptionsProps {
   // `searchParams` is a key value object based on the url search params.
   searchParams: {
-    [filter: string]: string;
+    // Search params are always strings or array of strings. Note that numbers are also strings.
+    [filter: string]: string | string[] | undefined;
   };
   // The searchOption `sortBy` and `sortOrder` are enums values.
   // Set the correct enums, default values and sortMapper in the `sortOptions`.
@@ -101,6 +117,10 @@ interface FromSearchParamsToSearchOptionsProps {
       };
     };
   };
+  filterKeys: {
+    name: string;
+    searchParamType: SearchParamTypes;
+  }[];
 }
 
 // This function translates the search params to valid search options.
@@ -113,6 +133,7 @@ export function fromSearchParamsToSearchOptions({
     defaultSortOrder,
     sortMapping,
   },
+  filterKeys,
 }: FromSearchParamsToSearchOptionsProps) {
   // Always return a valid SearchOptions object, even if the search params aren't correct,
   // so the application doesn't fail on invalid search params.
@@ -127,7 +148,31 @@ export function fromSearchParamsToSearchOptions({
       .transform(limitString => +limitString)
       .pipe(z.number().int().positive())
       .or(fallback(12)),
-    filters: z.record(searchOptionsFilterSchema).optional(),
+    filters: z.object(
+      filterKeys.reduce(
+        (acc, filterKey) => {
+          if (filterKey.searchParamType === 'string') {
+            acc[filterKey.name] = z.string().optional();
+          } else if (filterKey.searchParamType === 'array') {
+            acc[filterKey.name] = z
+              .string()
+              .transform(value => [value])
+              .or(z.array(z.string().optional()))
+              .optional()
+              .or(fallback([]));
+          } else if (filterKey.searchParamType === 'number') {
+            acc[filterKey.name] = z
+              .string()
+              .transform(value => +value)
+              .optional()
+              .or(fallback(undefined));
+          }
+
+          return acc;
+        },
+        {} as {[key: string]: Schema}
+      )
+    ),
     sortBy: SortByEnum.or(fallback(defaultSortBy)),
     sortOrder: SortOrderEnum.or(fallback(defaultSortOrder)),
     query: z.string().optional(),


### PR DESCRIPTION
Now that more filters are added to the API, I noticed I needed to correct some assumptions. I thought:

- Filter IDs never contain commas
- Filter IDs are always strings (the dates have number ids)
- Filters are always arrays (the dates have a single value)
- There is only one type of facet component (for example, no date component). This was not really a wrong assumption, but the code was not ready for different types of components.

This pull request tries to fix all the wrong assumptions.

Instead of separating the search params with commas. Different values are separated with the format '?key=a&key=b'.

Note: some applications use the format '?key[]=a&key[]=b'. But this depends on the programming language. PHP and C# will automatically parse the format '?key[]=a&key[]=b'. But Next.js uses the javascript function [`URLSearchParams: getAll()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/getAll) under the hood. So it will automatically parse the format '?key=a&key=b'' to `['a', 'b']`.

There are two things to be aware of:

1. The parsed search params from Next.Js will show a string if there is only one value and an array if there are multiple values. For example, '?foo=a&foo=2&bar=3' will parse to: `{foo: ['1', '2'], bar: '3'}`.
2. All values are strings.

Depending on the facets, we want to transform the Next.js parsed search params to arrays, strings or numbers.