### PR TITLE
API: maintenance

### DIFF
--- a/apps/dataset-browser/.env.development
+++ b/apps/dataset-browser/.env.development
@@ -2,5 +2,5 @@
 # DO NOT ADD SECRETS TO THIS FILE
 # If you want to add secrets use `.env.development.local` instead
 
-SEARCH_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/search-graph/services/search/elasticsearch
-SPARQL_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
+SEARCH_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/search-graph/services/search/elasticsearch
+SPARQL_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/knowledge-graph/services/kg/sparql

--- a/apps/dataset-browser/.env.test
+++ b/apps/dataset-browser/.env.test
@@ -2,5 +2,5 @@
 # DO NOT ADD SECRETS TO THIS FILE
 # If you want to add secrets use `.env.test.local` instead
 
-SEARCH_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/search-graph/services/search/elasticsearch
-SPARQL_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
+SEARCH_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/search-graph/services/search/elasticsearch
+SPARQL_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/knowledge-graph/services/kg/sparql

--- a/apps/researcher/.env.development
+++ b/apps/researcher/.env.development
@@ -2,7 +2,7 @@
 # DO NOT ADD SECRETS TO THIS FILE
 # If you want to add secrets use `.env.development.local` instead
 
-SEARCH_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/search-graph/services/search/elasticsearch
-SPARQL_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
+SEARCH_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/search-graph/services/search/elasticsearch
+SPARQL_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
 DATASET_BROWSER_URL=https://dev.datasets.colonialcollections.nl
 NEXT_PUBLIC_COMMUNITY_ENRICHMENT_LICENSE="https://creativecommons.org/licenses/by/4.0/"

--- a/apps/researcher/.env.development
+++ b/apps/researcher/.env.development
@@ -5,4 +5,4 @@
 SEARCH_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/search-graph/services/search/elasticsearch
 SPARQL_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
 DATASET_BROWSER_URL=https://dev.datasets.colonialcollections.nl
-NEXT_PUBLIC_COMMUNITY_ENRICHMENT_LICENSE="https://creativecommons.org/licenses/by/4.0/"
+NEXT_PUBLIC_COMMUNITY_ENRICHMENT_LICENSE=https://creativecommons.org/licenses/by/4.0/

--- a/apps/researcher/.env.test
+++ b/apps/researcher/.env.test
@@ -2,5 +2,5 @@
 # DO NOT ADD SECRETS TO THIS FILE
 # If you want to add secrets use `.env.test.local` instead
 
-SEARCH_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/search-graph/services/search/elasticsearch
-SPARQL_ENDPOINT_URL=https://api.colonial-heritage.triply.cc/datasets/data-hub-testing/knowledge-graph/services/kg/sparql
+SEARCH_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/search-graph/services/search/elasticsearch
+SPARQL_ENDPOINT_URL=https://api.colonialcollections.nl/datasets/data-hub-testing/knowledge-graph/services/kg/sparql

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -58,7 +58,6 @@ export type HeritageObject = {
   locationCreated?: Place;
   dateCreated?: TimeSpan;
   images?: Image[];
-  owner?: Agent;
   isPartOf?: Dataset;
 };
 

