### PR TITLE
fix: update data model for NDE Dataset Register

### DIFF
--- a/apps/dataset-browser/src/lib/datasets/enricher.ts
+++ b/apps/dataset-browser/src/lib/datasets/enricher.ts
@@ -66,9 +66,9 @@ export class DatasetEnricher {
     // Query can be expanded to also include other properties
     const query = `
       PREFIX cc: <https://colonialcollections.nl/schema#>
-      PREFIX dcat: <http://www.w3.org/ns/dcat#>
       PREFIX dqv: <http://www.w3.org/ns/dqv#>
       PREFIX qb: <http://purl.org/linked-data/cube#>
+      PREFIX schema: <https://schema.org/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
       CONSTRUCT {
@@ -82,14 +82,11 @@ export class DatasetEnricher {
         VALUES ?iri {
           ${irisForValues}
         }
-        ?iri a dcat:Dataset .
+        ?iri a schema:Dataset .
 
-        {
-          ?iri dqv:hasQualityMeasurement ?measurement .
-        }
-        UNION {
-          ?iri dcat:distribution/dqv:hasQualityMeasurement ?measurement .
-        }
+        { ?iri dqv:hasQualityMeasurement ?measurement }
+        UNION
+        { ?iri schema:distribution/dqv:hasQualityMeasurement ?measurement }
 
         ?measurement dqv:value ?value ;
           dqv:isMeasurementOf ?metric .

--- a/apps/dataset-browser/src/lib/datasets/fetcher.integration.test.ts
+++ b/apps/dataset-browser/src/lib/datasets/fetcher.integration.test.ts
@@ -47,12 +47,6 @@ describe('search', () => {
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
           dateModified: new Date('2023-02-17T00:00:00.000Z'),
           datePublished: new Date('2023-02-17T00:00:00.000Z'),
-          genres: [
-            {
-              id: 'man-made objects',
-              name: 'man-made objects',
-            },
-          ],
           measurements: [
             {
               id: 'https://example.org/datasets/1/measurements/2',
@@ -112,12 +106,9 @@ describe('search', () => {
         },
         {
           id: 'https://example.org/datasets/10',
-          name: '(No name)',
+          name: 'Dataset 10',
           publisher: {id: 'Library', name: 'Library'},
-          license: {
-            id: 'Custom License',
-            name: 'Custom License',
-          },
+          license: {id: 'Custom License', name: 'Custom License'},
           measurements: [
             {
               id: 'https://example.org/datasets/10/measurements/2',
@@ -184,12 +175,6 @@ describe('search', () => {
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
           },
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
-          genres: [
-            {
-              id: 'notes (documents)',
-              name: 'notes (documents)',
-            },
-          ],
           measurements: [
             {
               id: 'https://example.org/datasets/11/measurements/2',
@@ -330,13 +315,6 @@ describe('search', () => {
             'Cras erat elit, finibus eget ipsum vel, gravida dapibus leo. Etiam sem erat, suscipit id eros sit amet, scelerisque ornare sem. Aenean commodo elementum neque ac accumsan.',
           keywords: ['Fringilla'],
           dateCreated: new Date('2022-10-01T09:01:02.000Z'),
-          genres: [
-            {id: 'articles', name: 'articles'},
-            {
-              id: 'publications (documents)',
-              name: 'publications (documents)',
-            },
-          ],
           measurements: [
             {
               id: 'https://example.org/datasets/13/measurements/2',
@@ -464,7 +442,7 @@ describe('search', () => {
         },
         {
           id: 'https://example.org/datasets/2',
-          name: '(No name)',
+          name: 'Dataset 2',
           publisher: {id: 'Museum', name: 'Museum'},
           license: {
             id: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
@@ -473,13 +451,6 @@ describe('search', () => {
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
           dateModified: new Date('2023-02-17T00:00:00.000Z'),
           datePublished: new Date('2023-02-17T00:00:00.000Z'),
-          genres: [
-            {
-              id: 'art (broad object genre)',
-              name: 'art (broad object genre)',
-            },
-            {id: 'tableware', name: 'tableware'},
-          ],
           measurements: [
             {
               id: 'https://example.org/datasets/2/measurements/2',
@@ -569,7 +540,6 @@ describe('search', () => {
             'Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac.',
           keywords: ['Hendrerit', 'Suspendisse'],
           dateModified: new Date('2023-02-01T00:00:00.000Z'),
-          genres: [{id: 'tableware', name: 'tableware'}],
           measurements: [
             {
               id: 'https://example.org/datasets/4/measurements/2',
@@ -631,14 +601,10 @@ describe('search', () => {
           id: 'https://example.org/datasets/5',
           name: 'Dataset 5',
           publisher: {id: 'Archive', name: 'Archive'},
-          license: {
-            id: 'In Copyright',
-            name: 'In Copyright',
-          },
+          license: {id: 'In Copyright', name: 'In Copyright'},
           description:
             'Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam.',
           keywords: ['Keyword'],
-          genres: [{id: 'digital media', name: 'digital media'}],
           measurements: [
             {
               id: 'https://example.org/datasets/5/measurements/2',
@@ -699,30 +665,13 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {
-            totalCount: 5,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 3,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 5,
-            id: 'Archive',
-            name: 'Archive',
-          },
+          {totalCount: 5, id: 'Archive', name: 'Archive'},
+          {totalCount: 5, id: 'Library', name: 'Library'},
+          {totalCount: 3, id: 'Museum', name: 'Museum'},
           {
             totalCount: 1,
             id: 'Research Organisation',
             name: 'Research Organisation',
-          },
-          {
-            totalCount: 0,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -746,16 +695,8 @@ describe('search', () => {
             id: 'Copyright Undetermined',
             name: 'Copyright Undetermined',
           },
-          {
-            totalCount: 1,
-            id: 'Custom License',
-            name: 'Custom License',
-          },
-          {
-            totalCount: 1,
-            id: 'In Copyright',
-            name: 'In Copyright',
-          },
+          {totalCount: 1, id: 'Custom License', name: 'Custom License'},
+          {totalCount: 1, id: 'In Copyright', name: 'In Copyright'},
           {
             totalCount: 1,
             id: 'Open Data Commons Attribution License (ODC-By) v1.0',
@@ -768,48 +709,7 @@ describe('search', () => {
           },
         ],
         spatialCoverages: [],
-        genres: [
-          {
-            totalCount: 2,
-            id: 'articles',
-            name: 'articles',
-          },
-          {
-            totalCount: 2,
-            id: 'tableware',
-            name: 'tableware',
-          },
-          {
-            totalCount: 1,
-            id: 'art (broad object genre)',
-            name: 'art (broad object genre)',
-          },
-          {
-            totalCount: 1,
-            id: 'digital media',
-            name: 'digital media',
-          },
-          {
-            totalCount: 1,
-            id: 'man-made objects',
-            name: 'man-made objects',
-          },
-          {
-            totalCount: 1,
-            id: 'notes (documents)',
-            name: 'notes (documents)',
-          },
-          {
-            totalCount: 1,
-            id: 'publications (documents)',
-            name: 'publications (documents)',
-          },
-          {
-            totalCount: 1,
-            id: 'unidentified works',
-            name: 'unidentified works',
-          },
-        ],
+        genres: [],
       },
     });
   });
@@ -828,30 +728,13 @@ describe('search', () => {
       datasets: [],
       filters: {
         publishers: [
-          {
-            totalCount: 0,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 0,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 0,
-            id: 'Archive',
-            name: 'Archive',
-          },
+          {totalCount: 0, id: 'Archive', name: 'Archive'},
+          {totalCount: 0, id: 'Library', name: 'Library'},
+          {totalCount: 0, id: 'Museum', name: 'Museum'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
-          },
-          {
-            totalCount: 0,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -875,16 +758,8 @@ describe('search', () => {
             id: 'Copyright Undetermined',
             name: 'Copyright Undetermined',
           },
-          {
-            totalCount: 0,
-            id: 'Custom License',
-            name: 'Custom License',
-          },
-          {
-            totalCount: 0,
-            id: 'In Copyright',
-            name: 'In Copyright',
-          },
+          {totalCount: 0, id: 'Custom License', name: 'Custom License'},
+          {totalCount: 0, id: 'In Copyright', name: 'In Copyright'},
           {
             totalCount: 0,
             id: 'Open Data Commons Attribution License (ODC-By) v1.0',
@@ -897,48 +772,7 @@ describe('search', () => {
           },
         ],
         spatialCoverages: [],
-        genres: [
-          {
-            totalCount: 0,
-            id: 'articles',
-            name: 'articles',
-          },
-          {
-            totalCount: 0,
-            id: 'tableware',
-            name: 'tableware',
-          },
-          {
-            totalCount: 0,
-            id: 'art (broad object genre)',
-            name: 'art (broad object genre)',
-          },
-          {
-            totalCount: 0,
-            id: 'digital media',
-            name: 'digital media',
-          },
-          {
-            totalCount: 0,
-            id: 'man-made objects',
-            name: 'man-made objects',
-          },
-          {
-            totalCount: 0,
-            id: 'notes (documents)',
-            name: 'notes (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'publications (documents)',
-            name: 'publications (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'unidentified works',
-            name: 'unidentified works',
-          },
-        ],
+        genres: [],
       },
     });
   });
@@ -956,23 +790,11 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/5',
           name: 'Dataset 5',
-          publisher: {
-            id: 'Archive',
-            name: 'Archive',
-          },
-          license: {
-            id: 'In Copyright',
-            name: 'In Copyright',
-          },
+          publisher: {id: 'Archive', name: 'Archive'},
+          license: {id: 'In Copyright', name: 'In Copyright'},
           description:
             'Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam.',
           keywords: ['Keyword'],
-          genres: [
-            {
-              id: 'digital media',
-              name: 'digital media',
-            },
-          ],
           measurements: [
             {
               id: 'https://example.org/datasets/5/measurements/2',
@@ -1033,30 +855,13 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {
-            totalCount: 0,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 0,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 1,
-            id: 'Archive',
-            name: 'Archive',
-          },
+          {totalCount: 1, id: 'Archive', name: 'Archive'},
+          {totalCount: 0, id: 'Library', name: 'Library'},
+          {totalCount: 0, id: 'Museum', name: 'Museum'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
-          },
-          {
-            totalCount: 0,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -1080,16 +885,8 @@ describe('search', () => {
             id: 'Copyright Undetermined',
             name: 'Copyright Undetermined',
           },
-          {
-            totalCount: 0,
-            id: 'Custom License',
-            name: 'Custom License',
-          },
-          {
-            totalCount: 1,
-            id: 'In Copyright',
-            name: 'In Copyright',
-          },
+          {totalCount: 0, id: 'Custom License', name: 'Custom License'},
+          {totalCount: 1, id: 'In Copyright', name: 'In Copyright'},
           {
             totalCount: 0,
             id: 'Open Data Commons Attribution License (ODC-By) v1.0',
@@ -1102,48 +899,7 @@ describe('search', () => {
           },
         ],
         spatialCoverages: [],
-        genres: [
-          {
-            totalCount: 0,
-            id: 'articles',
-            name: 'articles',
-          },
-          {
-            totalCount: 0,
-            id: 'tableware',
-            name: 'tableware',
-          },
-          {
-            totalCount: 0,
-            id: 'art (broad object genre)',
-            name: 'art (broad object genre)',
-          },
-          {
-            totalCount: 1,
-            id: 'digital media',
-            name: 'digital media',
-          },
-          {
-            totalCount: 0,
-            id: 'man-made objects',
-            name: 'man-made objects',
-          },
-          {
-            totalCount: 0,
-            id: 'notes (documents)',
-            name: 'notes (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'publications (documents)',
-            name: 'publications (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'unidentified works',
-            name: 'unidentified works',
-          },
-        ],
+        genres: [],
       },
     });
   });
@@ -1181,30 +937,13 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {
-            totalCount: 5,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 0,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 0,
-            id: 'Archive',
-            name: 'Archive',
-          },
+          {totalCount: 0, id: 'Archive', name: 'Archive'},
+          {totalCount: 5, id: 'Library', name: 'Library'},
+          {totalCount: 0, id: 'Museum', name: 'Museum'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
-          },
-          {
-            totalCount: 0,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
           },
         ],
       },
@@ -1282,67 +1021,6 @@ describe('search', () => {
       },
     });
   });
-
-  it('finds datasets if "genres" filter matches', async () => {
-    const result = await datasetFetcher.search({
-      filters: {
-        genres: ['art (broad object genre)'],
-      },
-    });
-
-    expect(result).toMatchObject({
-      totalCount: 1,
-      datasets: [
-        {
-          id: 'https://example.org/datasets/2',
-        },
-      ],
-      filters: {
-        genres: [
-          {
-            totalCount: 0,
-            id: 'articles',
-            name: 'articles',
-          },
-          {
-            totalCount: 1,
-            id: 'tableware',
-            name: 'tableware',
-          },
-          {
-            totalCount: 1,
-            id: 'art (broad object genre)',
-            name: 'art (broad object genre)',
-          },
-          {
-            totalCount: 0,
-            id: 'digital media',
-            name: 'digital media',
-          },
-          {
-            totalCount: 0,
-            id: 'man-made objects',
-            name: 'man-made objects',
-          },
-          {
-            totalCount: 0,
-            id: 'notes (documents)',
-            name: 'notes (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'publications (documents)',
-            name: 'publications (documents)',
-          },
-          {
-            totalCount: 0,
-            id: 'unidentified works',
-            name: 'unidentified works',
-          },
-        ],
-      },
-    });
-  });
 });
 
 describe('getById', () => {
@@ -1372,7 +1050,6 @@ describe('getById', () => {
       dateCreated: new Date('2019-03-12T00:00:00.000Z'),
       dateModified: new Date('2023-02-17T00:00:00.000Z'),
       datePublished: new Date('2023-02-17T00:00:00.000Z'),
-      genres: [{id: 'man-made objects', name: 'man-made objects'}],
       measurements: [
         {
           id: 'https://example.org/datasets/1/measurements/2',

--- a/apps/dataset-browser/src/lib/datasets/fetcher.integration.test.ts
+++ b/apps/dataset-browser/src/lib/datasets/fetcher.integration.test.ts
@@ -665,13 +665,18 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {totalCount: 5, id: 'Archive', name: 'Archive'},
           {totalCount: 5, id: 'Library', name: 'Library'},
           {totalCount: 3, id: 'Museum', name: 'Museum'},
+          {totalCount: 5, id: 'Archive', name: 'Archive'},
           {
             totalCount: 1,
             id: 'Research Organisation',
             name: 'Research Organisation',
+          },
+          {
+            totalCount: 0,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -728,13 +733,18 @@ describe('search', () => {
       datasets: [],
       filters: {
         publishers: [
-          {totalCount: 0, id: 'Archive', name: 'Archive'},
           {totalCount: 0, id: 'Library', name: 'Library'},
           {totalCount: 0, id: 'Museum', name: 'Museum'},
+          {totalCount: 0, id: 'Archive', name: 'Archive'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
+          },
+          {
+            totalCount: 0,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -855,13 +865,18 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {totalCount: 1, id: 'Archive', name: 'Archive'},
           {totalCount: 0, id: 'Library', name: 'Library'},
           {totalCount: 0, id: 'Museum', name: 'Museum'},
+          {totalCount: 1, id: 'Archive', name: 'Archive'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
+          },
+          {
+            totalCount: 0,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
           },
         ],
         licenses: [
@@ -937,13 +952,18 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {totalCount: 0, id: 'Archive', name: 'Archive'},
           {totalCount: 5, id: 'Library', name: 'Library'},
           {totalCount: 0, id: 'Museum', name: 'Museum'},
+          {totalCount: 0, id: 'Archive', name: 'Archive'},
           {
             totalCount: 0,
             id: 'Research Organisation',
             name: 'Research Organisation',
+          },
+          {
+            totalCount: 0,
+            id: 'Onderzoeksinstelling',
+            name: 'Onderzoeksinstelling',
           },
         ],
       },

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -252,7 +252,7 @@ export class HeritageObjectFetcher {
           ####################
 
           OPTIONAL {
-            ?dataset dct:title ?datasetName
+            ?dataset schema:name ?datasetName
             FILTER(LANG(?datasetName) = "" || LANGMATCHES(LANG(?datasetName), "en"))
           }
 
@@ -261,7 +261,7 @@ export class HeritageObjectFetcher {
           ####################
 
           OPTIONAL {
-            ?dataset dct:publisher ?publisher .
+            ?dataset schema:publisher ?publisher .
             ?publisher schema:name ?publisherName ;
               rdf:type ?publisherTypeTemp .
 

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -46,41 +46,70 @@ describe('getByHeritageObjectId', () => {
     expect(provenanceEvents).toEqual(
       expect.arrayContaining([
         {
-          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
+          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
           types: [
             {
-              id: 'http://vocab.getty.edu/aat/300055292',
-              name: 'theft (social issue)',
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
             },
           ],
-          startDate: new Date('1901-01-01'),
-          endDate: new Date('1901-01-01'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/2',
-          endsBefore: 'https://example.org/objects/1/provenance/event/4',
+          description: 'Bought at an auction',
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startsAfter: 'https://example.org/objects/1/provenance/event/1',
+          endsBefore: 'https://example.org/objects/1/provenance/event/3',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/ceaf631aca53f3ce08e746c704112976',
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
             name: 'Amsterdam',
           },
           transferredFrom: {
-            id: 'https://museum.example.org/',
-            type: 'Organization',
-            name: 'Museum',
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            type: 'Person',
+            name: 'Jan de Vries',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417644',
+              name: 'transfer (method of acquisition)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ],
+          description: 'Bought for 1500 US dollars',
+          startDate: new Date('1855-01-01T00:00:00.000Z'),
+          endDate: new Date('1855-01-01T00:00:00.000Z'),
+          endsBefore: 'https://example.org/objects/1/provenance/event/2',
+          location: {
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            name: 'Jakarta',
+          },
+          transferredFrom: {
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            type: 'Person',
+            name: 'Peter Hoekstra',
+          },
+          transferredTo: {
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            type: 'Person',
+            name: 'Jan de Vries',
           },
         },
         {
           id: 'https://example.org/objects/1/provenance/event/4/activity/1',
           types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300445014',
-              name: 'returning',
-            },
+            {id: 'http://vocab.getty.edu/aat/300445014', name: 'returning'},
           ],
           description: 'Found in a basement',
-          startDate: new Date('1939-01-01'),
-          endDate: new Date('1939-01-01'),
+          startDate: new Date('1939-01-01T00:00:00.000Z'),
+          endDate: new Date('1939-01-01T00:00:00.000Z'),
           startsAfter: 'https://example.org/objects/1/provenance/event/3',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/8b43a21440e4fc05eef803e11dd9bc81',
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
             name: 'Paris',
           },
           transferredTo: {
@@ -90,57 +119,25 @@ describe('getByHeritageObjectId', () => {
           },
         },
         {
-          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
+          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
           types: [
             {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
-            {
-              id: 'http://vocab.getty.edu/aat/300417644',
-              name: 'transfer (method of acquisition)',
+              id: 'http://vocab.getty.edu/aat/300055292',
+              name: 'theft (social issue)',
             },
           ],
-          description: 'Bought for 1500 US dollars',
-          startDate: new Date('1855-01-01'),
-          endDate: new Date('1855-01-01'),
-          endsBefore: 'https://example.org/objects/1/provenance/event/2',
+          startDate: new Date('1901-01-01T00:00:00.000Z'),
+          endDate: new Date('1901-01-01T00:00:00.000Z'),
+          startsAfter: 'https://example.org/objects/1/provenance/event/2',
+          endsBefore: 'https://example.org/objects/1/provenance/event/4',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/284f309a0b4ecf92d513599a16d72cf0',
-            name: 'Jakarta',
-          },
-          transferredFrom: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/c7540c5ed76b0e24f19eec08a72e6e9d',
-            type: 'Person',
-            name: 'Peter Hoekstra',
-          },
-          transferredTo: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/f759902c257ad6daff7d98c7e48cc9dc',
-            type: 'Person',
-            name: 'Jan de Vries',
-          },
-        },
-        {
-          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
-          ],
-          description: 'Bought at an auction',
-          startDate: new Date('1879-01-01'),
-          endDate: new Date('1879-01-01'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/1',
-          endsBefore: 'https://example.org/objects/1/provenance/event/3',
-          location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/54da9245ecfc5f53678052ed81f71e56',
+            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
             name: 'Amsterdam',
           },
           transferredFrom: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/bda53ad8480465982765f52ef0ad42dd',
-            type: 'Person',
-            name: 'Jan de Vries',
+            id: 'https://museum.example.org/',
+            type: 'Organization',
+            name: 'Museum',
           },
         },
       ])


### PR DESCRIPTION
This PR changes the data model of the API just a little but, so that we can query the datasets retrieved from the [NDE Dataset Register](https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=45746637).

This PR, in its slipstream, also fixes some integration tests.