### PR TITLE
Add Hotjar script for user testing

### DIFF
--- a/apps/researcher/src/app/layout.tsx
+++ b/apps/researcher/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+import Script from 'next/script';
 
 type Props = {
   children: ReactNode;
@@ -8,5 +9,16 @@ type Props = {
 // of this file fixes an issue in Next.js 13.4 where link clicks that switch
 // the locale would otherwise cause a full reload.
 export default function RootLayout({children}: Props) {
-  return children;
+  return (
+    <>
+      {children}
+      <Script
+        id="Hotjar"
+        dangerouslySetInnerHTML={{
+          __html:
+            "(function(h,o,t,j,a,r){ h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)}; h._hjSettings={hjid:3748028,hjsv:6}; a=o.getElementsByTagName('head')[0]; r=o.createElement('script');r.async=1; r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv; a.appendChild(r); })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');",
+        }}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
Question from Bas: Can we add this Hotjar script? This is a kind of analytics tool focused on usability. This requires adding some kind of tag to the code.

```
<!-- Hotjar Tracking Code for https://app.colonialcollections.nl/ --> 
<script> 
(function(h,o,t,j,a,r){ h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)}; h._hjSettings={hjid:3748028,hjsv:6}; a=o.getElementsByTagName('head')[0]; r=o.createElement('script');r.async=1; r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv; a.appendChild(r); })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv='); 
</script>
```