### PR TITLE
fix: ignore terms with 0 results; return up to 10000 terms

### DIFF
--- a/apps/researcher/jest.config.js
+++ b/apps/researcher/jest.config.js
@@ -4,6 +4,7 @@ const createJestConfig = nextJest();
 
 /** @type {import('jest').Config} */
 const customJestConfig = {
+  testTimeout: 60000,
   testMatch: ['**/*.test.ts(x)?'],
   collectCoverage: true,
   setupFiles: ['<rootDir>/jest.setup.js'],

--- a/apps/researcher/src/lib/api/objects/searcher-request.ts
+++ b/apps/researcher/src/lib/api/objects/searcher-request.ts
@@ -1,9 +1,8 @@
 export function buildAggregation(id: string) {
   const aggregation = {
     terms: {
-      size: 1000, // TBD: what's a good size?
+      size: 10000, // TBD: revisit this - return fewer terms instead
       field: id,
-      order: {_key: 'asc'},
     },
   };
 

--- a/apps/researcher/src/lib/api/objects/searcher-result.ts
+++ b/apps/researcher/src/lib/api/objects/searcher-result.ts
@@ -1,14 +1,6 @@
 import type {SearchResultFilter} from '../definitions';
 import type {RawBucket} from './searcher';
 
-function toUnmatchedFilter(bucket: RawBucket): SearchResultFilter {
-  const totalCount = 0; // Initial count; will be overridden by the matching filter, if any
-  const id = bucket.key;
-  const name = bucket.key; // Replace with labelFetcher as soon as we have IRIs
-
-  return {totalCount, id, name};
-}
-
 function toMatchedFilter(bucket: RawBucket): SearchResultFilter {
   const totalCount = bucket.doc_count; // Actual count if a filter matched the query
   const id = bucket.key;
@@ -17,36 +9,12 @@ function toMatchedFilter(bucket: RawBucket): SearchResultFilter {
   return {totalCount, id, name};
 }
 
-function combineUnmatchedWithMatchedFilters(
-  unmatchedFilters: SearchResultFilter[],
-  matchedFilters: SearchResultFilter[]
-) {
-  const combinedFilters = unmatchedFilters.map(filter => {
-    const matchedFilter = matchedFilters.find(
-      matchedFilter => matchedFilter.id === filter.id
-    );
-    return matchedFilter ?? filter;
-  });
-
-  return combinedFilters;
-}
-
-export function buildFilters(
-  rawUnmatchedFilters: RawBucket[],
-  rawMatchedFilters: RawBucket[]
-) {
-  const unmatchedFilters = rawUnmatchedFilters.map(rawUnmatchedFilter => {
-    return toUnmatchedFilter(rawUnmatchedFilter);
-  });
+export function buildFilters(rawMatchedFilters: RawBucket[]) {
   const matchedFilters = rawMatchedFilters.map(rawMatchedFilter => {
     return toMatchedFilter(rawMatchedFilter);
   });
-  const combinedFilters = combineUnmatchedWithMatchedFilters(
-    unmatchedFilters,
-    matchedFilters
-  );
 
   // TBD: sort filters by totalCount, descending + subsort by totalCount, ascending?
 
-  return combinedFilters;
+  return matchedFilters;
 }

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -272,14 +272,14 @@ describe('search', () => {
       filters: {
         owners: [
           {
-            totalCount: 1,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
             totalCount: 2,
             id: 'Museum',
             name: 'Museum',
+          },
+          {
+            totalCount: 1,
+            id: 'Library',
+            name: 'Library',
           },
           {
             totalCount: 1,
@@ -311,14 +311,14 @@ describe('search', () => {
         ],
         subjects: [
           {
-            totalCount: 1,
-            id: 'Castle',
-            name: 'Castle',
-          },
-          {
             totalCount: 2,
             id: 'Celebrations',
             name: 'Celebrations',
+          },
+          {
+            totalCount: 1,
+            id: 'Castle',
+            name: 'Castle',
           },
           {
             totalCount: 1,
@@ -355,11 +355,6 @@ describe('search', () => {
             name: 'Canvas',
           },
           {
-            totalCount: 1,
-            id: 'Ink',
-            name: 'Ink',
-          },
-          {
             totalCount: 2,
             id: 'Oilpaint',
             name: 'Oilpaint',
@@ -368,6 +363,11 @@ describe('search', () => {
             totalCount: 2,
             id: 'Paper',
             name: 'Paper',
+          },
+          {
+            totalCount: 1,
+            id: 'Ink',
+            name: 'Ink',
           },
         ],
         creators: [
@@ -389,19 +389,14 @@ describe('search', () => {
         ],
         publishers: [
           {
-            totalCount: 0,
-            id: 'Archive',
-            name: 'Archive',
+            totalCount: 3,
+            id: 'Museum',
+            name: 'Museum',
           },
           {
             totalCount: 1,
             id: 'Library',
             name: 'Library',
-          },
-          {
-            totalCount: 3,
-            id: 'Museum',
-            name: 'Museum',
           },
           {
             totalCount: 1,
@@ -472,15 +467,7 @@ describe('search', () => {
     expect(result).toMatchObject({
       totalCount: 1,
       filters: {
-        owners: [
-          {totalCount: 1, id: 'Library', name: 'Library'},
-          {totalCount: 0, id: 'Museum', name: 'Museum'},
-          {
-            totalCount: 0,
-            id: 'Research Organisation',
-            name: 'Research Organisation',
-          },
-        ],
+        owners: [{totalCount: 1, id: 'Library', name: 'Library'}],
       },
     });
   });
@@ -495,12 +482,7 @@ describe('search', () => {
     expect(result).toMatchObject({
       totalCount: 1,
       filters: {
-        types: [
-          {totalCount: 0, id: 'Canvas Painting', name: 'Canvas Painting'},
-          {totalCount: 0, id: 'Drawing', name: 'Drawing'},
-          {totalCount: 1, id: 'Painting', name: 'Painting'},
-          {totalCount: 0, id: 'Photo', name: 'Photo'},
-        ],
+        types: [{totalCount: 1, id: 'Painting', name: 'Painting'}],
       },
     });
   });
@@ -517,9 +499,7 @@ describe('search', () => {
       filters: {
         subjects: [
           {totalCount: 1, id: 'Castle', name: 'Castle'},
-          {totalCount: 0, id: 'Celebrations', name: 'Celebrations'},
           {totalCount: 1, id: 'Cottage', name: 'Cottage'},
-          {totalCount: 0, id: 'Palace', name: 'Palace'},
         ],
       },
     });
@@ -535,11 +515,7 @@ describe('search', () => {
     expect(result).toMatchObject({
       totalCount: 1,
       filters: {
-        locations: [
-          {totalCount: 0, id: 'Indonesia', name: 'Indonesia'},
-          {totalCount: 1, id: 'Malaysia', name: 'Malaysia'},
-          {totalCount: 0, id: 'Suriname', name: 'Suriname'},
-        ],
+        locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
       },
     });
   });
@@ -561,19 +537,9 @@ describe('search', () => {
             name: 'Canvas',
           },
           {
-            totalCount: 0,
-            id: 'Ink',
-            name: 'Ink',
-          },
-          {
             totalCount: 2,
             id: 'Oilpaint',
             name: 'Oilpaint',
-          },
-          {
-            totalCount: 0,
-            id: 'Paper',
-            name: 'Paper',
           },
         ],
       },
@@ -596,16 +562,6 @@ describe('search', () => {
             id: 'Adriaan Boer',
             name: 'Adriaan Boer',
           },
-          {
-            totalCount: 0,
-            id: 'Geeske van Châtellerault',
-            name: 'Geeske van Châtellerault',
-          },
-          {
-            totalCount: 0,
-            id: 'Vincent van Gogh',
-            name: 'Vincent van Gogh',
-          },
         ],
       },
     });
@@ -623,29 +579,9 @@ describe('search', () => {
       filters: {
         publishers: [
           {
-            totalCount: 0,
-            id: 'Archive',
-            name: 'Archive',
-          },
-          {
             totalCount: 1,
             id: 'Library',
             name: 'Library',
-          },
-          {
-            totalCount: 0,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 0,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
-          },
-          {
-            totalCount: 0,
-            id: 'Research Organisation',
-            name: 'Research Organisation',
           },
         ],
       },
@@ -663,21 +599,6 @@ describe('search', () => {
       totalCount: 1,
       filters: {
         dateCreatedStart: [
-          {
-            totalCount: 0,
-            id: 1725,
-            name: 1725,
-          },
-          {
-            totalCount: 0,
-            id: 1889,
-            name: 1889,
-          },
-          {
-            totalCount: 0,
-            id: 1895,
-            name: 1895,
-          },
           {
             totalCount: 1,
             id: 1901,
@@ -703,21 +624,6 @@ describe('search', () => {
             totalCount: 1,
             id: 1736,
             name: 1736,
-          },
-          {
-            totalCount: 0,
-            id: 1890,
-            name: 1890,
-          },
-          {
-            totalCount: 0,
-            id: 1895,
-            name: 1895,
-          },
-          {
-            totalCount: 0,
-            id: 1902,
-            name: 1902,
           },
         ],
       },
@@ -751,11 +657,6 @@ describe('search', () => {
             id: 1895,
             name: 1895,
           },
-          {
-            totalCount: 0,
-            id: 1901,
-            name: 1901,
-          },
         ],
         dateCreatedEnd: [
           {
@@ -772,11 +673,6 @@ describe('search', () => {
             totalCount: 1,
             id: 1895,
             name: 1895,
-          },
-          {
-            totalCount: 0,
-            id: 1902,
-            name: 1902,
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -119,17 +119,6 @@ const rawSearchResponseSchema = z.object({
 const rawSearchResponseWithAggregationsSchema = rawSearchResponseSchema.merge(
   z.object({
     aggregations: z.object({
-      all: z.object({
-        owners: rawAggregationSchema,
-        types: rawAggregationSchema,
-        subjects: rawAggregationSchema,
-        locations: rawAggregationSchema,
-        materials: rawAggregationSchema,
-        creators: rawAggregationSchema,
-        publishers: rawAggregationSchema,
-        dateCreatedStart: rawAggregationSchema,
-        dateCreatedEnd: rawAggregationSchema,
-      }),
       owners: rawAggregationSchema,
       types: rawAggregationSchema,
       subjects: rawAggregationSchema,
@@ -314,13 +303,6 @@ export class HeritageObjectSearcher {
         },
       },
       aggregations: {
-        all: {
-          // Aggregate all filters, regardless of the query.
-          // We may need to refine this at some point, if performance needs it,
-          // e.g. by using a separate call and caching the results
-          global: {},
-          aggregations,
-        },
         ...aggregations,
       },
     };
@@ -383,48 +365,17 @@ export class HeritageObjectSearcher {
       return this.fromRawHeritageObjectToHeritageObject(rawHeritageObject);
     });
 
-    const ownerFilters = buildFilters(
-      aggregations.all.owners.buckets,
-      aggregations.owners.buckets
-    );
-
-    const typeFilters = buildFilters(
-      aggregations.all.types.buckets,
-      aggregations.types.buckets
-    );
-
-    const subjectFilters = buildFilters(
-      aggregations.all.subjects.buckets,
-      aggregations.subjects.buckets
-    );
-
-    const locationFilters = buildFilters(
-      aggregations.all.locations.buckets,
-      aggregations.locations.buckets
-    );
-
-    const materialFilters = buildFilters(
-      aggregations.all.materials.buckets,
-      aggregations.materials.buckets
-    );
-
-    const creatorFilters = buildFilters(
-      aggregations.all.creators.buckets,
-      aggregations.creators.buckets
-    );
-
-    const publisherFilters = buildFilters(
-      aggregations.all.publishers.buckets,
-      aggregations.publishers.buckets
-    );
-
+    const ownerFilters = buildFilters(aggregations.owners.buckets);
+    const typeFilters = buildFilters(aggregations.types.buckets);
+    const subjectFilters = buildFilters(aggregations.subjects.buckets);
+    const locationFilters = buildFilters(aggregations.locations.buckets);
+    const materialFilters = buildFilters(aggregations.materials.buckets);
+    const creatorFilters = buildFilters(aggregations.creators.buckets);
+    const publisherFilters = buildFilters(aggregations.publishers.buckets);
     const dateCreatedStartFilters = buildFilters(
-      aggregations.all.dateCreatedStart.buckets,
       aggregations.dateCreatedStart.buckets
     );
-
     const dateCreatedEndFilters = buildFilters(
-      aggregations.all.dateCreatedEnd.buckets,
       aggregations.dateCreatedEnd.buckets
     );
 


### PR DESCRIPTION
This PR:

1. No longer returns facet values with a count of `0` (this is a test, to find out whether it improves the search experience)
2. Returns up to 10,000 facets values per facet (this is a bad practice that we must revisit at some point, but allows us to see all or at least most of the facet values that we currently have in the data)