--- a/apps/researcher/src/lib/api/objects/definitions.ts
+++ b/apps/researcher/src/lib/api/objects/definitions.ts
@@ -13,7 +13,6 @@ export type SearchResult = {
   sortOrder: SortOrder;
   heritageObjects: HeritageObject[];
   filters: {
-    owners: SearchResultFilter[];
     types: SearchResultFilter[];
     subjects: SearchResultFilter[];
     locations: SearchResultFilter[];

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -40,7 +40,7 @@ describe('getById', () => {
       types: expect.arrayContaining([
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Canvas Painting',
         },
@@ -48,7 +48,7 @@ describe('getById', () => {
       subjects: expect.arrayContaining([
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Celebrations',
         },
@@ -56,13 +56,13 @@ describe('getById', () => {
       materials: expect.arrayContaining([
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Oilpaint',
         },
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Canvas',
         },
@@ -70,7 +70,7 @@ describe('getById', () => {
       techniques: expect.arrayContaining([
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Albumen process',
         },
@@ -79,14 +79,14 @@ describe('getById', () => {
         {
           type: 'Person',
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           name: 'Geeske van Châtellerault',
         },
       ]),
       dateCreated: {
         id: expect.stringContaining(
-          'https://colonial-heritage.triply.cc/.well-known/genid/'
+          'https://data.colonialcollections.nl/.well-known/genid/'
         ),
         startDate: new Date('1901-01-01'),
         endDate: new Date('1902-06-01'),
@@ -102,7 +102,7 @@ describe('getById', () => {
       images: expect.arrayContaining([
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           contentUrl:
             'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
@@ -113,7 +113,7 @@ describe('getById', () => {
         },
         {
           id: expect.stringContaining(
-            'https://colonial-heritage.triply.cc/.well-known/genid/'
+            'https://data.colonialcollections.nl/.well-known/genid/'
           ),
           contentUrl:
             'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
@@ -123,11 +123,6 @@ describe('getById', () => {
           },
         },
       ]),
-      owner: {
-        type: 'Organization',
-        id: 'https://museum.example.org/',
-        name: 'Museum',
-      },
       isPartOf: {
         id: 'https://example.org/datasets/1',
         name: 'Dataset 1',

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -62,7 +62,6 @@ export class HeritageObjectFetcher {
           ex:dateCreated ?dateCreatedTimeSpan ;
           ex:locationCreated ?locationCreated ;
           ex:image ?digitalObject ;
-          ex:owner ?owner ;
           ex:isPartOf ?dataset .
 
         ?type a ex:DefinedTerm ;
@@ -97,9 +96,6 @@ export class HeritageObjectFetcher {
 
         ?digitalObjectLicense a ex:DigitalDocument ;
           ex:name ?digitalObjectLicenseName .
-
-        ?owner a ?ownerType ;
-          ex:name ?ownerName .
 
         ?dataset a ex:Dataset ;
           ex:publisher ?publisher ;
@@ -266,24 +262,6 @@ export class HeritageObjectFetcher {
         }
 
         ####################
-        # Owner
-        ####################
-
-        OPTIONAL {
-          ?object crm:P52_has_current_owner ?owner .
-          ?owner schema:name ?ownerName ;
-            rdf:type ?ownerTypeTemp .
-
-          FILTER(LANG(?ownerName) = "" || LANGMATCHES(LANG(?ownerName), "en"))
-
-          VALUES (?ownerTypeTemp ?ownerType) {
-            (schema:Organization ex:Organization)
-            (schema:Person ex:Person)
-            (UNDEF UNDEF)
-          }
-        }
-
-        ####################
         # Part of dataset
         ####################
 
@@ -355,7 +333,6 @@ export class HeritageObjectFetcher {
       createPlaces(rawHeritageObject, 'ex:locationCreated')
     );
     const images = createImages(rawHeritageObject, 'ex:image');
-    const owner = onlyOne(createAgents(rawHeritageObject, 'ex:owner'));
     const dataset = onlyOne(createDatasets(rawHeritageObject, 'ex:isPartOf'));
 
     const heritageObjectWithUndefinedValues: HeritageObject = {
@@ -372,7 +349,6 @@ export class HeritageObjectFetcher {
       dateCreated,
       locationCreated,
       images,
-      owner,
       isPartOf: dataset,
     };
 

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -61,13 +61,13 @@ describe('getByHeritageObjectId', () => {
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             name: 'Amsterdam',
           },
           transferredFrom: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             type: 'Person',
             name: 'Jonathan Hansen',
@@ -93,7 +93,7 @@ describe('getByHeritageObjectId', () => {
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             name: 'Paris',
           },
@@ -119,7 +119,7 @@ describe('getByHeritageObjectId', () => {
             'https://example.org/objects/1/provenance/event/4/activity/1',
           location: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             name: 'Amsterdam',
           },
@@ -146,20 +146,20 @@ describe('getByHeritageObjectId', () => {
             'https://example.org/objects/1/provenance/event/5/activity/1',
           location: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             name: 'The Hague',
           },
           transferredFrom: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             type: 'Person',
             name: 'Jan de Vries',
           },
           transferredTo: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             type: 'Person',
             name: 'Jonathan Hansen',
@@ -184,20 +184,20 @@ describe('getByHeritageObjectId', () => {
             'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             name: 'Jakarta',
           },
           transferredFrom: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             type: 'Person',
             name: 'Peter Hoekstra',
           },
           transferredTo: {
             id: expect.stringContaining(
-              'https://colonial-heritage.triply.cc/.well-known/genid/'
+              'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             type: 'Person',
             name: 'Jan de Vries',

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -67,11 +67,6 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Museum',
-            name: 'Museum',
-          },
           isPartOf: {
             id: 'Dataset 1',
             name: 'Dataset 1',
@@ -125,11 +120,6 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/1f3fd6a1-164c-2fe9-c222-3c6dbd32d33d.jpg',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Research Organisation',
-            name: 'Research Organisation',
-          },
           isPartOf: {
             id: 'Dataset 13',
             name: 'Dataset 13',
@@ -173,11 +163,6 @@ describe('search', () => {
               name: 'Paper',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Library',
-            name: 'Library',
-          },
           isPartOf: {
             id: 'Dataset 10',
             name: 'Dataset 10',
@@ -253,11 +238,6 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
           ],
-          owner: {
-            type: 'Organization',
-            id: 'Museum',
-            name: 'Museum',
-          },
           isPartOf: {
             id: 'Dataset 1',
             name: 'Dataset 1',
@@ -270,23 +250,6 @@ describe('search', () => {
         },
       ],
       filters: {
-        owners: [
-          {
-            totalCount: 2,
-            id: 'Museum',
-            name: 'Museum',
-          },
-          {
-            totalCount: 1,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 1,
-            id: 'Research Organisation',
-            name: 'Research Organisation',
-          },
-        ],
         types: [
           {
             totalCount: 1,
@@ -453,21 +416,6 @@ describe('search', () => {
             name: 1902,
           },
         ],
-      },
-    });
-  });
-
-  it('finds heritage objects if "owners" filter matches', async () => {
-    const result = await heritageObjectSearcher.search({
-      filters: {
-        owners: ['Library'],
-      },
-    });
-
-    expect(result).toMatchObject({
-      totalCount: 1,
-      filters: {
-        owners: [{totalCount: 1, id: 'Library', name: 'Library'}],
       },
     });
   });

--- a/apps/researcher/src/lib/api/organizations/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/organizations/fetcher.integration.test.ts
@@ -37,7 +37,7 @@ describe('getById', () => {
       url: 'http://www.example.org',
       address: {
         id: expect.stringContaining(
-          'https://colonial-heritage.triply.cc/.well-known/genid/'
+          'https://data.colonialcollections.nl/.well-known/genid/'
         ),
         streetAddress: 'Museum Street 1',
         postalCode: '1234 AB',


### PR DESCRIPTION
This is a maintenance PR:

1. It updates the environment variables, replacing the old hostname of our TriplyDB instance with the new one
2. It updates the tests that referred to the old hostname
3. It removes the 'owner' property from a heritage object and corresponding facet from the search results: the owner is not used in the production data. We can add it later when needed.