### PR TITLE
Bump nextjs from "13.5.5" to "13.5.6"

### DIFF
--- a/apps/dataset-browser/package.json
+++ b/apps/dataset-browser/package.json
@@ -31,7 +31,7 @@
     "@next/mdx": "13.5.6",
     "classnames": "2.3.2",
     "fetch-sparql-endpoint": "3.3.3",
-    "next": "13.5.5",
+    "next": "13.5.6",
     "next-intl": "3.0.0-beta.19",
     "rdf-object": "1.14.0",
     "react": "18.2.0",

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -36,7 +36,7 @@
     "@next/mdx": "13.5.6",
     "classnames": "2.3.2",
     "fetch-sparql-endpoint": "3.3.3",
-    "next": "13.5.5",
+    "next": "13.5.6",
     "next-intl": "3.0.0-beta.19",
     "openseadragon": "4.1.0",
     "rdf-object": "1.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@next/mdx": "13.5.6",
         "classnames": "2.3.2",
         "fetch-sparql-endpoint": "3.3.3",
-        "next": "13.5.5",
+        "next": "13.5.6",
         "next-intl": "3.0.0-beta.19",
         "rdf-object": "1.14.0",
         "react": "18.2.0",
@@ -106,7 +106,7 @@
         "@next/mdx": "13.5.6",
         "classnames": "2.3.2",
         "fetch-sparql-endpoint": "3.3.3",
-        "next": "13.5.5",
+        "next": "13.5.6",
         "next-intl": "3.0.0-beta.19",
         "openseadragon": "4.1.0",
         "rdf-object": "1.14.0",
@@ -2257,7 +2257,8 @@
     "node_modules/@next/env": {
       "version": "13.5.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.5.tgz",
-      "integrity": "sha512-agvIhYWp+ilbScg81s/sLueZo8CNEYLjNOqhISxheLmD/AQI4/VxV7bV76i/KzxH4iHy/va0YS9z0AOwGnw4Fg=="
+      "integrity": "sha512-agvIhYWp+ilbScg81s/sLueZo8CNEYLjNOqhISxheLmD/AQI4/VxV7bV76i/KzxH4iHy/va0YS9z0AOwGnw4Fg==",
+      "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.5.3",
@@ -2289,9 +2290,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.5.tgz",
-      "integrity": "sha512-FvTdcJdTA7H1FGY8dKPPbf/O0oDC041/znHZwXA7liiGUhgw5hOQ+9z8tWvuz0M5a/SDjY/IRPBAb5FIFogYww==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
+      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
       "cpu": [
         "arm64"
       ],
@@ -2304,9 +2305,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.5.tgz",
-      "integrity": "sha512-mTqNIecaojmyia7appVO2QggBe1Z2fdzxgn6jb3x9qlAk8yY2sy4MAcsj71kC9RlenCqDmr9vtC/ESFf110TPA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
       "cpu": [
         "x64"
       ],
@@ -2319,9 +2320,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.5.tgz",
-      "integrity": "sha512-U9e+kNkfvwh/T8yo+xcslvNXgyMzPPX1IbwCwnHHFmX5ckb1Uc3XZSInNjFQEQR5xhJpB5sFdal+IiBIiLYkZA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
       "cpu": [
         "arm64"
       ],
@@ -2334,9 +2335,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.5.tgz",
-      "integrity": "sha512-h7b58eIoNCSmKVC5fr167U0HWZ/yGLbkKD9wIller0nGdyl5zfTji0SsPKJvrG8jvKPFt2xOkVBmXlFOtuKynw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2349,9 +2350,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.5.tgz",
-      "integrity": "sha512-6U4y21T1J6FfcpM9uqzBJicxycpB5gJKLyQ3g6KOfBzT8H1sMwfHTRrvHKB09GIn1BCRy5YJHrA1G26DzqR46w==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
       "cpu": [
         "x64"
       ],
@@ -2364,9 +2365,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.5.tgz",
-      "integrity": "sha512-OuqWSAQHJQM2EsapPFTSU/FLQ0wKm7UeRNatiR/jLeCe1V02aB9xmzuWYo2Neaxxag4rss3S8fj+lvMLzwDaFA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
       "cpu": [
         "x64"
       ],
@@ -2379,9 +2380,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.5.tgz",
-      "integrity": "sha512-+yLrOZIIZDY4uGn9bLOc0wTgs+M8RuOUFSUK3BhmcLav9e+tcAj0jyBHD4aXv2qWhppUeuYMsyBo1I58/eE6Dg==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
       "cpu": [
         "arm64"
       ],
@@ -2394,9 +2395,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.5.tgz",
-      "integrity": "sha512-SyMxXyJtf9ScMH0Dh87THJMXNFvfkRAk841xyW9SeOX3KxM1buXX3hN7vof4kMGk0Yg996OGsX+7C9ueS8ugsw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
       "cpu": [
         "ia32"
       ],
@@ -2409,9 +2410,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.5.tgz",
-      "integrity": "sha512-n5KVf2Ok0BbLwofAaHiiKf+BQCj1M8WmTujiER4/qzYAVngnsNSjqEWvJ03raeN9eURqxDO+yL5VRoDrR33H9A==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
       "cpu": [
         "x64"
       ],
@@ -9696,11 +9697,11 @@
       }
     },
     "node_modules/next": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.5.tgz",
