### PR TITLE
Fix end-to-end test

### DIFF
--- a/apps/researcher/cypress/e2e/home.cy.ts
+++ b/apps/researcher/cypress/e2e/home.cy.ts
@@ -24,11 +24,11 @@ describe('Object list filters', () => {
     cy.getBySel('selectedFilter').should('have.length', 1);
   });
 
-  it('filters by two publishers', () => {
+  it('filters by two materials', () => {
     cy.visit('/en', {
       failOnStatusCode: false,
     });
-    cy.getBySel('publishersFilter').within(() => {
+    cy.getBySel('materialsFilter').within(() => {
       cy.get('[type="checkbox"]').eq(0).check();
       cy.get('[type="checkbox"]').eq(1).check();
     });

--- a/packages/ui/list/base-facet.tsx
+++ b/packages/ui/list/base-facet.tsx
@@ -39,6 +39,7 @@ export function FacetCheckBox({
 }: FacetCheckBoxProps) {
   const selectedFilters = useListStore(s => s.selectedFilters);
   const filterChange = useListStore(s => s.filterChange);
+  const newDataNeeded = useListStore(s => s.newDataNeeded);
 
   const selectedFiltersForKey = useMemo(
     () => selectedFilters[filterKey] || [],
@@ -70,6 +71,7 @@ export function FacetCheckBox({
           value={id}
           checked={selectedFiltersForKey.some(filterId => id === filterId)}
           onChange={handleChange}
+          disabled={newDataNeeded}
         />
         <label className="truncate max-w-[230px]" htmlFor={`facet-${id}`}>
           {name}

--- a/packages/ui/list/selected-filters.tsx
+++ b/packages/ui/list/selected-filters.tsx
@@ -59,7 +59,7 @@ export function SelectedFiltersForKey({
       (selectedFilter as string[]).forEach(id => {
         badges.push({
           key: `${filterKey}-${id}`,
-          label: filters.find(({id: i}) => i === id)!.name,
+          label: filters.find(({id: i}) => i === id)?.name ?? id,
           action: () => clearSelectedArrayFilter({id, filterKey}),
         });
       });


### PR DESCRIPTION
Now, only filters with results are shown. This results in a few different problems:

1. The test 'filters by two publishers' fails because when selecting the first 'publisher', the other 'publishers' will disappear. You can choose two 'materials, ' so use 'materials' to test the selections of multiple filters.
2. It takes a moment before the new filter is loaded. A fast user on a slow machine can select multiple list items before the new filter set is returned. The fast end-to-end tests sometimes select multiple items before loading the new filter set from the API. To fix this, I have disabled the checkbox filters when waiting for a new filter list.
3. Only the IDs of the selected filters are saved in the store. The badges of selected items (above the list of objects) need the filter set from the API to find the selected filter's name. But now, the API will not return all filters, only those with results. The name cannot be loaded if there is a selected filter with 0 results. This scenario sometimes happens in the test: 'filters multiple categories together (query, publishers and types)'. After typing the query, the fast end-to-end tests will sometimes select a publisher before loading the new filter set. The combination of query and wrong selected publisher will result in 0 results. So, the API does not return the selected publisher, no name can be found, and an error is thrown. Point 2 will fix this test. But users can still get this error by first selecting a filter and then starting typing. See gif:

![error](https://github.com/colonial-heritage/colonial-collections/assets/1481602/6d3d6666-207e-44e8-9a49-d1b9590c14c3)

I will fix this for now by showing the ID if the name can not be found.