### PR TITLE
Bump "@clerk/nextjs" to "4.25.7"

### DIFF
--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@clerk/localizations": "1.26.2",
-    "@clerk/nextjs": "4.23.2",
-    "@clerk/types": "3.55.0",
+    "@clerk/nextjs": "4.25.7",
+    "@clerk/types": "3.57.0",
     "@colonial-collections/content": "*",
     "@colonial-collections/database": "*",
     "@colonial-collections/iris": "*",
@@ -48,7 +48,7 @@
     "zustand": "4.3.9"
   },
   "devDependencies": {
-    "@clerk/shared": "0.22.0",
+    "@clerk/shared": "1.0.0",
     "@jest/globals": "29.7.0",
     "@next/env": "13.5.5",
     "@rdfjs/types": "1.1.0",

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -67,7 +67,7 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
       <div className="flex border-stone-300 border-t text-sm text-stone-600">
         <div className="w-1/2 p-4 border-stone-300 border-r">
           {t.rich('membershipCount', {
-            count: community.membersCount,
+            count: community.membershipCount,
           })}
         </div>
         <div className="w-1/2 p-4">

--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -1,38 +1,10 @@
-import {Community, getMemberships} from '@/lib/community';
+import {Community} from '@/lib/community';
 import {getTranslator} from 'next-intl/server';
 import {useTranslations} from 'next-intl';
 import Link from 'next-intl/link';
 import Image from 'next/image';
 import {Suspense} from 'react';
-import {revalidatePath} from 'next/cache';
-import {ClerkAPIResponseError} from '@clerk/shared';
 import {objectList} from '@colonial-collections/database';
-
-interface MembershipCountProps {
-  communityId: string;
-  locale: string;
-}
-
-async function MembershipCount({communityId, locale}: MembershipCountProps) {
-  const t = await getTranslator(locale, 'Communities');
-
-  let memberships = [];
-  try {
-    memberships = await getMemberships(communityId);
-  } catch (err) {
-    console.error(err);
-    const errorStatus = (err as ClerkAPIResponseError).status;
-    if (errorStatus === 404 || errorStatus === 410) {
-      // This could be a sign of a deleted community in the cache.
-      // So, revalidate the communities page.
-      revalidatePath('/[locale]/communities', 'page');
-    }
-  }
-
-  return t.rich('membershipCount', {
-    count: memberships.length,
-  });
-}
 
 interface MembershipCountProps {
   communityId: string;
@@ -94,9 +66,9 @@ export default function CommunityCard({community, locale}: CommunityCardProps) {
 
       <div className="flex border-stone-300 border-t text-sm text-stone-600">
         <div className="w-1/2 p-4 border-stone-300 border-r">
-          <Suspense>
-            <MembershipCount communityId={community.id} locale={locale} />
-          </Suspense>
+          {t.rich('membershipCount', {
+            count: community.membersCount,
+          })}
         </div>
         <div className="w-1/2 p-4">
           <Suspense>

--- a/apps/researcher/src/lib/community.test.ts
+++ b/apps/researcher/src/lib/community.test.ts
@@ -91,6 +91,7 @@ describe('sort', () => {
       slug: 'community-2',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1690000000000,
+      membersCount: 10,
     },
     {
       id: 'community1',
@@ -98,6 +99,7 @@ describe('sort', () => {
       slug: 'community-1',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1600000000000,
+      membersCount: 5,
     },
     {
       id: 'community4',
@@ -105,6 +107,7 @@ describe('sort', () => {
       slug: 'community-4',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1680000000000,
+      membersCount: 15,
     },
     {
       id: 'community3',
@@ -112,6 +115,7 @@ describe('sort', () => {
       slug: 'community-3',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1650000000000,
+      membersCount: 20,
     },
     {
       id: 'community5',
@@ -119,6 +123,7 @@ describe('sort', () => {
       slug: 'community-5',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1670000000000,
+      membersCount: undefined,
     },
   ];
 
@@ -132,6 +137,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
+        membersCount: 5,
       },
       {
         id: 'community2',
@@ -139,6 +145,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
+        membersCount: 10,
       },
       {
         id: 'community3',
@@ -146,6 +153,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
+        membersCount: 20,
       },
       {
         id: 'community4',
@@ -153,6 +161,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
+        membersCount: 15,
       },
       {
         id: 'community5',
@@ -160,6 +169,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
+        membersCount: undefined,
       },
     ];
 
@@ -176,6 +186,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
+        membersCount: undefined,
       },
       {
         id: 'community4',
@@ -183,6 +194,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
+        membersCount: 15,
       },
       {
         id: 'community3',
@@ -190,6 +202,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
+        membersCount: 20,
       },
       {
         id: 'community2',
@@ -197,6 +210,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
+        membersCount: 10,
       },
       {
         id: 'community1',
@@ -204,6 +218,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
+        membersCount: 5,
       },
     ];
 
@@ -220,6 +235,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
+        membersCount: 10,
       },
       {
         id: 'community4',
@@ -227,6 +243,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
+        membersCount: 15,
       },
       {
         id: 'community5',
@@ -234,6 +251,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
+        membersCount: undefined,
       },
       {
         id: 'community3',
@@ -241,6 +259,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
+        membersCount: 20,
       },
       {
         id: 'community1',
@@ -248,14 +267,64 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
+        membersCount: 5,
       },
     ];
 
     expect(sortedCommunities).toStrictEqual(expectedSortedCommunities);
   });
 
-  it('returns the list unsorted if sortBy is an incorrect value', () => {
-    const sortedCommunities = sort(communities, 'incorrect' as SortBy);
+  it('sorts communities by membership count in descending order', () => {
+    const sortedCommunities = sort(communities, SortBy.MembershipCountDesc);
+
+    const expectedSortedCommunities = [
+      {
+        id: 'community3',
+        name: 'Community 3',
+        slug: 'community-3',
+        imageUrl: 'https://example.com/image.png',
+        createdAt: 1650000000000,
+        membersCount: 20,
+      },
+      {
+        id: 'community4',
+        name: 'Community 4',
+        slug: 'community-4',
+        imageUrl: 'https://example.com/image.png',
+        createdAt: 1680000000000,
+        membersCount: 15,
+      },
+      {
+        id: 'community2',
+        name: 'Community 2',
+        slug: 'community-2',
+        imageUrl: 'https://example.com/image.png',
+        createdAt: 1690000000000,
+        membersCount: 10,
+      },
+      {
+        id: 'community1',
+        name: 'Community 1',
+        slug: 'community-1',
+        imageUrl: 'https://example.com/image.png',
+        createdAt: 1600000000000,
+        membersCount: 5,
+      },
+      {
+        id: 'community5',
+        name: 'Community 5',
+        slug: 'community-5',
+        imageUrl: 'https://example.com/image.png',
+        createdAt: 1670000000000,
+        membersCount: undefined,
+      },
+    ];
+
+    expect(sortedCommunities).toStrictEqual(expectedSortedCommunities);
+  });
+
+  it('returns the original array if sortBy is not valid', () => {
+    const sortedCommunities = sort(communities, 'invalid' as SortBy);
 
     expect(sortedCommunities).toStrictEqual(communities);
   });

--- a/apps/researcher/src/lib/community.test.ts
+++ b/apps/researcher/src/lib/community.test.ts
@@ -91,7 +91,7 @@ describe('sort', () => {
       slug: 'community-2',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1690000000000,
-      membersCount: 10,
+      membershipCount: 10,
     },
     {
       id: 'community1',
@@ -99,7 +99,7 @@ describe('sort', () => {
       slug: 'community-1',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1600000000000,
-      membersCount: 5,
+      membershipCount: 5,
     },
     {
       id: 'community4',
@@ -107,7 +107,7 @@ describe('sort', () => {
       slug: 'community-4',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1680000000000,
-      membersCount: 15,
+      membershipCount: 15,
     },
     {
       id: 'community3',
@@ -115,7 +115,7 @@ describe('sort', () => {
       slug: 'community-3',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1650000000000,
-      membersCount: 20,
+      membershipCount: 20,
     },
     {
       id: 'community5',
@@ -123,7 +123,7 @@ describe('sort', () => {
       slug: 'community-5',
       imageUrl: 'https://example.com/image.png',
       createdAt: 1670000000000,
-      membersCount: undefined,
+      membershipCount: undefined,
     },
   ];
 
@@ -137,7 +137,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-        membersCount: 5,
+        membershipCount: 5,
       },
       {
         id: 'community2',
@@ -145,7 +145,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-        membersCount: 10,
+        membershipCount: 10,
       },
       {
         id: 'community3',
@@ -153,7 +153,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-        membersCount: 20,
+        membershipCount: 20,
       },
       {
         id: 'community4',
@@ -161,7 +161,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-        membersCount: 15,
+        membershipCount: 15,
       },
       {
         id: 'community5',
@@ -169,7 +169,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-        membersCount: undefined,
+        membershipCount: undefined,
       },
     ];
 
@@ -186,7 +186,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-        membersCount: undefined,
+        membershipCount: undefined,
       },
       {
         id: 'community4',
@@ -194,7 +194,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-        membersCount: 15,
+        membershipCount: 15,
       },
       {
         id: 'community3',
@@ -202,7 +202,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-        membersCount: 20,
+        membershipCount: 20,
       },
       {
         id: 'community2',
@@ -210,7 +210,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-        membersCount: 10,
+        membershipCount: 10,
       },
       {
         id: 'community1',
@@ -218,7 +218,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-        membersCount: 5,
+        membershipCount: 5,
       },
     ];
 
@@ -235,7 +235,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-        membersCount: 10,
+        membershipCount: 10,
       },
       {
         id: 'community4',
@@ -243,7 +243,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-        membersCount: 15,
+        membershipCount: 15,
       },
       {
         id: 'community5',
@@ -251,7 +251,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-        membersCount: undefined,
+        membershipCount: undefined,
       },
       {
         id: 'community3',
@@ -259,7 +259,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-        membersCount: 20,
+        membershipCount: 20,
       },
       {
         id: 'community1',
@@ -267,7 +267,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-        membersCount: 5,
+        membershipCount: 5,
       },
     ];
 
@@ -284,7 +284,7 @@ describe('sort', () => {
         slug: 'community-3',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1650000000000,
-        membersCount: 20,
+        membershipCount: 20,
       },
       {
         id: 'community4',
@@ -292,7 +292,7 @@ describe('sort', () => {
         slug: 'community-4',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1680000000000,
-        membersCount: 15,
+        membershipCount: 15,
       },
       {
         id: 'community2',
@@ -300,7 +300,7 @@ describe('sort', () => {
         slug: 'community-2',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1690000000000,
-        membersCount: 10,
+        membershipCount: 10,
       },
       {
         id: 'community1',
@@ -308,7 +308,7 @@ describe('sort', () => {
         slug: 'community-1',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1600000000000,
-        membersCount: 5,
+        membershipCount: 5,
       },
       {
         id: 'community5',
@@ -316,7 +316,7 @@ describe('sort', () => {
         slug: 'community-5',
         imageUrl: 'https://example.com/image.png',
         createdAt: 1670000000000,
-        membersCount: undefined,
+        membershipCount: undefined,
       },
     ];
 

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -8,6 +8,7 @@ export interface Community {
   slug: string;
   imageUrl: string;
   createdAt: number;
+  membersCount?: number;
 }
 
 export interface Membership {
@@ -28,6 +29,7 @@ function organizationToCommunity(organization: Organization): Community {
     slug: organization.slug!,
     imageUrl: organization.imageUrl,
     createdAt: organization.createdAt,
+    membersCount: organization.members_count,
   };
 }
 
@@ -87,8 +89,6 @@ export enum SortBy {
 export const defaultSortBy = SortBy.CreatedAtDesc;
 
 export function sort(communities: Community[], sortBy: SortBy) {
-  // TODO: Implement sorting by membership count.
-  // This can be done as soon as the `Community` includes membership count.
   return [...communities].sort((a, b) => {
     if (sortBy === SortBy.NameAsc) {
       return a.name.localeCompare(b.name);
@@ -96,6 +96,8 @@ export function sort(communities: Community[], sortBy: SortBy) {
       return b.name.localeCompare(a.name);
     } else if (sortBy === SortBy.CreatedAtDesc) {
       return b.createdAt - a.createdAt;
+    } else if (sortBy === SortBy.MembershipCountDesc) {
+      return (b.membersCount ?? 0) - (a.membersCount ?? 0);
     } else {
       return 0;
     }

--- a/apps/researcher/src/lib/community.ts
+++ b/apps/researcher/src/lib/community.ts
@@ -8,7 +8,7 @@ export interface Community {
   slug: string;
   imageUrl: string;
   createdAt: number;
-  membersCount?: number;
+  membershipCount?: number;
 }
 
 export interface Membership {
@@ -29,7 +29,7 @@ function organizationToCommunity(organization: Organization): Community {
     slug: organization.slug!,
     imageUrl: organization.imageUrl,
     createdAt: organization.createdAt,
-    membersCount: organization.members_count,
+    membershipCount: organization.members_count,
   };
 }
 
@@ -97,7 +97,7 @@ export function sort(communities: Community[], sortBy: SortBy) {
     } else if (sortBy === SortBy.CreatedAtDesc) {
       return b.createdAt - a.createdAt;
     } else if (sortBy === SortBy.MembershipCountDesc) {
-      return (b.membersCount ?? 0) - (a.membersCount ?? 0);
+      return (b.membershipCount ?? 0) - (a.membershipCount ?? 0);
     } else {
       return 0;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,8 +91,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@clerk/localizations": "1.26.2",
-        "@clerk/nextjs": "4.23.2",
-        "@clerk/types": "3.55.0",
+        "@clerk/nextjs": "4.25.7",
+        "@clerk/types": "3.57.0",
         "@colonial-collections/content": "*",
         "@colonial-collections/database": "*",
         "@colonial-collections/iris": "*",
@@ -118,7 +118,7 @@
         "zustand": "4.3.9"
       },
       "devDependencies": {
-        "@clerk/shared": "0.22.0",
+        "@clerk/shared": "1.0.0",
         "@jest/globals": "29.7.0",
         "@next/env": "13.5.5",
         "@rdfjs/types": "1.1.0",
@@ -878,11 +878,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.27.0.tgz",
-      "integrity": "sha512-Sj541JrpqAn1A/UwdyDBxFV3stq2A/Pe/8HdPTG3Cct6briPyavfi46O5s1+L3BSvUcKUY+UbM0+8VsoCNFi4w==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.31.3.tgz",
+      "integrity": "sha512-0SbpwG7q6eEnVH/Shj86LFDM/zvVT6ToVodZLKawPxwzMqXBhrSNMdPQn9Al7w2522NesL/apR64npY7FnI2vA==",
       "dependencies": {
-        "@clerk/types": "^3.49.0",
+        "@clerk/shared": "1.0.0",
+        "@clerk/types": "3.57.0",
         "@peculiar/webcrypto": "1.4.1",
         "@types/node": "16.18.6",
         "cookie": "0.5.0",
@@ -901,12 +902,12 @@
       "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "4.26.4",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.26.4.tgz",
-      "integrity": "sha512-JpOju2V0NnH2MPLmyaDmcF2pI5N/2v1F+CRBaocD/gXsDEXrfi0sYZWYR7TeViu9fh1dxu7OvEH8dSb2eesk5A==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.27.0.tgz",
+      "integrity": "sha512-/Vgr/dXwtwTCVY9Xj5FuzpUh4nRWED5Bmsra6Kc8LqvjhLJq6wMMfVmm7b3oShEm4Ks3TBYqAaa0XliLCkZRJw==",
       "dependencies": {
-        "@clerk/shared": "0.24.4",
-        "@clerk/types": "3.55.0",
+        "@clerk/shared": "1.0.0",
+        "@clerk/types": "3.57.0",
         "tslib": "2.4.1"
       },
       "engines": {
@@ -916,27 +917,14 @@
         "react": ">=16"
       }
     },
-    "node_modules/@clerk/clerk-react/node_modules/@clerk/shared": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.24.4.tgz",
-      "integrity": "sha512-yrJfyjQYB7LJNjjotF0uO1EmlCQkX2M26jrZfEvQ52WIMtE+GMQVvD3bgi/PlJRlCdB+Fuei8A9Q4eTGWchl/w==",
-      "dependencies": {
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.1",
-        "swr": "2.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
     "node_modules/@clerk/clerk-sdk-node": {
-      "version": "4.12.13",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.12.13.tgz",
-      "integrity": "sha512-N8tra01CCvpTUW7bcbjDKIfGkRk1AJyLG58KQ8wCWLV+gnNyjfXsCcYHxuRUJ1ZJ1VsZele7xAhfy9nVRmCDog==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.12.16.tgz",
+      "integrity": "sha512-mstF9j0sbeq4leru2UJacTI814fARt3RkVc6AB6hYQdOE0bs5P1pb1akrsK86eFs2Ej2cDpcOsdppirpe0qe/g==",
       "dependencies": {
-        "@clerk/backend": "0.31.0",
-        "@clerk/shared": "0.24.4",
-        "@clerk/types": "3.55.0",
+        "@clerk/backend": "0.31.3",
+        "@clerk/shared": "1.0.0",
+        "@clerk/types": "3.57.0",
         "@types/cookies": "0.7.7",
         "@types/express": "4.17.14",
         "@types/node-fetch": "2.6.2",
@@ -948,56 +936,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@clerk/clerk-sdk-node/node_modules/@clerk/backend": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.31.0.tgz",
-      "integrity": "sha512-xYThKskH7J3bHLX3US8lUq96DfEdbgMNsRizYXEJayPIKJuAaHEIwrtX+tmPEqQ2cunJPvcyi6tnVfROH/3yfg==",
-      "dependencies": {
-        "@clerk/shared": "0.24.4",
-        "@clerk/types": "3.55.0",
-        "@peculiar/webcrypto": "1.4.1",
-        "@types/node": "16.18.6",
-        "cookie": "0.5.0",
-        "deepmerge": "4.2.2",
-        "node-fetch-native": "1.0.1",
-        "snakecase-keys": "5.4.4",
-        "tslib": "2.4.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@clerk/clerk-sdk-node/node_modules/@clerk/backend/node_modules/snakecase-keys": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
-      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
-      "dependencies": {
-        "map-obj": "^4.1.0",
-        "snake-case": "^3.0.4",
-        "type-fest": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@clerk/clerk-sdk-node/node_modules/@clerk/shared": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.24.4.tgz",
-      "integrity": "sha512-yrJfyjQYB7LJNjjotF0uO1EmlCQkX2M26jrZfEvQ52WIMtE+GMQVvD3bgi/PlJRlCdB+Fuei8A9Q4eTGWchl/w==",
-      "dependencies": {
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.1",
-        "swr": "2.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/@clerk/clerk-sdk-node/node_modules/@types/node": {
-      "version": "16.18.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
-      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
-    },
     "node_modules/@clerk/clerk-sdk-node/node_modules/snakecase-keys": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
@@ -1008,17 +946,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@clerk/clerk-sdk-node/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@clerk/localizations": {
@@ -1036,14 +963,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-4.23.2.tgz",
-      "integrity": "sha512-99bSVu9r1E9MxybO/6mmPAufSKq4KU7SFeMVkylX7UF8sy5t/LE9cLHyc+9jitcCGgZNai9Om4sj1WIgkNOP8w==",
+      "version": "4.25.7",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-4.25.7.tgz",
+      "integrity": "sha512-HjlvVkJFPad/2FUdfY6Jp0VhzDQyqrUI1h1rdyIBTRe+zpGBPj/BfSrqRLZLsHUnK+f61HLWQTiwb0BGGpu6mQ==",
       "dependencies": {
-        "@clerk/backend": "^0.27.0",
-        "@clerk/clerk-react": "^4.23.2",
-        "@clerk/clerk-sdk-node": "^4.12.2",
-        "@clerk/types": "^3.49.0",
+        "@clerk/backend": "0.31.3",
+        "@clerk/clerk-react": "4.27.0",
+        "@clerk/clerk-sdk-node": "4.12.16",
+        "@clerk/shared": "1.0.0",
+        "@clerk/types": "3.57.0",
         "path-to-regexp": "6.2.1",
         "tslib": "2.4.1"
       },
@@ -1057,10 +985,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.22.0.tgz",
-      "integrity": "sha512-AHPypu9gZ3v44PRqiMA56c+YNLc2IzLaPUyiYFYU+xeH/R+wqzGp7OxZoZr/kmzgA8taiVl/bjixWgpuZwzI3A==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-1.0.0.tgz",
+      "integrity": "sha512-KsI4bp7T0ql6byiXeiRf/qgCNuJRhrFPdZ7gLxY4zQpe9MRZT5FsX5miYVklkfLGVw9UT0XxYo91zcT2cRmRig==",
       "dependencies": {
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.1",
@@ -1068,12 +995,17 @@
       },
       "peerDependencies": {
         "react": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-yaDuKt760JDVazrxB12tHcdOmOSwusEYhsyI627Uj+jF9mNOVP+bBxGjv36zr/otoAH0aboHkNoZuS/E7AkmqA==",
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.57.0.tgz",
+      "integrity": "sha512-i+XqgqRbcMn5gMwWGiA3W6lCTSDYdonDAgoJgNyRemQg7Zesnbd4OoJZfqyW6vN3wvD9Bl+gMb7gQ3VquNWUOA==",
       "dependencies": {
         "csstype": "3.1.1"
       },
@@ -2457,14 +2389,19 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
       "dependencies": {
         "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
@@ -2768,18 +2705,18 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
-      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
+      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+      "version": "3.4.37",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
+      "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2807,9 +2744,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.37",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
-      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2827,9 +2764,9 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
-      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
+      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA=="
     },
     "node_modules/@types/http-link-header": {
       "version": "1.0.3",
@@ -2893,9 +2830,9 @@
       "dev": true
     },
     "node_modules/@types/keygrip": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.3.tgz",
-      "integrity": "sha512-tfzBBb7OV2PbUfKbG6zRE5UbmtdLVCKT/XT364Z9ny6pXNbd9GnIB6aFYpq2A5lZ6mq9bhXgK6h5MFGNwhMmuQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.4.tgz",
+      "integrity": "sha512-/tjWYD8StMrINelsrHNmpXceo9s3/Y22AzePH1qCvXIgmz/aQp2YFFr6HqhNQVIOdcvaVyp5GS+yjHGuF7Rwsg=="
     },
     "node_modules/@types/mdx": {
       "version": "2.0.8",
@@ -2904,9 +2841,9 @@
       "dev": true
     },
     "node_modules/@types/mime": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
-      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.3",
@@ -2956,14 +2893,14 @@
       "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ=="
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg=="
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
-      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA=="
     },
     "node_modules/@types/react": {
       "version": "18.2.31",
@@ -3009,18 +2946,18 @@
       "dev": true
     },
     "node_modules/@types/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
-      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
+      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",


### PR DESCRIPTION
I'm not sure why Dependabot is not updating `@clerk/nextjs`. But it hasn't been updated for 20 days and there have been multiple new versions since then. This new version also includes `membership_count` so I have updated the code to use this property.

I think this update also fixes a bug. I did not see the "add object to list" button on dev.app.colonialcollections.nl after logging in. The button should only be hidden if you are not logged in. I do see it now in Preview (and local development). I'm not sure what is causing this bug. So I will keep an eye on this.