### PR TITLE
Fix bug: Wrong text if metadata entry is empty

### DIFF
--- a/apps/researcher/src/app/[locale]/(objects)/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/(objects)/objects/[id]/page.tsx
@@ -5,7 +5,7 @@ import Gallery from './gallery';
 import ToFilteredListButton from '@/components/to-filtered-list-button';
 import {ChevronLeftIcon} from '@heroicons/react/24/solid';
 import {ObjectIcon} from '@/components/icons';
-import {MetadataContainer, MetadataEntries} from './metadata';
+import {Metadata} from './metadata';
 import {decodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 import organizations from '@/lib/organizations-instance';
 import {
@@ -193,84 +193,70 @@ export default async function Details({params}: Props) {
             <h2 className="text-2xl">{t('metadata')}</h2>
           </div>
           <div className="flex flex-col gap-8 self-stretch">
-            <MetadataContainer
+            <Metadata
               translationKey="name"
               enrichmentType={AdditionalType.Name}
             >
-              <MetadataEntries>{object.name}</MetadataEntries>
-            </MetadataContainer>
-            <MetadataContainer
+              {object.name}
+            </Metadata>
+            <Metadata
               translationKey="description"
               enrichmentType={AdditionalType.Description}
             >
-              <MetadataEntries>{object.description}</MetadataEntries>
-            </MetadataContainer>
+              {object.description}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="materials"
               enrichmentType={AdditionalType.Material}
             >
-              <MetadataEntries>
-                {object.materials?.map(material => (
-                  <div key={material.id}>{material.name}</div>
-                ))}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.materials?.map(material => (
+                <div key={material.id}>{material.name}</div>
+              ))}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="dateCreated"
               enrichmentType={AdditionalType.DateCreated}
             >
-              <MetadataEntries>
-                {object.dateCreated && (
-                  <div>{formatDateCreated(object.dateCreated, locale)}</div>
-                )}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.dateCreated && (
+                <div>{formatDateCreated(object.dateCreated, locale)}</div>
+              )}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="types"
               enrichmentType={AdditionalType.Type}
             >
-              <MetadataEntries>
-                {object.types?.map(type => (
-                  <div key={type.id}>{type.name}</div>
-                ))}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.types?.map(type => <div key={type.id}>{type.name}</div>)}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="techniques"
               enrichmentType={AdditionalType.Technique}
             >
-              <MetadataEntries>
-                {object.techniques?.map(technique => (
-                  <div key={technique.id}>{technique.name}</div>
-                ))}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.techniques?.map(technique => (
+                <div key={technique.id}>{technique.name}</div>
+              ))}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="creators"
               enrichmentType={AdditionalType.Creator}
             >
-              <MetadataEntries>
-                {object.creators?.map(creator => (
-                  <div key={creator.id}>{creator.name}</div>
-                ))}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.creators?.map(creator => (
+                <div key={creator.id}>{creator.name}</div>
+              ))}
+            </Metadata>
 
-            <MetadataContainer
+            <Metadata
               translationKey="inscriptions"
               enrichmentType={AdditionalType.Inscription}
             >
-              <MetadataEntries>
-                {object.inscriptions?.map(inscription => (
-                  <div key={inscription}>{inscription}</div>
-                ))}
-              </MetadataEntries>
-            </MetadataContainer>
+              {object.inscriptions?.map(inscription => (
+                <div key={inscription}>{inscription}</div>
+              ))}
+            </Metadata>
           </div>
         </main>
         <aside className="w-full md:w-1/3 self-stretch order-1 md:order-2  md:mx-0 md:bg-neutral-100 p-1">


### PR DESCRIPTION
Bug: there seems to be a small bug in the labels - under "Materials" at https://app.colonialcollections.nl/objects/https%3A%2F%2Fcolonial-heritage%252Etriply%252Ecc%2Fnmvw%2Fid%2Fobject %2FTM-904-3 says "No Inscriptions available"

The problem was that the translation key for the message was set in a Zustand store, this store was updated for each metadata with a new key. However, only the last key was used for all metadata components.

First, I want to provide some background about my intention for the metadata component. I wanted one wrapper component with the possibility of different types of metadata entries. Something like:

```
<MetadataContainer
  translationKey="name"
  enrichmentType={AdditionalType.Name}
>
  <MetadataTextEntries>{object.name}</MetadataTextEntries>
</MetadataContainer>

<MetadataContainer
  translationKey="materials"
  enrichmentType={AdditionalType.Material}
>
  <MetadataListEntries>{object.materials.map(...)}</MetadataListEntries>
</MetadataContainer>
```

But there are no different types of enrichments, so there is not really a need for different types (yet).

The second problem is that the metadata component is a server component, server components do not support react context. So there is no simple way to send the `translationKey` from the container to the child component. 

My solution was to simplify the component. There is now only one `Metadata` component. All props are passed on to the child components instead of using a store.
  