### PR TITLE
fix: filter with AND instead of OR

### DIFF
--- a/apps/dataset-browser/src/lib/api/datasets/searcher.integration.test.ts
+++ b/apps/dataset-browser/src/lib/api/datasets/searcher.integration.test.ts
@@ -43,7 +43,7 @@ describe('search', () => {
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
           dateModified: new Date('2023-02-17T00:00:00.000Z'),
           datePublished: new Date('2023-02-17T00:00:00.000Z'),
-          keywords: ['Suspendisse', 'Hendrerit'],
+          keywords: expect.arrayContaining(['Suspendisse', 'Hendrerit']),
           mainEntityOfPages: ['https://example.org/'],
           measurements: [
             {
@@ -252,7 +252,7 @@ describe('search', () => {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
           },
-          keywords: ['Vestibulum', 'Hendrerit'],
+          keywords: expect.arrayContaining(['Vestibulum', 'Hendrerit']),
           measurements: [
             {
               id: 'https://example.org/datasets/12/measurements/2',
@@ -395,7 +395,7 @@ describe('search', () => {
             id: 'http://creativecommons.org/publicdomain/zero/1.0/deed.nl',
             name: 'CC0 1.0 Universeel (CC0 1.0) Publiek Domein Verklaring',
           },
-          keywords: ['Suspendisse', 'Hendrerit'],
+          keywords: expect.arrayContaining(['Suspendisse', 'Hendrerit']),
           measurements: [
             {
               id: 'https://example.org/datasets/14/measurements/2',
@@ -561,7 +561,7 @@ describe('search', () => {
             name: 'Open Data Commons Attribution License (ODC-By) v1.0',
           },
           dateModified: new Date('2023-02-01T00:00:00.000Z'),
-          keywords: ['Suspendisse', 'Hendrerit'],
+          keywords: expect.arrayContaining(['Suspendisse', 'Hendrerit']),
           measurements: [
             {
               id: 'https://example.org/datasets/4/measurements/2',

--- a/apps/dataset-browser/src/lib/api/datasets/searcher.ts
+++ b/apps/dataset-browser/src/lib/api/datasets/searcher.ts
@@ -188,7 +188,7 @@ export class DatasetSearcher {
             {
               // Only return documents of a specific type
               terms: {
-                [`${RawKeys.Type}.keyword`]: [
+                [`${RawKeys.Type}.keyword` as string]: [
                   'https://colonialcollections.nl/schema#Dataset',
                 ],
               },
@@ -207,12 +207,16 @@ export class DatasetSearcher {
     ]);
 
     for (const [rawDatasetKey, filters] of queryFilters) {
-      if (filters !== undefined && filters.length) {
-        searchRequest.query.bool.filter.push({
-          terms: {
-            [`${rawDatasetKey}.keyword`]: filters,
-          },
+      if (filters !== undefined) {
+        const andFilters = filters.map(filter => {
+          return {
+            terms: {
+              [`${rawDatasetKey}.keyword`]: [filter],
+            },
+          };
         });
+
+        searchRequest.query.bool.filter.push(...andFilters);
       }
     }
 

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -420,6 +420,24 @@ describe('search', () => {
     });
   });
 
+  it('finds heritage objects if multiple filters match by "and"', async () => {
+    const result = await heritageObjectSearcher.search({
+      filters: {
+        materials: ['Oilpaint', 'Canvas'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 2,
+      filters: {
+        materials: [
+          {totalCount: 2, id: 'Canvas', name: 'Canvas'},
+          {totalCount: 2, id: 'Oilpaint', name: 'Oilpaint'},
+        ],
+      },
+    });
+  });
+
   it('finds heritage objects if "types" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -286,7 +286,7 @@ export class HeritageObjectSearcher {
             {
               // Only return documents of a specific type
               terms: {
-                [`${RawKeys.Type}.keyword`]: [
+                [`${RawKeys.Type}.keyword` as string]: [
                   'https://colonialcollections.nl/schema#HeritageObject',
                 ],
               },
@@ -309,12 +309,16 @@ export class HeritageObjectSearcher {
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {
-      if (filters !== undefined && filters.length) {
-        searchRequest.query.bool.filter.push({
-          terms: {
-            [`${rawHeritageObjectKey}.keyword`]: filters,
-          },
+      if (filters !== undefined) {
+        const andFilters = filters.map(filter => {
+          return {
+            terms: {
+              [`${rawHeritageObjectKey}.keyword`]: [filter],
+            },
+          };
         });
+
+        searchRequest.query.bool.filter.push(...andFilters);
       }
     }
 


### PR DESCRIPTION
This PR fixes [1] by changing the filtering behaviour of our Elasticsearch client: it now filters by 'and' instead of 'or'. This causes the search results to be narrowed down significantly.

We should test whether this indeed is the desired behaviour. For example, the effect is that users will see less facet values to choose from. This could hamper their search experience.

[1] https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=48168750