-      "integrity": "sha512-LddFJjpfrtrMMw8Q9VLhIURuSidiCNcMQjRqcPtrKd+Fx07MsG7hYndJb/f2d3I+mTbTotsTJfCnn0eZ/YPk8w==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
+      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
       "dependencies": {
-        "@next/env": "13.5.5",
+        "@next/env": "13.5.6",
         "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -9715,15 +9716,15 @@
         "node": ">=16.14.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.5",
-        "@next/swc-darwin-x64": "13.5.5",
-        "@next/swc-linux-arm64-gnu": "13.5.5",
-        "@next/swc-linux-arm64-musl": "13.5.5",
-        "@next/swc-linux-x64-gnu": "13.5.5",
-        "@next/swc-linux-x64-musl": "13.5.5",
-        "@next/swc-win32-arm64-msvc": "13.5.5",
-        "@next/swc-win32-ia32-msvc": "13.5.5",
-        "@next/swc-win32-x64-msvc": "13.5.5"
+        "@next/swc-darwin-arm64": "13.5.6",
+        "@next/swc-darwin-x64": "13.5.6",
+        "@next/swc-linux-arm64-gnu": "13.5.6",
+        "@next/swc-linux-arm64-musl": "13.5.6",
+        "@next/swc-linux-x64-gnu": "13.5.6",
+        "@next/swc-linux-x64-musl": "13.5.6",
+        "@next/swc-win32-arm64-msvc": "13.5.6",
+        "@next/swc-win32-ia32-msvc": "13.5.6",
+        "@next/swc-win32-x64-msvc": "13.5.6"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -9759,6 +9760,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -13391,7 +13397,7 @@
         "@headlessui/react": "1.7.17",
         "@heroicons/react": "2.0.18",
         "classnames": "2.3.2",
-        "next": "13.5.5",
+        "next": "13.5.6",
         "next-intl": "3.0.0-beta.19",
         "react": "18.2.0",
         "zustand": "4.4.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.18",
     "classnames": "2.3.2",
-    "next": "13.5.5",
+    "next": "13.5.6",
     "next-intl": "3.0.0-beta.19",
     "react": "18.2.0",
     "zustand": "4.4.1"


### PR DESCRIPTION
I got an error after clicking the "Add to list" button.

This error was already issued to next.js and fixed. See: https://github.com/vercel/next.js/issues/56947

With this upgrade, the button works without errors.