### PR TITLE
feat: add location of creation to object details

### DIFF
--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -36,6 +36,7 @@
     "@hookform/resolvers": "3.3.2",
     "@next/mdx": "14.0.1",
     "classnames": "2.3.2",
+    "defu": "6.1.3",
     "fetch-sparql-endpoint": "4.1.0",
     "iso-639-1-dir": "3.0.5",
     "jwt-decode": "^4.0.0",

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -8,7 +8,7 @@ export type Thing = {
 };
 
 export type Term = Thing;
-export type Place = Thing;
+export type Place = Thing & {isPartOf?: Place};
 export type Person = Thing & {type: 'Person'};
 export type Unknown = Thing & {type: 'Unknown'};
 export type Agent = Person | Organization | Unknown;
@@ -53,6 +53,7 @@ export type HeritageObject = {
   materials?: Term[];
   techniques?: Term[];
   creators?: Agent[];
+  locationCreated?: Place;
   dateCreated?: TimeSpan;
   images?: Image[];
   owner?: Agent;

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -37,23 +37,23 @@ describe('getById', () => {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
       inscriptions: ['Maecenas commodo est neque'],
-      types: [
+      types: expect.arrayContaining([
         {
           id: expect.stringContaining(
             'https://colonial-heritage.triply.cc/.well-known/genid/'
           ),
           name: 'Canvas Painting',
         },
-      ],
-      subjects: [
+      ]),
+      subjects: expect.arrayContaining([
         {
           id: expect.stringContaining(
             'https://colonial-heritage.triply.cc/.well-known/genid/'
           ),
           name: 'Celebrations',
         },
-      ],
-      materials: [
+      ]),
+      materials: expect.arrayContaining([
         {
           id: expect.stringContaining(
             'https://colonial-heritage.triply.cc/.well-known/genid/'
@@ -66,16 +66,16 @@ describe('getById', () => {
           ),
           name: 'Canvas',
         },
-      ],
-      techniques: [
+      ]),
+      techniques: expect.arrayContaining([
         {
           id: expect.stringContaining(
             'https://colonial-heritage.triply.cc/.well-known/genid/'
           ),
           name: 'Albumen process',
         },
-      ],
-      creators: [
+      ]),
+      creators: expect.arrayContaining([
         {
           type: 'Person',
           id: expect.stringContaining(
@@ -83,13 +83,21 @@ describe('getById', () => {
           ),
           name: 'Geeske van Châtellerault',
         },
-      ],
+      ]),
       dateCreated: {
         id: expect.stringContaining(
           'https://colonial-heritage.triply.cc/.well-known/genid/'
         ),
         startDate: new Date('1901-01-01'),
         endDate: new Date('1902-06-01'),
+      },
+      locationCreated: {
+        id: 'https://sws.geonames.org/1749659/',
+        name: 'Pulau Sebang',
+        isPartOf: {
+          id: 'https://sws.geonames.org/1733045/',
+          name: 'Malaysia',
+        },
       },
       images: expect.arrayContaining([
         {

--- a/apps/researcher/src/lib/api/objects/index.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/index.integration.test.ts
@@ -32,7 +32,7 @@ describe('getProvenanceEventsByHeritageObjectId', () => {
         'https://example.org/objects/1'
       );
 
-    expect(provenanceEvents).toHaveLength(4);
+    expect(provenanceEvents).toHaveLength(5);
   });
 });
 

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -131,6 +131,13 @@ describe('getByHeritageObjectId', () => {
             type: 'Person',
             name: 'Jan de Vries',
           },
+          transferredTo: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            type: 'Person',
+            name: 'Jonathan Hansen',
+          },
         },
         {
           id: 'https://example.org/objects/1/provenance/event/5/activity/1',
@@ -157,6 +164,11 @@ describe('getByHeritageObjectId', () => {
             ),
             type: 'Person',
             name: 'Jonathan Hansen',
+          },
+          transferredTo: {
+            id: 'https://museum.example.org/',
+            type: 'Organization',
+            name: 'Museum',
           },
         },
         {

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -59,11 +59,15 @@ describe('getByHeritageObjectId', () => {
           startsAfter: 'https://example.org/objects/1/provenance/event/1',
           endsBefore: 'https://example.org/objects/1/provenance/event/3',
           location: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Amsterdam',
           },
           transferredFrom: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jan de Vries',
           },
@@ -85,16 +89,22 @@ describe('getByHeritageObjectId', () => {
           endDate: new Date('1855-01-01T00:00:00.000Z'),
           endsBefore: 'https://example.org/objects/1/provenance/event/2',
           location: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Jakarta',
           },
           transferredFrom: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Peter Hoekstra',
           },
           transferredTo: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jan de Vries',
           },
@@ -109,7 +119,9 @@ describe('getByHeritageObjectId', () => {
           endDate: new Date('1939-01-01T00:00:00.000Z'),
           startsAfter: 'https://example.org/objects/1/provenance/event/3',
           location: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Paris',
           },
           transferredTo: {
@@ -131,7 +143,9 @@ describe('getByHeritageObjectId', () => {
           startsAfter: 'https://example.org/objects/1/provenance/event/2',
           endsBefore: 'https://example.org/objects/1/provenance/event/4',
           location: {
-            id: expect.stringContaining('https://colonial-heritage.triply.cc/'),
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Amsterdam',
           },
           transferredFrom: {

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -42,51 +42,23 @@ describe('getByHeritageObjectId', () => {
       );
 
     // For now ignore order of elements in the array (until the events are sorted)
-    expect(provenanceEvents).toHaveLength(4);
     expect(provenanceEvents).toEqual(
       expect.arrayContaining([
-        {
-          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
-          ],
-          description: 'Bought at an auction',
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/1',
-          endsBefore: 'https://example.org/objects/1/provenance/event/3',
-          location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            name: 'Amsterdam',
-          },
-          transferredFrom: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            type: 'Person',
-            name: 'Jan de Vries',
-          },
-        },
         {
           id: 'https://example.org/objects/1/provenance/event/1/activity/1',
           types: [
             {
-              id: 'http://vocab.getty.edu/aat/300417644',
-              name: 'transfer (method of acquisition)',
-            },
-            {
               id: 'http://vocab.getty.edu/aat/300417642',
               name: 'purchase (method of acquisition)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300417644',
+              name: 'transfer (method of acquisition)',
             },
           ],
           description: 'Bought for 1500 US dollars',
           startDate: new Date('1855-01-01T00:00:00.000Z'),
-          endDate: new Date('1855-01-01T00:00:00.000Z'),
+          endDate: new Date('1857-01-01T00:00:00.000Z'),
           endsBefore: 'https://example.org/objects/1/provenance/event/2',
           location: {
             id: expect.stringContaining(
@@ -110,27 +82,6 @@ describe('getByHeritageObjectId', () => {
           },
         },
         {
-          id: 'https://example.org/objects/1/provenance/event/4/activity/1',
-          types: [
-            {id: 'http://vocab.getty.edu/aat/300445014', name: 'returning'},
-          ],
-          description: 'Found in a basement',
-          startDate: new Date('1939-01-01T00:00:00.000Z'),
-          endDate: new Date('1939-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/3',
-          location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            name: 'Paris',
-          },
-          transferredTo: {
-            id: 'https://museum.example.org/',
-            type: 'Organization',
-            name: 'Museum',
-          },
-        },
-        {
           id: 'https://example.org/objects/1/provenance/event/3/activity/1',
           types: [
             {
@@ -140,7 +91,7 @@ describe('getByHeritageObjectId', () => {
           ],
           startDate: new Date('1901-01-01T00:00:00.000Z'),
           endDate: new Date('1901-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/2',
+          startsAfter: 'https://example.org/objects/1/provenance/event/5',
           endsBefore: 'https://example.org/objects/1/provenance/event/4',
           location: {
             id: expect.stringContaining(
@@ -149,6 +100,84 @@ describe('getByHeritageObjectId', () => {
             name: 'Amsterdam',
           },
           transferredFrom: {
+            id: 'https://museum.example.org/',
+            type: 'Organization',
+            name: 'Museum',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ],
+          description: 'Bought at an auction in The Hague',
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startsAfter: 'https://example.org/objects/1/provenance/event/1',
+          endsBefore: 'https://example.org/objects/1/provenance/event/5',
+          location: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            name: 'The Hague',
+          },
+          transferredFrom: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            type: 'Person',
+            name: 'Jan de Vries',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/5/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ],
+          description: 'Bought at an auction in Amsterdam',
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startsAfter: 'https://example.org/objects/1/provenance/event/1',
+          endsBefore: 'https://example.org/objects/1/provenance/event/3',
+          location: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            name: 'Amsterdam',
+          },
+          transferredFrom: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            type: 'Person',
+            name: 'Jonathan Hansen',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/4/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300445014',
+              name: 'returning',
+            },
+          ],
+          description: 'Found in a basement',
+          startDate: new Date('1939-01-01T00:00:00.000Z'),
+          endDate: new Date('1940-01-01T00:00:00.000Z'),
+          startsAfter: 'https://example.org/objects/1/provenance/event/3',
+          location: {
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
+            name: 'Paris',
+          },
+          transferredTo: {
             id: 'https://museum.example.org/',
             type: 'Organization',
             name: 'Museum',

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
@@ -1,6 +1,6 @@
-import {ontologyUrl, Place, ProvenanceEvent, Term} from '../definitions';
-import {getPropertyValue, onlyOne, removeUndefinedValues} from '../rdf-helpers';
-import {createThings, createAgents} from './rdf-helpers';
+import {ProvenanceEvent, Term} from '../definitions';
+import {getPropertyValue, onlyOne, removeNullish} from '../rdf-helpers';
+import {createAgents, createThings, createPlaces} from './rdf-helpers';
 import {SparqlEndpointFetcher} from 'fetch-sparql-endpoint';
 import {isIri} from '@colonial-collections/iris';
 import type {Readable} from 'node:stream';
@@ -26,62 +26,62 @@ export class ProvenanceEventsFetcher {
 
   private async fetchTriples(iri: string) {
     const query = `
-      PREFIX cc: <${ontologyUrl}>
       PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+      PREFIX ex: <https://example.org/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX schema: <https://schema.org/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
       CONSTRUCT {
-        ?object a cc:HeritageObject ;
-          cc:subjectOf ?acquisition, ?transferOfCustody .
+        ?object a ex:HeritageObject ;
+          ex:subjectOf ?acquisition, ?transferOfCustody .
 
-        ?acquisition a cc:Event ;
-          cc:additionalType ?acquisitionType ;
-          cc:startDate ?acquisitionBeginOfTheBegin ;
-          cc:endDate ?acquisitionEndOfTheEnd ;
-          cc:transferredFrom ?acquisitionOwnerFrom ;
-          cc:transferredTo ?acquisitionOwnerTo ;
-          cc:description ?acquisitionDescription ;
-          cc:location ?acquisitionLocation ;
-          cc:startsAfter ?acquisitionStartsAfterTheEndOf ;
-          cc:endsBefore ?acquisitionEndsBeforeTheStartOf .
+        ?acquisition a ex:Event ;
+          ex:additionalType ?acquisitionType ;
+          ex:startDate ?acquisitionBeginOfTheBegin ;
+          ex:endDate ?acquisitionEndOfTheEnd ;
+          ex:transferredFrom ?acquisitionOwnerFrom ;
+          ex:transferredTo ?acquisitionOwnerTo ;
+          ex:description ?acquisitionDescription ;
+          ex:location ?acquisitionLocation ;
+          ex:startsAfter ?acquisitionStartsAfterTheEndOf ;
+          ex:endsBefore ?acquisitionEndsBeforeTheStartOf .
 
-        ?acquisitionType a cc:DefinedTerm ;
-          cc:name ?acquisitionTypeName .
+        ?acquisitionType a ex:DefinedTerm ;
+          ex:name ?acquisitionTypeName .
 
         ?acquisitionOwnerFrom a ?acquisitionOwnerFromType ;
-          cc:name ?acquisitionOwnerFromName .
+          ex:name ?acquisitionOwnerFromName .
 
         ?acquisitionOwnerTo a ?acquisitionOwnerToType ;
-          cc:name ?acquisitionOwnerToName .
+          ex:name ?acquisitionOwnerToName .
 
-        ?acquisitionLocation a cc:Place ;
-          cc:name ?acquisitionLocationName .
+        ?acquisitionLocation a ex:Place ;
+          ex:name ?acquisitionLocationName .
 
-        ?transferOfCustody a cc:Event ;
-          cc:additionalType ?transferOfCustodyType ;
-          cc:startDate ?transferOfCustodyBeginOfTheBegin ;
-          cc:endDate ?transferOfCustodyEndOfTheEnd ;
-          cc:transferredFrom ?transferOfCustodyCustodianFrom ;
-          cc:transferredTo ?transferOfCustodyCustodianTo ;
-          cc:description ?transferOfCustodyDescription ;
-          cc:location ?transferOfCustodyLocation ;
-          cc:startsAfter ?transferOfCustodyStartsAfterTheEndOf ;
-          cc:endsBefore ?transferOfCustodyEndsBeforeTheStartOf .
+        ?transferOfCustody a ex:Event ;
+          ex:additionalType ?transferOfCustodyType ;
+          ex:startDate ?transferOfCustodyBeginOfTheBegin ;
+          ex:endDate ?transferOfCustodyEndOfTheEnd ;
+          ex:transferredFrom ?transferOfCustodyCustodianFrom ;
+          ex:transferredTo ?transferOfCustodyCustodianTo ;
+          ex:description ?transferOfCustodyDescription ;
+          ex:location ?transferOfCustodyLocation ;
+          ex:startsAfter ?transferOfCustodyStartsAfterTheEndOf ;
+          ex:endsBefore ?transferOfCustodyEndsBeforeTheStartOf .
 
-        ?transferOfCustodyType a cc:DefinedTerm ;
-          cc:name ?transferOfCustodyTypeName .
+        ?transferOfCustodyType a ex:DefinedTerm ;
+          ex:name ?transferOfCustodyTypeName .
 
         ?transferOfCustodyCustodianFrom a ?transferOfCustodyCustodianFromType ;
-          cc:name ?transferOfCustodyCustodianFromName .
+          ex:name ?transferOfCustodyCustodianFromName .
 
         ?transferOfCustodyCustodianTo a ?transferOfCustodyCustodianToType ;
-          cc:name ?transferOfCustodyCustodianToName .
+          ex:name ?transferOfCustodyCustodianToName .
 
-        ?transferOfCustodyLocation a cc:Place ;
-          cc:name ?transferOfCustodyLocationName .
+        ?transferOfCustodyLocation a ex:Place ;
+          ex:name ?transferOfCustodyLocationName .
       }
       WHERE {
         BIND(<${iri}> AS ?object)
@@ -120,8 +120,8 @@ export class ProvenanceEventsFetcher {
               rdf:type ?acquisitionOwnerFromTypeTmp .
 
             VALUES (?acquisitionOwnerFromTypeTmp ?acquisitionOwnerFromType) {
-              (schema:Organization cc:Organization)
-              (crm:E21_Person cc:Person)
+              (schema:Organization ex:Organization)
+              (crm:E21_Person ex:Person)
               (UNDEF UNDEF)
             }
           }
@@ -136,8 +136,8 @@ export class ProvenanceEventsFetcher {
               rdf:type ?acquisitionOwnerToTypeTmp .
 
             VALUES (?acquisitionOwnerToTypeTmp ?acquisitionOwnerToType) {
-              (schema:Organization cc:Organization)
-              (crm:E21_Person cc:Person)
+              (schema:Organization ex:Organization)
+              (crm:E21_Person ex:Person)
               (UNDEF UNDEF)
             }
           }
@@ -227,8 +227,8 @@ export class ProvenanceEventsFetcher {
               rdf:type ?transferOfCustodyCustodianFromTypeTemp .
 
             VALUES (?transferOfCustodyCustodianFromTypeTemp ?transferOfCustodyCustodianFromType) {
-              (schema:Organization cc:Organization)
-              (crm:E21_Person cc:Person)
+              (schema:Organization ex:Organization)
+              (crm:E21_Person ex:Person)
               (UNDEF UNDEF)
             }
           }
@@ -243,8 +243,8 @@ export class ProvenanceEventsFetcher {
               rdf:type ?transferOfCustodyCustodianToTypeTemp .
 
             VALUES (?transferOfCustodyCustodianToTypeTemp ?transferOfCustodyCustodianToType) {
-              (schema:Organization cc:Organization)
-              (crm:E21_Person cc:Person)
+              (schema:Organization ex:Organization)
+              (crm:E21_Person ex:Person)
               (UNDEF UNDEF)
             }
           }
@@ -309,36 +309,34 @@ export class ProvenanceEventsFetcher {
 
   private toProvenanceEvent(rawProvenanceEvent: Resource) {
     const id = rawProvenanceEvent.value;
-    const startDate = getPropertyValue(rawProvenanceEvent, 'cc:startDate');
-    const endDate = getPropertyValue(rawProvenanceEvent, 'cc:endDate');
-    const description = getPropertyValue(rawProvenanceEvent, 'cc:description');
-    const startsAfter = getPropertyValue(rawProvenanceEvent, 'cc:startsAfter');
-    const endsBefore = getPropertyValue(rawProvenanceEvent, 'cc:endsBefore');
-    const types = createThings<Term>(rawProvenanceEvent, 'cc:additionalType');
-    const location = onlyOne(
-      createThings<Place>(rawProvenanceEvent, 'cc:location')
-    );
+    const startDate = getPropertyValue(rawProvenanceEvent, 'ex:startDate');
+    const endDate = getPropertyValue(rawProvenanceEvent, 'ex:endDate');
+    const description = getPropertyValue(rawProvenanceEvent, 'ex:description');
+    const startsAfter = getPropertyValue(rawProvenanceEvent, 'ex:startsAfter');
+    const endsBefore = getPropertyValue(rawProvenanceEvent, 'ex:endsBefore');
+    const types = createThings<Term>(rawProvenanceEvent, 'ex:additionalType');
+    const location = onlyOne(createPlaces(rawProvenanceEvent, 'ex:location'));
     const transferredFromAgent = onlyOne(
-      createAgents(rawProvenanceEvent, 'cc:transferredFrom')
+      createAgents(rawProvenanceEvent, 'ex:transferredFrom')
     );
     const transferredToAgent = onlyOne(
-      createAgents(rawProvenanceEvent, 'cc:transferredTo')
+      createAgents(rawProvenanceEvent, 'ex:transferredTo')
     );
 
     const provenanceEventWithUndefinedValues: ProvenanceEvent = {
       id,
       types,
-      description: description !== undefined ? description : undefined,
+      description,
       startDate: startDate !== undefined ? new Date(startDate) : undefined,
       endDate: endDate !== undefined ? new Date(endDate) : undefined,
-      startsAfter: startsAfter !== undefined ? startsAfter : undefined,
-      endsBefore: endsBefore !== undefined ? endsBefore : undefined,
-      location: location !== undefined ? location : undefined,
+      startsAfter,
+      endsBefore,
+      location,
       transferredFrom: transferredFromAgent,
       transferredTo: transferredToAgent,
     };
 
-    const provenanceEvent = removeUndefinedValues<ProvenanceEvent>(
+    const provenanceEvent = removeNullish<ProvenanceEvent>(
       provenanceEventWithUndefinedValues
     );
 
@@ -351,7 +349,7 @@ export class ProvenanceEventsFetcher {
   ) {
     const loader = new RdfObjectLoader({
       context: {
-        cc: ontologyUrl,
+        ex: 'https://example.org/',
         rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
       },
     });
@@ -363,7 +361,7 @@ export class ProvenanceEventsFetcher {
       return undefined; // No such object
     }
 
-    const rawProvenanceEvents = rawHeritageObject.properties['cc:subjectOf'];
+    const rawProvenanceEvents = rawHeritageObject.properties['ex:subjectOf'];
     const provenanceEvents = rawProvenanceEvents.map(rawProvenanceEvent =>
       this.toProvenanceEvent(rawProvenanceEvent)
     );

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -1,8 +1,8 @@
-import {ontologyUrl} from '../definitions';
 import {
   createAgents,
   createDatasets,
   createImages,
+  createPlaces,
   createThings,
   createTimeSpans,
 } from './rdf-helpers';
@@ -13,7 +13,7 @@ import {StreamParser} from 'n3';
 
 const loader = new RdfObjectLoader({
   context: {
-    cc: ontologyUrl,
+    ex: 'https://example.org/',
     rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   },
 });
@@ -21,70 +21,80 @@ let resource: Resource;
 
 beforeAll(async () => {
   const triples = `
-    @prefix cc: <${ontologyUrl}> .
     @prefix ex: <https://example.org/> .
     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-    ex:object1 a cc:Object ;
-      cc:name "Name" ;
-      cc:subject ex:subject1, ex:subject2 ;
-      cc:creator ex:creator1, ex:creator2, ex:creator3, ex:creator4 ;
-      cc:image ex:image1, ex:image2, ex:image3 ;
-      cc:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 ;
-      cc:isPartOf ex:dataset1, ex:dataset2, ex:dataset3 .
+    ex:object1 a ex:Object ;
+      ex:name "Name" ;
+      ex:subject ex:subject1, ex:subject2 ;
+      ex:creator ex:creator1, ex:creator2, ex:creator3, ex:creator4 ;
+      ex:image ex:image1, ex:image2, ex:image3 ;
+      ex:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 ;
+      ex:locationCreated ex:location1, ex:location2 ;
+      ex:isPartOf ex:dataset1, ex:dataset2, ex:dataset3 .
 
-    ex:subject1 a cc:Term ;
-      cc:name "Term" .
+    ex:subject1 a ex:Term ;
+      ex:name "Term" .
 
-    ex:subject2 a cc:Term .
+    ex:subject2 a ex:Term .
 
-    ex:creator1 a cc:Person ;
-      cc:name "Person" .
+    ex:creator1 a ex:Person ;
+      ex:name "Person" .
 
-    ex:creator2 a cc:Organization ;
-      cc:name "Organization" .
+    ex:creator2 a ex:Organization ;
+      ex:name "Organization" .
 
-    ex:creator3 a cc:Organization .
+    ex:creator3 a ex:Organization .
 
-    ex:creator4 cc:name "Organization" .
+    ex:creator4 ex:name "Organization" .
 
-    ex:image1 a cc:Image ;
-      cc:contentUrl <https://example.org/image1.jpg> .
+    ex:image1 a ex:Image ;
+      ex:contentUrl <https://example.org/image1.jpg> .
 
-    ex:image2 a cc:Image ;
-      cc:contentUrl <https://example.org/image2.jpg> .
+    ex:image2 a ex:Image ;
+      ex:contentUrl <https://example.org/image2.jpg> .
 
-    ex:image3 a cc:Image .
+    ex:image3 a ex:Image .
 
-    ex:dateCreated1 a cc:TimeSpan ;
-      cc:startDate "1889"^^xsd:gYear ;
-      cc:endDate "1900"^^xsd:gYear .
+    ex:dateCreated1 a ex:TimeSpan ;
+      ex:startDate "1889"^^xsd:gYear ;
+      ex:endDate "1900"^^xsd:gYear .
 
     # No end date
-    ex:dateCreated2 a cc:TimeSpan ;
-      cc:startDate "1889"^^xsd:gYear .
+    ex:dateCreated2 a ex:TimeSpan ;
+      ex:startDate "1889"^^xsd:gYear .
 
     # No start date
-    ex:dateCreated3 a cc:TimeSpan ;
-      cc:endDate "1900"^^xsd:gYear .
+    ex:dateCreated3 a ex:TimeSpan ;
+      ex:endDate "1900"^^xsd:gYear .
 
-    ex:dataset1 a cc:Dataset ;
-      cc:name "Dataset 1" ;
-      cc:publisher ex:publisher1 .
+    ex:location1 a ex:Place ;
+      ex:name "City 1" .
 
-    ex:publisher1 a cc:Organization ;
-      cc:name "Publishing organization" .
+    ex:location2 a ex:Place ;
+      ex:name "City 2" ;
+      ex:isPartOf ex:location3 .
 
-    ex:dataset2 a cc:Dataset ;
-      cc:name "Dataset 2" ;
-      cc:publisher ex:publisher2 .
+    ex:location3 a ex:Place ;
+      ex:name "Country" .
 
-    ex:publisher2 a cc:Person ;
-      cc:name "Publishing person" .
+    ex:dataset1 a ex:Dataset ;
+      ex:name "Dataset 1" ;
+      ex:publisher ex:publisher1 .
+
+    ex:publisher1 a ex:Organization ;
+      ex:name "Publishing organization" .
+
+    ex:dataset2 a ex:Dataset ;
+      ex:name "Dataset 2" ;
+      ex:publisher ex:publisher2 .
+
+    ex:publisher2 a ex:Person ;
+      ex:name "Publishing person" .
 
     # No publisher
-    ex:dataset3 a cc:Dataset ;
-      cc:name "Dataset 3" .
+    ex:dataset3 a ex:Dataset ;
+      ex:name "Dataset 3" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -96,13 +106,13 @@ beforeAll(async () => {
 
 describe('createThings', () => {
   it('returns undefined if properties do not exist', () => {
-    const things = createThings(resource, 'cc:unknown');
+    const things = createThings(resource, 'ex:unknown');
 
     expect(things).toBeUndefined();
   });
 
   it('returns things if properties exist', () => {
-    const things = createThings(resource, 'cc:subject');
+    const things = createThings(resource, 'ex:subject');
 
     expect(things).toStrictEqual([
       {id: 'https://example.org/subject1', name: 'Term'},
@@ -113,13 +123,13 @@ describe('createThings', () => {
 
 describe('createAgents', () => {
   it('returns undefined if properties do not exist', () => {
-    const agents = createAgents(resource, 'cc:unknown');
+    const agents = createAgents(resource, 'ex:unknown');
 
     expect(agents).toBeUndefined();
   });
 
   it('returns agents if properties exist', () => {
-    const agents = createAgents(resource, 'cc:creator');
+    const agents = createAgents(resource, 'ex:creator');
 
     expect(agents).toStrictEqual([
       {type: 'Person', id: 'https://example.org/creator1', name: 'Person'},
@@ -142,15 +152,42 @@ describe('createAgents', () => {
   });
 });
 
+describe('createPlaces', () => {
+  it('returns undefined if properties do not exist', () => {
+    const places = createPlaces(resource, 'ex:unknown');
+
+    expect(places).toBeUndefined();
+  });
+
+  it('returns places if properties exist', () => {
+    const places = createPlaces(resource, 'ex:locationCreated');
+
+    expect(places).toStrictEqual([
+      {
+        id: 'https://example.org/location1',
+        name: 'City 1',
+      },
+      {
+        id: 'https://example.org/location2',
+        name: 'City 2',
+        isPartOf: {
+          id: 'https://example.org/location3',
+          name: 'Country',
+        },
+      },
+    ]);
+  });
+});
+
 describe('createImages', () => {
   it('returns undefined if properties do not exist', () => {
-    const images = createImages(resource, 'cc:unknown');
+    const images = createImages(resource, 'ex:unknown');
 
     expect(images).toBeUndefined();
   });
 
   it('returns images if properties exist', () => {
-    const images = createImages(resource, 'cc:image');
+    const images = createImages(resource, 'ex:image');
 
     expect(images).toStrictEqual([
       {
@@ -168,13 +205,13 @@ describe('createImages', () => {
 
 describe('createTimeSpan', () => {
   it('returns undefined if properties do not exist', () => {
-    const timeSpans = createTimeSpans(resource, 'cc:unknown');
+    const timeSpans = createTimeSpans(resource, 'ex:unknown');
 
     expect(timeSpans).toBeUndefined();
   });
 
   it('returns time spans if properties exist', () => {
-    const timeSpans = createTimeSpans(resource, 'cc:dateCreated');
+    const timeSpans = createTimeSpans(resource, 'ex:dateCreated');
 
     expect(timeSpans).toStrictEqual([
       {
@@ -198,13 +235,13 @@ describe('createTimeSpan', () => {
 
 describe('createDataset', () => {
   it('returns undefined if properties do not exist', () => {
-    const datasets = createDatasets(resource, 'cc:unknown');
+    const datasets = createDatasets(resource, 'ex:unknown');
 
     expect(datasets).toBeUndefined();
   });
 
   it('returns datasets if properties exist', () => {
-    const datasets = createDatasets(resource, 'cc:isPartOf');
+    const datasets = createDatasets(resource, 'ex:isPartOf');
 
     expect(datasets).toStrictEqual([
       {

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -12,7 +12,7 @@ import {
   Term,
 } from '../definitions';
 import {SearchResult} from './definitions';
-import {removeUndefinedValues} from '../rdf-helpers';
+import {removeNullish} from '../rdf-helpers';
 import {reach} from '@hapi/hoek';
 import {z} from 'zod';
 
@@ -248,7 +248,7 @@ export class HeritageObjectSearcher {
       isPartOf: dataset,
     };
 
-    const heritageObject = removeUndefinedValues<HeritageObject>(
+    const heritageObject = removeNullish<HeritageObject>(
       heritageObjectWithUndefinedValues
     );
 

--- a/apps/researcher/src/lib/api/organizations/fetcher.ts
+++ b/apps/researcher/src/lib/api/organizations/fetcher.ts
@@ -1,5 +1,5 @@
-import {ontologyUrl, Organization} from '../definitions';
-import {onlyOne, removeUndefinedValues} from '../rdf-helpers';
+import {Organization} from '../definitions';
+import {onlyOne, removeNullish} from '../rdf-helpers';
 import {createAddresses} from './rdf-helpers';
 import {getPropertyValue} from '../rdf-helpers';
 import {SparqlEndpointFetcher} from 'fetch-sparql-endpoint';
@@ -27,20 +27,20 @@ export class OrganizationFetcher {
 
   private async fetchTriples(iri: string) {
     const query = `
-      PREFIX cc: <${ontologyUrl}>
+      PREFIX ex: <https://example.org/>
       PREFIX schema: <https://schema.org/>
 
       CONSTRUCT {
-        ?organization a cc:Organization ;
-          cc:name ?name ;
-          cc:url ?url ;
-          cc:address ?address .
+        ?organization a ex:Organization ;
+          ex:name ?name ;
+          ex:url ?url ;
+          ex:address ?address .
 
-        ?address a cc:PostalAddress ;
-          cc:streetAddress ?streetAddress ;
-          cc:postalCode ?postalCode ;
-          cc:addressLocality ?addressLocality ;
-          cc:addressCountry ?addressCountry .
+        ?address a ex:PostalAddress ;
+          ex:streetAddress ?streetAddress ;
+          ex:postalCode ?postalCode ;
+          ex:addressLocality ?addressLocality ;
+          ex:addressCountry ?addressCountry .
       }
       WHERE {
         BIND(<${iri}> as ?organization)
@@ -76,7 +76,7 @@ export class OrganizationFetcher {
   ) {
     const loader = new RdfObjectLoader({
       context: {
-        cc: ontologyUrl,
+        ex: 'https://example.org/',
         rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
       },
     });
@@ -88,9 +88,9 @@ export class OrganizationFetcher {
       return undefined; // No such organization
     }
 
-    const name = getPropertyValue(rawOrganization, 'cc:name');
-    const url = getPropertyValue(rawOrganization, 'cc:url');
-    const address = onlyOne(createAddresses(rawOrganization, 'cc:address'));
+    const name = getPropertyValue(rawOrganization, 'ex:name');
+    const url = getPropertyValue(rawOrganization, 'ex:url');
+    const address = onlyOne(createAddresses(rawOrganization, 'ex:address'));
 
     const organizationWithUndefinedValues: Organization = {
       type: 'Organization',
@@ -100,7 +100,7 @@ export class OrganizationFetcher {
       address,
     };
 
-    const organization = removeUndefinedValues<Organization>(
+    const organization = removeNullish<Organization>(
       organizationWithUndefinedValues
     );
 

--- a/apps/researcher/src/lib/api/organizations/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/organizations/rdf-helpers.test.ts
@@ -1,4 +1,3 @@
-import {ontologyUrl} from '../definitions';
 import {createAddresses} from './rdf-helpers';
 import {describe, expect, it} from '@jest/globals';
 import {RdfObjectLoader, Resource} from 'rdf-object';
@@ -7,7 +6,7 @@ import {StreamParser} from 'n3';
 
 const loader = new RdfObjectLoader({
   context: {
-    cc: ontologyUrl,
+    ex: 'https://example.org/',
     rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   },
 });
@@ -15,24 +14,23 @@ let resource: Resource;
 
 beforeAll(async () => {
   const triples = `
-    @prefix cc: <${ontologyUrl}> .
     @prefix ex: <https://example.org/> .
 
-    ex:organization1 a cc:Organization ;
-      cc:name "Name" ;
-      cc:url <https://example.org/> ;
-      cc:address [
-        a cc:PostalAddress ;
-        cc:streetAddress "Street 1" ;
-        cc:postalCode "Postal code 1" ;
-        cc:addressLocality "Locality 1" ;
-        cc:addressCountry "Country 1"
+    ex:organization1 a ex:Organization ;
+      ex:name "Name" ;
+      ex:url <https://example.org/> ;
+      ex:address [
+        a ex:PostalAddress ;
+        ex:streetAddress "Street 1" ;
+        ex:postalCode "Postal code 1" ;
+        ex:addressLocality "Locality 1" ;
+        ex:addressCountry "Country 1"
       ], [
-        a cc:PostalAddress ;
-        cc:streetAddress "Street 2" ;
-        cc:postalCode "Postal code 2" ;
-        cc:addressLocality "Locality 2" ;
-        cc:addressCountry "Country 2"
+        a ex:PostalAddress ;
+        ex:streetAddress "Street 2" ;
+        ex:postalCode "Postal code 2" ;
+        ex:addressLocality "Locality 2" ;
+        ex:addressCountry "Country 2"
       ] .
   `;
 
@@ -45,13 +43,13 @@ beforeAll(async () => {
 
 describe('createAddresses', () => {
   it('returns undefined if property does not exist', () => {
-    const addresses = createAddresses(resource, 'cc:unknown');
+    const addresses = createAddresses(resource, 'ex:unknown');
 
     expect(addresses).toBeUndefined();
   });
 
   it('returns addresses if property exists', () => {
-    const addresses = createAddresses(resource, 'cc:address');
+    const addresses = createAddresses(resource, 'ex:address');
 
     expect(addresses).toStrictEqual([
       {

--- a/apps/researcher/src/lib/api/organizations/rdf-helpers.ts
+++ b/apps/researcher/src/lib/api/organizations/rdf-helpers.ts
@@ -6,10 +6,10 @@ function createAddress(addressResource: Resource) {
   // Ignore TS 'undefined' warnings - the properties always exist
   const postalAddress: PostalAddress = {
     id: addressResource.value,
-    streetAddress: getPropertyValue(addressResource, 'cc:streetAddress')!,
-    postalCode: getPropertyValue(addressResource, 'cc:postalCode')!,
-    addressLocality: getPropertyValue(addressResource, 'cc:addressLocality')!,
-    addressCountry: getPropertyValue(addressResource, 'cc:addressCountry')!,
+    streetAddress: getPropertyValue(addressResource, 'ex:streetAddress')!,
+    postalCode: getPropertyValue(addressResource, 'ex:postalCode')!,
+    addressLocality: getPropertyValue(addressResource, 'ex:addressLocality')!,
+    addressCountry: getPropertyValue(addressResource, 'ex:addressCountry')!,
   };
 
   return postalAddress;

--- a/apps/researcher/src/lib/api/rdf-helpers.ts
+++ b/apps/researcher/src/lib/api/rdf-helpers.ts
@@ -1,4 +1,4 @@
-import {applyToDefaults} from '@hapi/hoek';
+import {defu} from 'defu';
 import type {Resource} from 'rdf-object';
 
 export function getProperty(resource: Resource, propertyName: string) {
@@ -33,10 +33,8 @@ export function onlyOne<T>(items: T[] | undefined) {
   return undefined;
 }
 
-export function removeUndefinedValues<T>(objectWithUndefinedValues: object) {
-  const object = applyToDefaults({}, objectWithUndefinedValues, {
-    nullOverride: false, // Ignore null values
-  });
+export function removeNullish<T>(objectWithNullishValues: object) {
+  const object = defu(objectWithNullishValues, {});
 
   return object as T;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "@hookform/resolvers": "3.3.2",
         "@next/mdx": "14.0.1",
         "classnames": "2.3.2",
+        "defu": "6.1.3",
         "fetch-sparql-endpoint": "4.1.0",
         "iso-639-1-dir": "3.0.5",
         "jwt-decode": "^4.0.0",


### PR DESCRIPTION
This PR adds the location of creation to an heritage object [1]. The location is currently only visible on the search page, in a facet, not on the detail page of an object. The data structure looks like this:

```json
{
  "id": "http://...",
  "locationCreated": {
    "id": "http://...",
    "name": "Jakarta",
    "isPartOf": { // Optional - may not exist (e.g. if the location above is a country)
      "id": "http://...",
      "name": "Indonesia",
    }
  }
}
```

This PR is rather large: it also updates the unit tests and brings the backend APIs in the `researcher` more in line with the backend API of the `dataset-browser`. All changes should be backward-compatible, though.

[1] https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=43426571