### PR TITLE
Community bugs

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/[slug]/edit-community-form.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/edit-community-form.tsx
@@ -10,6 +10,7 @@ import {camelCase} from 'tiny-case';
 import {useCommunityProfile} from '@/lib/community/hooks';
 import {LocalizedMarkdown} from '@colonial-collections/ui';
 import {enrichmentLicence} from '@/lib/enrichment-licence';
+import {Suspense} from 'react';
 
 interface Props {
   communityId: string;
@@ -183,11 +184,13 @@ export default function EditCommunityForm({
             </label>
           </div>
           <div className="text-sm mb-1">
-            <LocalizedMarkdown
-              name="license"
-              contentPath="@/messages"
-              textSize="small"
-            />
+            <Suspense>
+              <LocalizedMarkdown
+                name="license"
+                contentPath="@/messages"
+                textSize="small"
+              />
+            </Suspense>
           </div>
         </div>
         <p>{errors.agreedToLicense?.message}</p>

--- a/apps/researcher/src/app/[locale]/communities/[slug]/edit-community-form.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/edit-community-form.tsx
@@ -123,10 +123,7 @@ export default function EditCommunityForm({
 
       <div className="flex flex-col gap-1 max-w-2xl w-full">
         <label htmlFor="description" className="flex flex-col gap-1 mb-1">
-          <strong>
-            {t('labelDescription')}
-            <span className="font-normal text-neutral-600"> *</span>
-          </strong>
+          <strong>{t('labelDescription')}</strong>
         </label>
         <textarea
           id="description"
@@ -142,10 +139,7 @@ export default function EditCommunityForm({
 
       <div className="flex flex-col gap-1 max-w-2xl w-full">
         <label htmlFor="attributionId" className="flex flex-col gap-1 mb-1">
-          <strong>
-            {t('labelAttributionId')}
-            <span className="font-normal text-neutral-600"> *</span>
-          </strong>
+          <strong>{t('labelAttributionId')}</strong>
           <div className="text-sm mb-1 whitespace-pre-line">
             {t.rich('descriptionAttributionId', {
               link: text => (

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -10,7 +10,7 @@ import {JoinCommunityButton, ManageMembersButton} from './buttons';
 import {getMemberships, getCommunityBySlug} from '@/lib/community/actions';
 import ErrorMessage from '@/components/error-message';
 import {ClerkAPIResponseError} from '@clerk/shared';
-import {Protect} from '@clerk/nextjs';
+import {Protect, SignedIn} from '@clerk/nextjs';
 import {revalidatePath} from 'next/cache';
 import {objectList} from '@colonial-collections/database';
 import ObjectCard from './object';
@@ -74,7 +74,9 @@ export default async function CommunityPage({params}: Props) {
 
   return (
     <>
-      <SetActive communityId={community.id} />
+      <SignedIn>
+        <SetActive communityId={community.id} />
+      </SignedIn>
       <div className="px-4 sm:px-10 -mt-3 -mb-3 sm:-mb-9 flex gap-2 flex-row sm:justify-between w-full max-w-[1800px] mx-auto">
         <div>
           <ToFilteredListButton className="flex items-center gap-1">

--- a/packages/ui/localized-markdown.tsx
+++ b/packages/ui/localized-markdown.tsx
@@ -11,7 +11,7 @@ interface Props {
   textSize?: 'small' | 'normal';
 }
 
-const LocalizedMarkdown = (async ({name, contentPath, textSize}: Props) => {
+export async function LocalizedMarkdown({name, contentPath, textSize}: Props) {
   const locale = useLocale();
   const markdownClassName = classNames(
     'max-w-3xl prose',
@@ -42,12 +42,4 @@ const LocalizedMarkdown = (async ({name, contentPath, textSize}: Props) => {
   } catch {
     notFound();
   }
-}) as unknown as (props: Props) => JSX.Element;
-
-// TypeScript doesn't understand async components yet.
-// So this is a temporary workaround.
-// More info:
-//  - Next.js issue: https://github.com/vercel/next.js/issues/42292
-//  - Typescript pull request: https://github.com/microsoft/TypeScript/pull/51328
-// export LocalizedMarkdown as unknown as (props: Props) => JSX.Element;
-export {LocalizedMarkdown};
+}


### PR DESCRIPTION
Fix 3 bugs on the community page.

## 1. [Only set community active when signed in](https://github.com/colonial-heritage/colonial-collections/commit/bf7a828aa691b7ea95cc404b7367db826b0e1db2)

The app tries to set the community to active when not signed in. This will result in an error (and failing end-to-end tests)

## 2. [Load async component with Suspense](https://github.com/colonial-heritage/colonial-collections/commit/bb97d0f633604d4c55f71578e53930cf985585cb)

The `LocalizedMarkdown` component is an async component. This does not load well in client components. The old workaround does not work anymore (probably since a package update; I'm unsure when). When you open the community form with the `LocalizedMarkdown,` you will get an error. The new solution is added a `Suspense` wrapper.

## 3. [Only community name is required](https://github.com/colonial-heritage/colonial-collections/pull/397/commits/258b63e280969d4de75f2e29bad041ec4a40626a)

 In the community form, all fields had a "*". But only the name is required, so I removed the others.
