### PR TITLE
feat: use SPARQL for fetching the search results

### DIFF
--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -10,6 +10,32 @@ beforeEach(() => {
   });
 });
 
+describe('getByIds', () => {
+  it('returns empty list if no heritage objects match the IDs', async () => {
+    const heritageObjects = await heritageObjectFetcher.getByIds([
+      'https://unknown.org/',
+    ]);
+
+    expect(heritageObjects).toStrictEqual([]);
+  });
+
+  it('returns the heritage objects that match the IDs', async () => {
+    const heritageObjects = await heritageObjectFetcher.getByIds([
+      'https://example.org/objects/1',
+      'https://example.org/objects/5',
+    ]);
+
+    expect(heritageObjects).toMatchObject([
+      {
+        id: 'https://example.org/objects/1',
+      },
+      {
+        id: 'https://example.org/objects/5',
+      },
+    ]);
+  });
+});
+
 describe('getById', () => {
   it('returns undefined if a malformed ID is used', async () => {
     const heritageObject = await heritageObjectFetcher.getById('malformedID');

--- a/apps/researcher/src/lib/api/objects/index.ts
+++ b/apps/researcher/src/lib/api/objects/index.ts
@@ -30,6 +30,7 @@ export class HeritageObjects {
     });
     this.heritageObjectSearcher = new HeritageObjectSearcher({
       endpointUrl: opts.elasticSearchEndpointUrl,
+      heritageObjectFetcher: this.heritageObjectFetcher,
     });
   }
 

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -1,12 +1,18 @@
+import {HeritageObjectFetcher} from './fetcher';
 import {HeritageObjectSearcher} from './searcher';
 import {beforeEach, describe, expect, it} from '@jest/globals';
 import {env} from 'node:process';
 
 let heritageObjectSearcher: HeritageObjectSearcher;
 
+const heritageObjectFetcher = new HeritageObjectFetcher({
+  endpointUrl: env.SPARQL_ENDPOINT_URL as string,
+});
+
 beforeEach(() => {
   heritageObjectSearcher = new HeritageObjectSearcher({
     endpointUrl: env.SEARCH_ENDPOINT_URL as string,
+    heritageObjectFetcher,
   });
 });
 
@@ -23,152 +29,235 @@ describe('search', () => {
       heritageObjects: [
         {
           id: 'https://example.org/objects/1',
-          name: 'Object 1',
           identifier: '1234',
+          name: 'Object 1',
           description:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
-          types: [
+          types: expect.arrayContaining([
             {
-              id: 'Painting',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Painting',
             },
-          ],
-          subjects: [
+          ]),
+          subjects: expect.arrayContaining([
             {
-              id: 'Celebrations',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Celebrations',
             },
-          ],
-          materials: [
+          ]),
+          materials: expect.arrayContaining([
             {
-              id: 'Canvas',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Canvas',
             },
             {
-              id: 'Oilpaint',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Oilpaint',
             },
-          ],
-          creators: [
+          ]),
+          creators: expect.arrayContaining([
             {
-              id: 'Vincent van Gogh',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              type: 'Person',
               name: 'Vincent van Gogh',
             },
-          ],
-          images: [
+          ]),
+          dateCreated: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1889-05-01T00:00:00.000Z'),
+            endDate: new Date('1890-12-01T00:00:00.000Z'),
+          },
+          locationCreated: {
+            id: 'https://sws.geonames.org/3382998/',
+            name: 'Suriname',
+          },
+          images: expect.arrayContaining([
             {
-              id: 'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               contentUrl:
                 'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+              license: {
+                id: 'http://rightsstatements.org/vocab/InC/1.0/',
+                name: 'In Copyright',
+              },
             },
             {
-              id: 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               contentUrl:
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
-          ],
+          ]),
           isPartOf: {
-            id: 'Dataset 1',
+            id: 'https://example.org/datasets/1',
             name: 'Dataset 1',
             publisher: {
+              id: 'https://museum.example.org/',
               type: 'Organization',
-              id: 'Museum',
               name: 'Museum',
             },
           },
         },
         {
           id: 'https://example.org/objects/2',
-          name: 'Object 2',
           identifier: '5678',
+          name: 'Object 2',
           description:
             'Suspendisse ut condimentum leo, et vulputate lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Fusce vel volutpat nunc. Sed vel libero ac lorem dapibus euismod. Aenean a ante et turpis bibendum consectetur at pulvinar quam.',
-          types: [
+          types: expect.arrayContaining([
             {
-              id: 'Photo',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Photo',
             },
-          ],
-          subjects: [
+          ]),
+          subjects: expect.arrayContaining([
             {
-              id: 'Palace',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Palace',
             },
-          ],
-          materials: [
+          ]),
+          materials: expect.arrayContaining([
             {
-              id: 'Paper',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Paper',
             },
-          ],
-          techniques: [
+          ]),
+          techniques: expect.arrayContaining([
             {
-              id: 'Albumen process',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Albumen process',
             },
-          ],
-          creators: [
+          ]),
+          creators: expect.arrayContaining([
             {
-              id: 'Adriaan Boer',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              type: 'Person',
               name: 'Adriaan Boer',
             },
-          ],
-          images: [
+          ]),
+          dateCreated: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1895-02-01T00:00:00.000Z'),
+            endDate: new Date('1895-02-15T00:00:00.000Z'),
+          },
+          locationCreated: {
+            id: 'https://sws.geonames.org/1642911/',
+            name: 'Jakarta',
+            isPartOf: {
+              id: 'https://sws.geonames.org/1643084/',
+              name: 'Indonesia',
+            },
+          },
+          images: expect.arrayContaining([
             {
-              id: 'http://images.memorix.nl/rce/thumb/1600x1600/1f3fd6a1-164c-2fe9-c222-3c6dbd32d33d.jpg',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               contentUrl:
                 'http://images.memorix.nl/rce/thumb/1600x1600/1f3fd6a1-164c-2fe9-c222-3c6dbd32d33d.jpg',
             },
-          ],
+          ]),
           isPartOf: {
-            id: 'Dataset 13',
+            id: 'https://example.org/datasets/13',
             name: 'Dataset 13',
             publisher: {
+              id: 'https://research.example.org/',
               type: 'Organization',
-              id: 'Onderzoeksinstelling',
-              name: 'Onderzoeksinstelling',
+              name: 'Research Organisation',
             },
           },
         },
         {
           id: 'https://example.org/objects/3',
-          name: 'Object 3',
           identifier: '9012',
+          name: 'Object 3',
           description:
             'Ut dictum elementum augue sit amet sodales. Vivamus viverra ligula sed arcu cursus sagittis. Donec ac placerat lacus.',
-          inscriptions: ['Maecenas commodo est neque'],
-          types: [
+          types: expect.arrayContaining([
             {
-              id: 'Drawing',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Drawing',
             },
-          ],
-          subjects: [
+          ]),
+          subjects: expect.arrayContaining([
             {
-              id: 'Castle',
-              name: 'Castle',
-            },
-            {
-              id: 'Cottage',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Cottage',
             },
-          ],
-          materials: [
             {
-              id: 'Ink',
-              name: 'Ink',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Castle',
             },
+          ]),
+          inscriptions: ['Maecenas commodo est neque'],
+          materials: expect.arrayContaining([
             {
-              id: 'Paper',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Paper',
             },
-          ],
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Ink',
+            },
+          ]),
+          dateCreated: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1725-01-01T00:00:00.000Z'),
+            endDate: new Date('1736-01-01T00:00:00.000Z'),
+          },
+          locationCreated: {
+            id: 'https://sws.geonames.org/1642673/',
+            name: 'Java',
+            isPartOf: {
+              id: 'https://sws.geonames.org/1643084/',
+              name: 'Indonesia',
+            },
+          },
           isPartOf: {
-            id: 'Dataset 10',
+            id: 'https://example.org/datasets/10',
             name: 'Dataset 10',
             publisher: {
+              id: 'https://library.example.org/',
               type: 'Organization',
-              id: 'Library',
               name: 'Library',
             },
           },
@@ -176,74 +265,114 @@ describe('search', () => {
         {
           id: 'https://example.org/objects/4',
           isPartOf: {
-            id: 'Dataset 1',
+            id: 'https://example.org/datasets/1',
             name: 'Dataset 1',
             publisher: {
+              id: 'https://museum.example.org/',
               type: 'Organization',
-              id: 'Museum',
               name: 'Museum',
             },
           },
         },
         {
           id: 'https://example.org/objects/5',
-          name: 'Object 5',
           identifier: '7890',
+          name: 'Object 5',
           description:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
-          inscriptions: ['Maecenas commodo est neque'],
-          types: [
+          types: expect.arrayContaining([
             {
-              id: 'Canvas Painting',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Canvas Painting',
             },
-          ],
-          subjects: [
+          ]),
+          subjects: expect.arrayContaining([
             {
-              id: 'Celebrations',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Celebrations',
             },
-          ],
-          materials: [
+          ]),
+          inscriptions: ['Maecenas commodo est neque'],
+          materials: expect.arrayContaining([
             {
-              id: 'Canvas',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Canvas',
             },
             {
-              id: 'Oilpaint',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Oilpaint',
             },
-          ],
-          techniques: [
+          ]),
+          techniques: expect.arrayContaining([
             {
-              id: 'Albumen process',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               name: 'Albumen process',
             },
-          ],
-          creators: [
+          ]),
+          creators: expect.arrayContaining([
             {
-              id: 'Geeske van Châtellerault',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              type: 'Person',
               name: 'Geeske van Châtellerault',
             },
-          ],
-          images: [
+          ]),
+          dateCreated: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1901-01-01T00:00:00.000Z'),
+            endDate: new Date('1902-06-01T00:00:00.000Z'),
+          },
+          locationCreated: {
+            id: 'https://sws.geonames.org/1749659/',
+            name: 'Pulau Sebang',
+            isPartOf: {
+              id: 'https://sws.geonames.org/1733045/',
+              name: 'Malaysia',
+            },
+          },
+          images: expect.arrayContaining([
             {
-              id: 'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               contentUrl:
                 'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+              license: {
+                id: 'https://creativecommons.org/publicdomain/zero/1.0/',
+                name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
+              },
             },
             {
-              id: 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
               contentUrl:
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
+              license: {
+                id: 'https://creativecommons.org/licenses/by/4.0/',
+                name: 'Attribution 4.0 International (CC BY 4.0)',
+              },
             },
-          ],
+          ]),
           isPartOf: {
-            id: 'Dataset 1',
+            id: 'https://example.org/datasets/1',
             name: 'Dataset 1',
             publisher: {
+              id: 'https://museum.example.org/',
               type: 'Organization',
-              id: 'Museum',
               name: 'Museum',
             },
           },

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -1,22 +1,17 @@
 import {
-  Dataset,
-  HeritageObject,
-  Image,
-  Person,
   SearchResultFilter,
   SortBy,
   SortByEnum,
   SortOrder,
   SortOrderEnum,
-  Term,
 } from '../definitions';
 import {SearchResult} from './definitions';
-import {removeNullish} from '../rdf-helpers';
-import {reach} from '@hapi/hoek';
+import {HeritageObjectFetcher} from './fetcher';
 import {z} from 'zod';
 
 const constructorOptionsSchema = z.object({
   endpointUrl: z.string(),
+  heritageObjectFetcher: z.instanceof(HeritageObjectFetcher),
 });
 
 export type ConstructorOptions = z.infer<typeof constructorOptionsSchema>;
@@ -25,20 +20,15 @@ enum RawKeys {
   Id = '@id',
   Type = 'http://www w3 org/1999/02/22-rdf-syntax-ns#type',
   AdditionalType = 'https://colonialcollections nl/schema#additionalType',
-  Identifier = 'https://colonialcollections nl/schema#identifier',
   Name = 'https://colonialcollections nl/schema#name',
-  Description = 'https://colonialcollections nl/schema#description',
-  Inscription = 'https://colonialcollections nl/schema#inscription',
   About = 'https://colonialcollections nl/schema#about',
   Creator = 'https://colonialcollections nl/schema#creator',
   Material = 'https://colonialcollections nl/schema#material',
   Technique = 'https://colonialcollections nl/schema#technique',
-  Image = 'https://colonialcollections nl/schema#image',
   Publisher = 'https://colonialcollections nl/schema#publisher',
   YearCreatedStart = 'https://colonialcollections nl/schema#yearCreatedStart',
   YearCreatedEnd = 'https://colonialcollections nl/schema#yearCreatedEnd',
   CountryCreated = 'https://colonialcollections nl/schema#countryCreated',
-  IsPartOf = 'https://colonialcollections nl/schema#isPartOf',
 }
 
 const sortByToRawKeys = new Map<string, string>([
@@ -69,23 +59,7 @@ const searchOptionsSchema = z.object({
 
 export type SearchOptions = z.input<typeof searchOptionsSchema>;
 
-const rawHeritageObjectSchema = z
-  .object({})
-  .setKey(RawKeys.Id, z.string())
-  .setKey(RawKeys.AdditionalType, z.array(z.string()).optional())
-  .setKey(RawKeys.Identifier, z.array(z.string()).optional())
-  .setKey(RawKeys.Name, z.array(z.string()).optional())
-  .setKey(RawKeys.Description, z.array(z.string()).optional())
-  .setKey(RawKeys.Inscription, z.array(z.string()).optional())
-  .setKey(RawKeys.About, z.array(z.string()).optional())
-  .setKey(RawKeys.Creator, z.array(z.string()).optional())
-  .setKey(RawKeys.Material, z.array(z.string()).optional())
-  .setKey(RawKeys.Technique, z.array(z.string()).optional())
-  .setKey(RawKeys.Image, z.array(z.string()).optional())
-  .setKey(RawKeys.Publisher, z.array(z.string()).optional())
-  .setKey(RawKeys.IsPartOf, z.array(z.string()).min(1));
-
-type RawHeritageObject = z.infer<typeof rawHeritageObjectSchema>;
+const rawHeritageObjectSchema = z.object({}).setKey(RawKeys.Id, z.string());
 
 const rawBucketSchema = z.object({
   key: z.string().or(z.number()),
@@ -132,11 +106,13 @@ type RawSearchResponseWithAggregations = z.infer<
 
 export class HeritageObjectSearcher {
   private endpointUrl: string;
+  private heritageObjectFetcher: HeritageObjectFetcher;
 
   constructor(options: ConstructorOptions) {
     const opts = constructorOptionsSchema.parse(options);
 
     this.endpointUrl = opts.endpointUrl;
+    this.heritageObjectFetcher = opts.heritageObjectFetcher;
   }
 
   async makeRequest<T>(searchRequest: Record<string, unknown>): Promise<T> {
@@ -157,85 +133,6 @@ export class HeritageObjectSearcher {
     const responseData: T = await response.json();
 
     return responseData;
-  }
-
-  // Map the response to our internal model
-  private fromRawHeritageObjectToHeritageObject(
-    rawHeritageObject: RawHeritageObject
-  ) {
-    const name = reach(rawHeritageObject, `${RawKeys.Name}.0`);
-    const identifier = reach(rawHeritageObject, `${RawKeys.Identifier}.0`);
-    const description = reach(rawHeritageObject, `${RawKeys.Description}.0`);
-    const inscriptions = reach(rawHeritageObject, `${RawKeys.Inscription}`);
-    const publisherName = reach(rawHeritageObject, `${RawKeys.Publisher}.0`);
-    const datasetName = reach(rawHeritageObject, `${RawKeys.IsPartOf}.0`);
-    const dataset: Dataset = {
-      id: datasetName,
-      name: datasetName,
-      publisher: {
-        type: 'Organization', // TODO: determine dynamically - could also be a 'Person'
-        id: publisherName,
-        name: publisherName,
-      },
-    };
-
-    // Replace 'names' with IRIs as soon as we have IRIs
-    const toThings = <T>(rawKey: string) => {
-      const names: string[] | undefined = reach(rawHeritageObject, `${rawKey}`);
-      if (names === undefined) {
-        return undefined;
-      }
-
-      const things = names.map(name => {
-        return {
-          id: name,
-          name,
-        };
-      });
-
-      return things as T[];
-    };
-
-    const types = toThings<Term>(RawKeys.AdditionalType);
-    const subjects = toThings<Term>(RawKeys.About);
-    const materials = toThings<Term>(RawKeys.Material);
-    const techniques = toThings<Term>(RawKeys.Technique);
-    const creators = toThings<Person>(RawKeys.Creator); // TODO: set type (Person or Organization)
-
-    let images: Image[] | undefined;
-    const contentUrls: string[] | undefined = reach(
-      rawHeritageObject,
-      `${RawKeys.Image}`
-    );
-    if (contentUrls !== undefined) {
-      images = contentUrls.map(contentUrl => {
-        return {
-          id: contentUrl, // At this moment the same
-          contentUrl,
-        };
-      });
-    }
-
-    const heritageObjectWithUndefinedValues: HeritageObject = {
-      id: rawHeritageObject[RawKeys.Id],
-      name,
-      identifier,
-      description,
-      inscriptions,
-      types,
-      subjects,
-      materials,
-      techniques,
-      creators,
-      images,
-      isPartOf: dataset,
-    };
-
-    const heritageObject = removeNullish<HeritageObject>(
-      heritageObjectWithUndefinedValues
-    );
-
-    return heritageObject;
   }
 
   private buildAggregation(id: string) {
@@ -286,7 +183,7 @@ export class HeritageObjectSearcher {
             {
               // Only return documents of a specific type
               terms: {
-                [`${RawKeys.Type}.keyword`]: [
+                [`${RawKeys.Type}.keyword` as string]: [
                   'https://colonialcollections.nl/schema#HeritageObject',
                 ],
               },
@@ -369,10 +266,11 @@ export class HeritageObjectSearcher {
   ) {
     const {hits, aggregations} = rawSearchResponse;
 
-    const heritageObjects: HeritageObject[] = hits.hits.map(hit => {
-      const rawHeritageObject = hit._source;
-      return this.fromRawHeritageObjectToHeritageObject(rawHeritageObject);
-    });
+    const rawHeritageObjects = hits.hits.map(hit => hit._source);
+    const ids = rawHeritageObjects.map(
+      rawHeritageObject => rawHeritageObject['@id']
+    );
+    const heritageObjects = await this.heritageObjectFetcher.getByIds(ids);
 
     const typeFilters = this.buildFilters(aggregations.types.buckets);
     const subjectFilters = this.buildFilters(aggregations.subjects.buckets);


### PR DESCRIPTION
This PR updates the search API of the Research App. We now use Elasticsearch for fetching search results. But SPARQL gives much greater power. This PR replaces ES with SPARQL. This is a backward-compatible change and doesn't (or shouldn't) impact the frontend.