### PR TITLE
fix: IDs of prov events

### DIFF
--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -45,101 +45,6 @@ describe('getByHeritageObjectId', () => {
     expect(provenanceEvents).toEqual(
       expect.arrayContaining([
         {
-          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
-            {
-              id: 'http://vocab.getty.edu/aat/300417644',
-              name: 'transfer (method of acquisition)',
-            },
-          ],
-          description: 'Bought for 1500 US dollars',
-          startDate: new Date('1855-01-01T00:00:00.000Z'),
-          endDate: new Date('1857-01-01T00:00:00.000Z'),
-          endsBefore: 'https://example.org/objects/1/provenance/event/2',
-          location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            name: 'Jakarta',
-          },
-          transferredFrom: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            type: 'Person',
-            name: 'Peter Hoekstra',
-          },
-          transferredTo: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            type: 'Person',
-            name: 'Jan de Vries',
-          },
-        },
-        {
-          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300055292',
-              name: 'theft (social issue)',
-            },
-          ],
-          startDate: new Date('1901-01-01T00:00:00.000Z'),
-          endDate: new Date('1901-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/5',
-          endsBefore: 'https://example.org/objects/1/provenance/event/4',
-          location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            name: 'Amsterdam',
-          },
-          transferredFrom: {
-            id: 'https://museum.example.org/',
-            type: 'Organization',
-            name: 'Museum',
-          },
-        },
-        {
-          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
-          ],
-          description: 'Bought at an auction in The Hague',
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/1',
-          endsBefore: 'https://example.org/objects/1/provenance/event/5',
-          location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            name: 'The Hague',
-          },
-          transferredFrom: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            type: 'Person',
-            name: 'Jan de Vries',
-          },
-          transferredTo: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
-            type: 'Person',
-            name: 'Jonathan Hansen',
-          },
-        },
-        {
           id: 'https://example.org/objects/1/provenance/event/5/activity/1',
           types: [
             {
@@ -150,18 +55,16 @@ describe('getByHeritageObjectId', () => {
           description: 'Bought at an auction in Amsterdam',
           startDate: new Date('1879-01-01T00:00:00.000Z'),
           endDate: new Date('1879-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/1',
-          endsBefore: 'https://example.org/objects/1/provenance/event/3',
+          startsAfter:
+            'https://example.org/objects/1/provenance/event/2/activity/1',
+          endsBefore:
+            'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/9cb5c59b958f4878937957c423d308b5',
             name: 'Amsterdam',
           },
           transferredFrom: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/c08aa36cf775e23c92dd2430c1bbb99b',
             type: 'Person',
             name: 'Jonathan Hansen',
           },
@@ -182,17 +85,102 @@ describe('getByHeritageObjectId', () => {
           description: 'Found in a basement',
           startDate: new Date('1939-01-01T00:00:00.000Z'),
           endDate: new Date('1940-01-01T00:00:00.000Z'),
-          startsAfter: 'https://example.org/objects/1/provenance/event/3',
+          startsAfter:
+            'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
-            id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
-            ),
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/fa56164b9dd96e37a4e93e018c51018e',
             name: 'Paris',
           },
           transferredTo: {
             id: 'https://museum.example.org/',
             type: 'Organization',
             name: 'Museum',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300055292',
+              name: 'theft (social issue)',
+            },
+          ],
+          startDate: new Date('1901-01-01T00:00:00.000Z'),
+          endDate: new Date('1901-01-01T00:00:00.000Z'),
+          startsAfter:
+            'https://example.org/objects/1/provenance/event/5/activity/1',
+          endsBefore:
+            'https://example.org/objects/1/provenance/event/4/activity/1',
+          location: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/cd7ccc86fb7b17d1fb0bf425de63c796',
+            name: 'Amsterdam',
+          },
+          transferredFrom: {
+            id: 'https://museum.example.org/',
+            type: 'Organization',
+            name: 'Museum',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ],
+          description: 'Bought at an auction in The Hague',
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startsAfter:
+            'https://example.org/objects/1/provenance/event/1/activity/1',
+          endsBefore:
+            'https://example.org/objects/1/provenance/event/5/activity/1',
+          location: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/522af0fad56ad754c58f48768e06bb58',
+            name: 'The Hague',
+          },
+          transferredFrom: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/552102cb8b424cc0d8b49e59b6a990df',
+            type: 'Person',
+            name: 'Jan de Vries',
+          },
+          transferredTo: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/c581b92d73922421a4b688595e0000be',
+            type: 'Person',
+            name: 'Jonathan Hansen',
+          },
+        },
+        {
+          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300417644',
+              name: 'transfer (method of acquisition)',
+            },
+          ],
+          description: 'Bought for 1500 US dollars',
+          startDate: new Date('1855-01-01T00:00:00.000Z'),
+          endDate: new Date('1857-01-01T00:00:00.000Z'),
+          endsBefore:
+            'https://example.org/objects/1/provenance/event/2/activity/1',
+          location: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/2b434a4d7ed20396b17ba591079edc09',
+            name: 'Jakarta',
+          },
+          transferredFrom: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/32d1c530bc7643fcf73a5f4e9fc18594',
+            type: 'Person',
+            name: 'Peter Hoekstra',
+          },
+          transferredTo: {
+            id: 'https://colonial-heritage.triply.cc/.well-known/genid/f639c45571fe3eef8752501d0ca96720',
+            type: 'Person',
+            name: 'Jan de Vries',
           },
         },
       ])

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.ts
@@ -150,7 +150,6 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?acquisitionProvEvent crm:P4_has_time-span/crm:P82a_begin_of_the_begin ?acquisitionBeginOfTheBegin .
-            # TBD: add a FILTER() to remove invalid dates?
           }
 
           ####################
