### PR TITLE
Update translations for persons to constituents

### DIFF
--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -187,7 +187,9 @@ export default async function Home({searchParams = {}}: Props) {
                 >
                   <div className="ml-4 mt-2">
                     <PageTitle>
-                      {t('title', {totalConstituents: searchResult.totalCount})}
+                      {t('title', {
+                        constituentsTotalCount: searchResult.totalCount,
+                      })}
                     </PageTitle>
                   </div>
                   <div>

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -130,7 +130,7 @@ export default async function Home({searchParams = {}}: Props) {
   }
 
   const locale = useLocale();
-  const t = await getTranslator(locale, 'Persons');
+  const t = await getTranslator(locale, 'Constituents');
 
   return (
     <>
@@ -187,7 +187,7 @@ export default async function Home({searchParams = {}}: Props) {
                 >
                   <div className="ml-4 mt-2">
                     <PageTitle>
-                      {t('title', {totalPersons: searchResult.totalCount})}
+                      {t('title', {totalConstituents: searchResult.totalCount})}
                     </PageTitle>
                   </div>
                   <div>

--- a/apps/researcher/src/app/[locale]/persons/person-list.tsx
+++ b/apps/researcher/src/app/[locale]/persons/person-list.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export default function PersonList({persons, totalCount}: Props) {
-  const t = useTranslations('Persons');
+  const t = useTranslations('Constituents');
 
   if (totalCount > 0) {
     return (

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -8,10 +8,10 @@
     "fetchError": "There was a problem fetching the objects. Please reload the page to try again.",
     "filters": "Filters"
   },
-  "Persons": {
-    "title": "{totalPersons, plural, =0 {0 persons} =1 {1 person} other {# persons}}",
+  "Constituents": {
+    "title": "{totalConstituents, plural, =0 {0 constituents} =1 {1 constituent} other {# constituents}}",
     "noResults": "There are no results",
-    "fetchError": "There was a problem fetching the objects. Please reload the page to try again.",
+    "fetchError": "There was a problem fetching the constituents. Please reload the page to try again.",
     "filters": "Filters"
   },
   "Navigation": {
@@ -24,7 +24,7 @@
   },
   "Tabs": {
     "objects": "Search for objects",
-    "persons": "Search for persons"
+    "persons": "Search for constituents"
   },
   "LanguageSelector": {
     "nl": "Nederlands",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -9,7 +9,7 @@
     "filters": "Filters"
   },
   "Constituents": {
-    "title": "{totalConstituents, plural, =0 {0 constituents} =1 {1 constituent} other {# constituents}}",
+    "title": "{constituentsTotalCount, plural, =0 {0 constituents} =1 {1 constituent} other {# constituents}}",
     "noResults": "There are no results",
     "fetchError": "There was a problem fetching the constituents. Please reload the page to try again.",
     "filters": "Filters"

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -9,7 +9,7 @@
     "filters": "Filters"
   },
   "Constituents": {
-    "title": "{totalConstituents, plural, =0 {0 betrokkenen} =1 {1 betrokken} other {# betrokkenen}}",
+    "title": "{totalConstituents, plural, =0 {0 Personen en Instellingen} =1 {1 Persoon of Instelling} other {# Personen en Instellingen}}",
     "noResults": "Er zijn geen resultaten",
     "fetchError": "Er is een probleem opgetreden bij het ophalen van de resultaten. Laad de pagina opnieuw om het opnieuw te proberen.",
     "filters": "Filters"
@@ -24,7 +24,7 @@
   },
   "Tabs": {
     "objects": "Objecten zoeken",
-    "persons": "Betrokkenen zoeken"
+    "persons": "Personen en Instellingen zoeken"
   },
   "LanguageSelector": {
     "nl": "Nederlands",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -9,7 +9,7 @@
     "filters": "Filters"
   },
   "Constituents": {
-    "title": "{totalConstituents, plural, =0 {0 Personen en Instellingen} =1 {1 Persoon of Instelling} other {# Personen en Instellingen}}",
+    "title": "{constituentsTotalCount, plural, =0 {0 Personen en instellingen} =1 {1 Persoon of instelling} other {# Personen en instellingen}}",
     "noResults": "Er zijn geen resultaten",
     "fetchError": "Er is een probleem opgetreden bij het ophalen van de resultaten. Laad de pagina opnieuw om het opnieuw te proberen.",
     "filters": "Filters"
@@ -24,7 +24,7 @@
   },
   "Tabs": {
     "objects": "Objecten zoeken",
-    "persons": "Personen en Instellingen zoeken"
+    "persons": "Personen en instellingen zoeken"
   },
   "LanguageSelector": {
     "nl": "Nederlands",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -8,8 +8,8 @@
     "fetchError": "Er is een probleem opgetreden bij het ophalen van de resultaten. Laad de pagina opnieuw om het opnieuw te proberen.",
     "filters": "Filters"
   },
-  "Persons": {
-    "title": "{totalPersons, plural, =0 {0 personen} =1 {1 persoon} other {# personen}}",
+  "Constituents": {
+    "title": "{totalConstituents, plural, =0 {0 betrokkenen} =1 {1 betrokken} other {# betrokkenen}}",
     "noResults": "Er zijn geen resultaten",
     "fetchError": "Er is een probleem opgetreden bij het ophalen van de resultaten. Laad de pagina opnieuw om het opnieuw te proberen.",
     "filters": "Filters"
@@ -24,7 +24,7 @@
   },
   "Tabs": {
     "objects": "Objecten zoeken",
-    "persons": "Personen zoeken"
+    "persons": "Betrokkenen zoeken"
   },
   "LanguageSelector": {
     "nl": "Nederlands",


### PR DESCRIPTION
Rename 'Persons' to 'Constituents' (English) and 'Betrokkenen' (dutch) 

In code, the entity is still called a person. We also have a person api. Changing this will be some more work.