### PR TITLE
feat: enricher update

### DIFF
--- a/packages/enricher/src/definitions.ts
+++ b/packages/enricher/src/definitions.ts
@@ -10,6 +10,7 @@ export const ontologyVersionIdentifier = 'Version1';
 export enum AdditionalType {
   Creator = 'creator',
   DateCreated = 'dateCreated',
+  LocationCreated = 'locationCreated',
   Description = 'description',
   Inscription = 'inscription',
   Material = 'material',

--- a/packages/enricher/src/fetcher.ts
+++ b/packages/enricher/src/fetcher.ts
@@ -32,6 +32,7 @@ export class EnrichmentFetcher {
       PREFIX cc: <${ontologyUrl}>
       PREFIX dc: <http://purl.org/dc/elements/1.1/>
       PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX ex: <https://example.org/>
       PREFIX oa: <http://www.w3.org/ns/oa#>
       PREFIX np: <http://www.nanopub.org/nschema#>
       PREFIX npa: <http://purl.org/nanopub/admin/>
@@ -42,21 +43,21 @@ export class EnrichmentFetcher {
 
       CONSTRUCT {
         # Need this to easily retrieve the enrichments in the RdfObjectLoader
-        ?source cc:hasEnrichment ?annotation .
+        ?source ex:hasEnrichment ?annotation .
 
-        ?annotation a cc:Enrichment ;
-          cc:additionalType ?additionalType ;
-          cc:about ?target ;
-          cc:isPartOf ?source ;
-          cc:description ?value ;
-          cc:citation ?comment ;
-          cc:inLanguage ?language ;
-          cc:license ?license ;
-          cc:creator ?creator ;
-          cc:dateCreated ?dateCreated .
+        ?annotation a ex:Enrichment ;
+          ex:additionalType ?additionalType ;
+          ex:about ?target ;
+          ex:isPartOf ?source ;
+          ex:description ?value ;
+          ex:citation ?comment ;
+          ex:inLanguage ?language ;
+          ex:license ?license ;
+          ex:creator ?creator ;
+          ex:dateCreated ?dateCreated .
 
-        ?creator a cc:Agent ;
-          cc:name ?creatorName .
+        ?creator a ex:Agent ;
+          ex:name ?creatorName .
       }
       WHERE {
         BIND(<${iri}> AS ?source)
@@ -110,6 +111,7 @@ export class EnrichmentFetcher {
     const loader = new RdfObjectLoader({
       context: {
         cc: ontologyUrl,
+        ex: 'https://example.org/',
       },
     });
 
@@ -120,7 +122,7 @@ export class EnrichmentFetcher {
       return []; // No enrichments found about the requested resource
     }
 
-    const rawEnrichments = resource.properties['cc:hasEnrichment'];
+    const rawEnrichments = resource.properties['ex:hasEnrichment'];
     const enrichments = rawEnrichments.map(rawEnrichment =>
       createEnrichment(rawEnrichment)
     );

--- a/packages/enricher/src/helpers.ts
+++ b/packages/enricher/src/helpers.ts
@@ -42,18 +42,18 @@ function getPropertyValue(resource: Resource, propertyName: string) {
 }
 
 export function createEnrichment(rawEnrichment: Resource) {
-  const additionalType = getPropertyValue(rawEnrichment, 'cc:additionalType');
-  const isPartOf = getPropertyValue(rawEnrichment, 'cc:isPartOf');
-  const description = getPropertyValue(rawEnrichment, 'cc:description');
-  const citation = getPropertyValue(rawEnrichment, 'cc:citation');
-  const inLanguage = getPropertyValue(rawEnrichment, 'cc:inLanguage');
-  const creator = getPropertyValue(rawEnrichment, 'cc:creator');
-  const license = getPropertyValue(rawEnrichment, 'cc:license');
+  const additionalType = getPropertyValue(rawEnrichment, 'ex:additionalType');
+  const isPartOf = getPropertyValue(rawEnrichment, 'ex:isPartOf');
+  const description = getPropertyValue(rawEnrichment, 'ex:description');
+  const citation = getPropertyValue(rawEnrichment, 'ex:citation');
+  const inLanguage = getPropertyValue(rawEnrichment, 'ex:inLanguage');
+  const creator = getPropertyValue(rawEnrichment, 'ex:creator');
+  const license = getPropertyValue(rawEnrichment, 'ex:license');
 
-  const creatorResource = rawEnrichment.property['cc:creator'];
-  const creatorName = getPropertyValue(creatorResource, 'cc:name');
+  const creatorResource = rawEnrichment.property['ex:creator'];
+  const creatorName = getPropertyValue(creatorResource, 'ex:name');
 
-  const rawDateCreated = getPropertyValue(rawEnrichment, 'cc:dateCreated');
+  const rawDateCreated = getPropertyValue(rawEnrichment, 'ex:dateCreated');
   // @ts-expect-error:TS2322
   const dateCreated = new Date(rawDateCreated);
 

--- a/packages/enricher/src/storer.ts
+++ b/packages/enricher/src/storer.ts
@@ -42,7 +42,7 @@ export class EnrichmentStorer {
     const languageCode = opts.inLanguage;
 
     // Make clear what application has published this nanopub
-    const softwareTool = DF.namedNode('https://app.collonialcollections.nl/');
+    const softwareTool = DF.namedNode('https://app.colonialcollections.nl/');
     publicationStore.addQuad(
       DF.quad(
         softwareTool,

--- a/packages/enricher/src/storer.ts
+++ b/packages/enricher/src/storer.ts
@@ -41,6 +41,23 @@ export class EnrichmentStorer {
     const bodyId = DF.blankNode();
     const languageCode = opts.inLanguage;
 
+    // Make clear what application has published this nanopub
+    const softwareTool = DF.namedNode('https://app.collonialcollections.nl/');
+    publicationStore.addQuad(
+      DF.quad(
+        softwareTool,
+        DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        DF.namedNode('http://purl.org/nanopub/x/SoftwareTool')
+      )
+    );
+    publicationStore.addQuad(
+      DF.quad(
+        softwareTool,
+        DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+        DF.literal('Colonial Collections')
+      )
+    );
+
     publicationStore.addQuad(
       DF.quad(
         nanopubId,
@@ -60,6 +77,13 @@ export class EnrichmentStorer {
         nanopubId,
         DF.namedNode('http://purl.org/dc/terms/license'),
         DF.namedNode(opts.license)
+      )
+    );
+    publicationStore.addQuad(
+      DF.quad(
+        nanopubId,
+        DF.namedNode('http://purl.org/nanopub/x/wasCreatedWith'),
+        softwareTool
       )
     );
 


### PR DESCRIPTION
This PR updates the `enricher` package:

1. It refactors the internal model a bit
2. The software tool that has created an enrichment is now being stored - in this case: the app on https://app.colonialcollections.nl/ - to make the provenance of the enrichment clearer
3. It allows for creating enrichments about the 'location of creation' (fixing [#271](https://github.com/orgs/colonial-heritage/projects/1?pane=issue&itemId=47568481))