### PR TITLE
feat: add license of image to API

### DIFF
--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -12,6 +12,7 @@ export type Place = Thing & {isPartOf?: Place};
 export type Person = Thing & {type: 'Person'};
 export type Unknown = Thing & {type: 'Unknown'};
 export type Agent = Person | Organization | Unknown;
+export type License = Thing;
 
 export type Dataset = Thing & {
   publisher?: Agent;
@@ -34,6 +35,7 @@ export type Organization = Thing & {
 export type Image = {
   id: string;
   contentUrl: string;
+  license?: License;
 };
 
 export type TimeSpan = {

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -106,6 +106,10 @@ describe('getById', () => {
           ),
           contentUrl:
             'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
+          license: {
+            id: 'https://creativecommons.org/licenses/by/4.0/',
+            name: 'Attribution 4.0 International (CC BY 4.0)',
+          },
         },
         {
           id: expect.stringContaining(
@@ -113,6 +117,10 @@ describe('getById', () => {
           ),
           contentUrl:
             'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+          license: {
+            id: 'https://creativecommons.org/publicdomain/zero/1.0/',
+            name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
+          },
         },
       ]),
       owner: {

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -92,7 +92,11 @@ export class HeritageObjectFetcher {
           ex:name ?countryCreatedName .
 
         ?digitalObject a ex:ImageObject ;
-          ex:contentUrl ?contentUrl .
+          ex:contentUrl ?digitalObjectContentUrl ;
+          ex:license ?digitalObjectLicense .
+
+        ?digitalObjectLicense a ex:DigitalDocument ;
+          ex:name ?digitalObjectLicenseName .
 
         ?owner a ?ownerType ;
           ex:name ?ownerName .
@@ -247,7 +251,18 @@ export class HeritageObjectFetcher {
           ?object crm:P65_shows_visual_item/la:digitally_shown_by ?digitalObject .
           ?digitalObject a dig:D1_Digital_Object ;
             crm:P2_has_type <http://vocab.getty.edu/aat/300215302> ; # Digital image
-            la:access_point ?contentUrl .
+            la:access_point ?digitalObjectContentUrl .
+
+          OPTIONAL {
+            ?digitalObject crm:P104_is_subject_to ?right .
+            ?right a crm:E30_Right ;
+              crm:P2_has_type ?digitalObjectLicense .
+
+            OPTIONAL {
+              ?digitalObjectLicense schema:name ?digitalObjectLicenseName .
+              FILTER(LANG(?digitalObjectLicenseName) = "" || LANGMATCHES(LANG(?digitalObjectLicenseName), "en"))
+            }
+          }
         }
 
         ####################

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -60,11 +60,15 @@ describe('getByHeritageObjectId', () => {
           endsBefore:
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/9cb5c59b958f4878937957c423d308b5',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Amsterdam',
           },
           transferredFrom: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/c08aa36cf775e23c92dd2430c1bbb99b',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jonathan Hansen',
           },
@@ -88,7 +92,9 @@ describe('getByHeritageObjectId', () => {
           startsAfter:
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/fa56164b9dd96e37a4e93e018c51018e',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Paris',
           },
           transferredTo: {
@@ -112,7 +118,9 @@ describe('getByHeritageObjectId', () => {
           endsBefore:
             'https://example.org/objects/1/provenance/event/4/activity/1',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/cd7ccc86fb7b17d1fb0bf425de63c796',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Amsterdam',
           },
           transferredFrom: {
@@ -137,16 +145,22 @@ describe('getByHeritageObjectId', () => {
           endsBefore:
             'https://example.org/objects/1/provenance/event/5/activity/1',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/522af0fad56ad754c58f48768e06bb58',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'The Hague',
           },
           transferredFrom: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/552102cb8b424cc0d8b49e59b6a990df',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jan de Vries',
           },
           transferredTo: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/c581b92d73922421a4b688595e0000be',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jonathan Hansen',
           },
@@ -169,16 +183,22 @@ describe('getByHeritageObjectId', () => {
           endsBefore:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/2b434a4d7ed20396b17ba591079edc09',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             name: 'Jakarta',
           },
           transferredFrom: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/32d1c530bc7643fcf73a5f4e9fc18594',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Peter Hoekstra',
           },
           transferredTo: {
-            id: 'https://colonial-heritage.triply.cc/.well-known/genid/f639c45571fe3eef8752501d0ca96720',
+            id: expect.stringContaining(
+              'https://colonial-heritage.triply.cc/.well-known/genid/'
+            ),
             type: 'Person',
             name: 'Jan de Vries',
           },

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -49,7 +49,11 @@ beforeAll(async () => {
     ex:creator4 ex:name "Organization" .
 
     ex:image1 a ex:Image ;
-      ex:contentUrl <https://example.org/image1.jpg> .
+      ex:contentUrl <https://example.org/image1.jpg> ;
+      ex:license ex:license1 .
+
+    ex:license1 a ex:DigitalDocument ;
+      ex:name "License" .
 
     ex:image2 a ex:Image ;
       ex:contentUrl <https://example.org/image2.jpg> .
@@ -193,6 +197,10 @@ describe('createImages', () => {
       {
         id: 'https://example.org/image1',
         contentUrl: 'https://example.org/image1.jpg',
+        license: {
+          id: 'https://example.org/license1',
+          name: 'License',
+        },
       },
       {
         id: 'https://example.org/image2',

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.ts
@@ -1,4 +1,4 @@
-import {Agent, Dataset, Image, Place, TimeSpan} from '../definitions';
+import {Agent, Dataset, Image, License, Place, TimeSpan} from '../definitions';
 import {getProperty, getPropertyValue} from '../rdf-helpers';
 import type {Resource} from 'rdf-object';
 
@@ -58,6 +58,17 @@ function createImage(imageResource: Resource) {
     id: imageResource.value,
     contentUrl: contentUrl!, // Ignore 'string | undefined' warning - it's always set
   };
+
+  // An image may not have a license
+  const licenseResource = getProperty(imageResource, 'ex:license');
+  if (licenseResource !== undefined) {
+    const name = getPropertyValue(licenseResource, 'ex:name');
+    const license: License = {
+      id: licenseResource.value,
+      name,
+    };
+    image.license = license;
+  }
 
   return image;
 }


### PR DESCRIPTION
This PR adds a license to the image of an object. The license is optional - data providers may not have it.