### PR TITLE
Show correct facet background for the old design of the Dataset Browser

### DIFF
--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -32,6 +32,7 @@ import {
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import {ElementType} from 'react';
 import {ListStoreUpdater} from './list-store-updater';
+import {FacetVariant} from '@colonial-collections/ui/list/definitions';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
@@ -74,6 +75,7 @@ function FacetMenu({filters}: FacetMenuProps) {
               filters={filters[name]}
               filterKey={name}
               testId={`${name}Filter`}
+              variant={FacetVariant.Old}
             />
           )
       )}

--- a/packages/ui/list/base-facet.tsx
+++ b/packages/ui/list/base-facet.tsx
@@ -2,15 +2,26 @@
 
 import {useCallback, useMemo, ReactNode} from 'react';
 import {useListStore} from '@colonial-collections/list-store';
+import classNames from 'classnames';
+import {FacetVariant} from './definitions';
 
 interface FacetWrapperProps {
   children: ReactNode;
   testId?: string;
+  variant?: FacetVariant;
 }
 
-export function FacetWrapper({children, testId}: FacetWrapperProps) {
+export function FacetWrapper({
+  children,
+  testId,
+  variant = FacetVariant.Default,
+}: FacetWrapperProps) {
   return (
-    <div className="bg-consortiumBlue-900 rounded p-2">
+    <div
+      className={classNames('rounded p-2', {
+        'bg-consortiumBlue-900': variant === FacetVariant.Default,
+      })}
+    >
       <div className="w-full max-w-[450px]" data-testid={testId}>
         {children}
       </div>

--- a/packages/ui/list/definitions.ts
+++ b/packages/ui/list/definitions.ts
@@ -3,3 +3,8 @@ export interface SearchResultFilter {
   id: string | number;
   totalCount: number;
 }
+
+export enum FacetVariant {
+  Default = 'default',
+  Old = 'old',
+}

--- a/packages/ui/list/multi-select-facet.tsx
+++ b/packages/ui/list/multi-select-facet.tsx
@@ -1,22 +1,29 @@
 'use client';
 
 import {FacetCheckBox, FacetTitle, FacetWrapper} from './base-facet';
-import {SearchResultFilter} from './SearchResultFilter';
+import {FacetVariant, SearchResultFilter} from './definitions';
 
 interface Props {
   title: string;
   filters: SearchResultFilter[];
   filterKey: string;
   testId?: string;
+  variant?: FacetVariant;
 }
 
-export function MultiSelectFacet({title, filters, filterKey, testId}: Props) {
+export function MultiSelectFacet({
+  title,
+  filters,
+  filterKey,
+  testId,
+  variant,
+}: Props) {
   if (!filters.length) {
     return null;
   }
 
   return (
-    <FacetWrapper testId={testId}>
+    <FacetWrapper testId={testId} variant={variant}>
       <FacetTitle title={title} />
       {filters.map(searchResultFilter => (
         <FacetCheckBox

--- a/packages/ui/list/searchable-multi-select-facet.tsx
+++ b/packages/ui/list/searchable-multi-select-facet.tsx
@@ -2,7 +2,7 @@
 
 import {Modal, ModalButton, ModalHeader} from '../modal';
 import {FacetCheckBox, FacetTitle, FacetWrapper} from './base-facet';
-import {SearchResultFilter} from './SearchResultFilter';
+import {SearchResultFilter} from './definitions';
 import {useEffect} from 'react';
 import {
   InformationCircleIcon,

--- a/packages/ui/list/selected-filters.tsx
+++ b/packages/ui/list/selected-filters.tsx
@@ -6,7 +6,7 @@ import {
   useListStore,
   Type as SearchParamType,
 } from '@colonial-collections/list-store';
-import {SearchResultFilter} from './SearchResultFilter';
+import {SearchResultFilter} from './definitions';
 import {useMemo} from 'react';
 import {MagnifyingGlassIcon, TagIcon} from '@heroicons/react/24/solid';
 


### PR DESCRIPTION
The dataset browser has not yet moved to the new colours, but it shares components with the research app.

For most components, this is not a big problem, but the facets aren't readable. So I have added a temporary variant property. If we decide on more changes between the apps we could think about adding a theme.

Old:
![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/9474860e-7e18-4072-b6d1-8b223dfab87a)

With the changes is this pull request:
![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/5bd9b407-7d03-4d28-9b2f-e4e6784989a8)