@@ -159,7 +158,6 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?acquisitionProvEvent crm:P4_has_time-span/crm:P82b_end_of_the_end ?acquisitionEndOfTheEnd .
-            # TBD: add a FILTER() to remove invalid dates?
           }
 
           ####################
@@ -187,11 +185,13 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?acquisitionProvEvent crm:P183i_starts_after_the_end_of ?acquisitionStartsAfterTheEndOf ;
+            ?acquisitionProvEvent crm:P183i_starts_after_the_end_of ?acquisitionProvEventStartsAfterTheEndOf .
+            ?acquisitionProvEventStartsAfterTheEndOf crm:P9_consists_of ?acquisitionStartsAfterTheEndOf .
           }
 
           OPTIONAL {
-            ?acquisitionProvEvent crm:P183_ends_before_the_start_of ?acquisitionEndsBeforeTheStartOf ;
+            ?acquisitionProvEvent crm:P183_ends_before_the_start_of ?acquisitionProvEventEndsBeforeTheStartOf .
+            ?acquisitionProvEventEndsBeforeTheStartOf crm:P9_consists_of ?acquisitionEndsBeforeTheStartOf .
           }
         }
 
@@ -257,7 +257,6 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?transferOfCustodyProvEvent crm:P4_has_time-span/crm:P82a_begin_of_the_begin ?transferOfCustodyBeginOfTheBegin .
-            # TBD: add a FILTER() to remove invalid dates?
           }
 
           ####################
@@ -266,7 +265,6 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?transferOfCustodyProvEvent crm:P4_has_time-span/crm:P82b_end_of_the_end ?transferOfCustodyEndOfTheEnd .
-            # TBD: add a FILTER() to remove invalid dates?
           }
 
           ####################
@@ -294,11 +292,13 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P183i_starts_after_the_end_of ?transferOfCustodyStartsAfterTheEndOf ;
+            ?transferOfCustodyProvEvent crm:P183i_starts_after_the_end_of ?transferOfCustodyProvEventStartsAfterTheEndOf .
+            ?transferOfCustodyProvEventStartsAfterTheEndOf crm:P9_consists_of ?transferOfCustodyStartsAfterTheEndOf .
           }
 
           OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P183_ends_before_the_start_of ?transferOfCustodyEndsBeforeTheStartOf ;
+            ?transferOfCustodyProvEvent crm:P183_ends_before_the_start_of ?transferOfCustodyProvEventEndsBeforeTheStartOf .
+            ?transferOfCustodyProvEventEndsBeforeTheStartOf crm:P9_consists_of ?transferOfCustodyEndsBeforeTheStartOf .
           }
         }
       }


### PR DESCRIPTION
This PR fixes the IDs that were used in the provenance events: the code previously used IDs of the parent events of provenance events, not the IDs of the actual events. This made the coherence of provenance events strange.