### PR TITLE
Show 'Add narrative' button if there is no information yet

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
@@ -31,47 +31,47 @@ export function Metadata({
       )
     : [];
 
-  if (!children && metadataEnrichments.length === 0) {
-    return (
-      <div className="text-consortiumBlue-100 italic w-full border-t py-6 text-sm">
-        {t.rich('noData', {
-          subject: () => <span className="lowercase">{t(translationKey)}</span>,
-        })}
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col xl:flex-row gap-2 xl:gap-10">
-        <div className="w-full xl:w-1/5 border-t border-consortiumBlue-400 pt-4">
-          <div className="sticky top-0 bg-consortiumBlue-800 py-1">
-            <h3 className="text-lg w-full my-1 flex items-center">
-              {t(translationKey)}
-            </h3>
-            <div className="text-consortiumBlue-100 text-sm">
-              {t(`${translationKey}SubTitle`)}
+      {!children && metadataEnrichments.length === 0 ? (
+        <div className="text-consortiumBlue-100 italic w-full border-t py-6 text-sm">
+          {t.rich('noData', {
+            subject: () => (
+              <span className="lowercase">{t(translationKey)}</span>
+            ),
+          })}
+        </div>
+      ) : (
+        <div className="flex flex-col xl:flex-row gap-2 xl:gap-10">
+          <div className="w-full xl:w-1/5 border-t border-consortiumBlue-400 pt-4">
+            <div className="sticky top-0 bg-consortiumBlue-800 py-1">
+              <h3 className="text-lg w-full my-1 flex items-center">
+                {t(translationKey)}
+              </h3>
+              <div className="text-consortiumBlue-100 text-sm">
+                {t(`${translationKey}SubTitle`)}
+              </div>
             </div>
           </div>
-        </div>
-        <div className="w-full xl:w-4/5 flex flex-col gap-2">
-          <MetadataEntry translationKey={translationKey} isCurrentPublisher>
-            {children}
-          </MetadataEntry>
-          {metadataEnrichments?.map(enrichment => (
-            <MetadataEntry
-              key={enrichment.id}
-              translationKey={translationKey}
-              dateCreated={enrichment.dateCreated}
-              citation={enrichment.citation}
-              creator={enrichment.creator}
-              languageCode={enrichment.inLanguage as LanguageCode}
-            >
-              {enrichment.description}
+          <div className="w-full xl:w-4/5 flex flex-col gap-2">
+            <MetadataEntry translationKey={translationKey} isCurrentPublisher>
+              {children}
             </MetadataEntry>
-          ))}
+            {metadataEnrichments?.map(enrichment => (
+              <MetadataEntry
+                key={enrichment.id}
+                translationKey={translationKey}
+                dateCreated={enrichment.dateCreated}
+                citation={enrichment.citation}
+                creator={enrichment.creator}
+                languageCode={enrichment.inLanguage as LanguageCode}
+              >
+                {enrichment.description}
+              </MetadataEntry>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
       {enrichmentType && (
         <AddMetadataEnrichment
           translationKey={translationKey}


### PR DESCRIPTION
The button was not visible if there was no data for the metadata. Always show the button.

Old situation:

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/bd5af0ec-b679-42fa-9bc7-a1b82868cc16)

After this code change:

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/61127b6a-02e2-44e2-bfab-e94f29942b2e)
