### PR TITLE
fix: sort by date created, no longer by relevance

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/page.tsx
@@ -213,8 +213,8 @@ export default async function SearchResults({searchParams = {}}: Props) {
                         values={[
                           SortByUserOption.DateCreatedDesc,
                           SortByUserOption.DateCreatedAsc,
-                          SortByUserOption.NameAsc,
                           SortByUserOption.NameDesc,
+                          SortByUserOption.NameAsc,
                         ]}
                       />
                     </div>

--- a/apps/researcher/src/app/[locale]/objects/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/page.tsx
@@ -1,7 +1,7 @@
 import heritageObjects from '@/lib/heritage-objects-instance';
 import {getTranslations} from 'next-intl/server';
 import HeritageObjectList from './heritage-object-list';
-import {sortMapping} from './sort-mapping';
+import {SortByUserOption, sortMapping} from './sort-mapping';
 import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
@@ -124,7 +124,7 @@ export default async function SearchResults({searchParams = {}}: Props) {
       SortOrderEnum,
       defaultSortOrder: SortOrder.Descending,
       SortByEnum,
-      defaultSortBy: SortBy.Relevance,
+      defaultSortBy: SortBy.DateCreated,
       sortMapping: sortMapping,
     },
     filterKeys: filterSettings.map(({name, searchParamType}) => ({
@@ -209,7 +209,14 @@ export default async function SearchResults({searchParams = {}}: Props) {
                       {t('title', {totalDatasets: searchResult.totalCount})}
                     </h2>
                     <div className="flex flex-col sm:flex-row justify-end gap-2">
-                      <OrderSelector />
+                      <OrderSelector
+                        values={[
+                          SortByUserOption.DateCreatedDesc,
+                          SortByUserOption.DateCreatedAsc,
+                          SortByUserOption.NameAsc,
+                          SortByUserOption.NameDesc,
+                        ]}
+                      />
                     </div>
                   </div>
                   <SelectedFilters

--- a/apps/researcher/src/app/[locale]/objects/sort-mapping.ts
+++ b/apps/researcher/src/app/[locale]/objects/sort-mapping.ts
@@ -1,16 +1,26 @@
 import {SortBy as SortBySearchOption, SortOrder} from '@/lib/api/objects';
-import {SortBy} from '@colonial-collections/list-store';
+
+export enum SortByUserOption {
+  DateCreatedDesc = 'dateCreatedDesc',
+  DateCreatedAsc = 'dateCreatedAsc',
+  NameAsc = 'nameAsc',
+  NameDesc = 'nameDesc',
+}
 
 export const sortMapping = {
-  [SortBy.RelevanceDesc]: {
-    sortBy: SortBySearchOption.Relevance,
+  [SortByUserOption.DateCreatedDesc]: {
+    sortBy: SortBySearchOption.DateCreated,
     sortOrder: SortOrder.Descending,
   },
-  [SortBy.NameAsc]: {
+  [SortByUserOption.DateCreatedAsc]: {
+    sortBy: SortBySearchOption.DateCreated,
+    sortOrder: SortOrder.Ascending,
+  },
+  [SortByUserOption.NameAsc]: {
     sortBy: SortBySearchOption.Name,
     sortOrder: SortOrder.Ascending,
   },
-  [SortBy.NameDesc]: {
+  [SortByUserOption.NameDesc]: {
     sortBy: SortBySearchOption.Name,
     sortOrder: SortOrder.Descending,
   },

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -64,7 +64,6 @@ export type HeritageObject = {
 export enum SortBy {
   DateCreated = 'dateCreated',
   Name = 'name',
-  Relevance = 'relevance', // Obsolete, for BC - remove as soon as DateCreated is implemented
 }
 
 export const SortByEnum = z.nativeEnum(SortBy);

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -62,8 +62,8 @@ export type HeritageObject = {
 };
 
 export enum SortBy {
+  DateCreated = 'dateCreated',
   Name = 'name',
-  Relevance = 'relevance',
 }
 
 export const SortByEnum = z.nativeEnum(SortBy);

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -64,6 +64,7 @@ export type HeritageObject = {
 export enum SortBy {
   DateCreated = 'dateCreated',
   Name = 'name',
+  Relevance = 'relevance', // Obsolete, for BC - remove as soon as DateCreated is implemented
 }
 
 export const SortByEnum = z.nativeEnum(SortBy);

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -24,9 +24,79 @@ describe('search', () => {
       totalCount: 5,
       offset: 0,
       limit: 10,
-      sortBy: 'relevance',
-      sortOrder: 'desc',
+      sortBy: 'dateCreated',
+      sortOrder: 'asc',
       heritageObjects: [
+        {
+          id: 'https://example.org/objects/3',
+          identifier: '9012',
+          name: 'Object 3',
+          description:
+            'Ut dictum elementum augue sit amet sodales. Vivamus viverra ligula sed arcu cursus sagittis. Donec ac placerat lacus.',
+          types: expect.arrayContaining([
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Drawing',
+            },
+          ]),
+          subjects: expect.arrayContaining([
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Castle',
+            },
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Cottage',
+            },
+          ]),
+          inscriptions: ['Maecenas commodo est neque'],
+          materials: expect.arrayContaining([
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Ink',
+            },
+            {
+              id: expect.stringContaining(
+                'https://data.colonialcollections.nl/.well-known/genid/'
+              ),
+              name: 'Paper',
+            },
+          ]),
+          dateCreated: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1725-01-01T00:00:00.000Z'),
+            endDate: new Date('1736-01-01T00:00:00.000Z'),
+          },
+          locationsCreated: expect.arrayContaining([
+            {
+              id: 'https://sws.geonames.org/1642673/',
+              name: 'Java',
+              isPartOf: {
+                id: 'https://sws.geonames.org/1643084/',
+                name: 'Indonesia',
+              },
+            },
+          ]),
+          isPartOf: {
+            id: 'https://example.org/datasets/10',
+            name: 'Dataset 10',
+            publisher: {
+              id: 'https://library.example.org/',
+              type: 'Organization',
+              name: 'Library',
+            },
+          },
+        },
         {
           id: 'https://example.org/objects/1',
           identifier: '1234',
@@ -54,13 +124,13 @@ describe('search', () => {
               id: expect.stringContaining(
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
-              name: 'Canvas',
+              name: 'Oilpaint',
             },
             {
               id: expect.stringContaining(
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
-              name: 'Oilpaint',
+              name: 'Canvas',
             },
           ]),
           creators: expect.arrayContaining([
@@ -199,88 +269,6 @@ describe('search', () => {
           },
         },
         {
-          id: 'https://example.org/objects/3',
-          identifier: '9012',
-          name: 'Object 3',
-          description:
-            'Ut dictum elementum augue sit amet sodales. Vivamus viverra ligula sed arcu cursus sagittis. Donec ac placerat lacus.',
-          types: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Drawing',
-            },
-          ]),
-          subjects: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Cottage',
-            },
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Castle',
-            },
-          ]),
-          inscriptions: ['Maecenas commodo est neque'],
-          materials: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Paper',
-            },
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Ink',
-            },
-          ]),
-          dateCreated: {
-            id: expect.stringContaining(
-              'https://data.colonialcollections.nl/.well-known/genid/'
-            ),
-            startDate: new Date('1725-01-01T00:00:00.000Z'),
-            endDate: new Date('1736-01-01T00:00:00.000Z'),
-          },
-          locationsCreated: expect.arrayContaining([
-            {
-              id: 'https://sws.geonames.org/1642673/',
-              name: 'Java',
-              isPartOf: {
-                id: 'https://sws.geonames.org/1643084/',
-                name: 'Indonesia',
-              },
-            },
-          ]),
-          isPartOf: {
-            id: 'https://example.org/datasets/10',
-            name: 'Dataset 10',
-            publisher: {
-              id: 'https://library.example.org/',
-              type: 'Organization',
-              name: 'Library',
-            },
-          },
-        },
-        {
-          id: 'https://example.org/objects/4',
-          isPartOf: {
-            id: 'https://example.org/datasets/1',
-            name: 'Dataset 1',
-            publisher: {
-              id: 'https://museum.example.org/',
-              type: 'Organization',
-              name: 'Museum',
-            },
-          },
-        },
-        {
           id: 'https://example.org/objects/5',
           identifier: '7890',
           name: 'Object 5',
@@ -357,10 +345,10 @@ describe('search', () => {
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
               contentUrl:
-                'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
+                'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
               license: {
-                id: 'https://creativecommons.org/publicdomain/zero/1.0/',
-                name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
+                id: 'https://creativecommons.org/licenses/by/4.0/',
+                name: 'Attribution 4.0 International (CC BY 4.0)',
               },
             },
             {
@@ -368,13 +356,25 @@ describe('search', () => {
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
               contentUrl:
-                'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
+                'http://images.memorix.nl/rce/thumb/1600x1600/e0164095-6a2d-b448-cc59-3a8ab2fafed7.jpg',
               license: {
-                id: 'https://creativecommons.org/licenses/by/4.0/',
-                name: 'Attribution 4.0 International (CC BY 4.0)',
+                id: 'https://creativecommons.org/publicdomain/zero/1.0/',
+                name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
               },
             },
           ]),
+          isPartOf: {
+            id: 'https://example.org/datasets/1',
+            name: 'Dataset 1',
+            publisher: {
+              id: 'https://museum.example.org/',
+              type: 'Organization',
+              name: 'Museum',
+            },
+          },
+        },
+        {
+          id: 'https://example.org/objects/4',
           isPartOf: {
             id: 'https://example.org/datasets/1',
             name: 'Dataset 1',

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -32,8 +32,8 @@ enum RawKeys {
 }
 
 const sortByToRawKeys = new Map<string, string>([
-  [SortBy.Name, `${RawKeys.Name}.keyword`], // TBD: name may not exist
-  [SortBy.Relevance, '_score'],
+  [SortBy.Name, `${RawKeys.Name}.keyword`],
+  [SortBy.DateCreated, RawKeys.YearCreatedStart],
 ]);
 
 // TBD: add language option, for returning results in a specific locale (e.g. 'nl', 'en')
@@ -41,8 +41,8 @@ const searchOptionsSchema = z.object({
   query: z.string().optional().default('*'), // If no query provided, match all
   offset: z.number().int().nonnegative().optional().default(0),
   limit: z.number().int().positive().optional().default(10),
-  sortBy: SortByEnum.optional().default(SortBy.Relevance),
-  sortOrder: SortOrderEnum.optional().default(SortOrder.Descending),
+  sortBy: SortByEnum.optional().default(SortBy.DateCreated),
+  sortOrder: SortOrderEnum.optional().default(SortOrder.Ascending),
   filters: z
     .object({
       types: z.array(z.string()).optional().default([]),

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -169,7 +169,8 @@
     "aboutFacetsText": "The data of these facet items are collected from multiple datasets. We are in the process of improving the quality of these facets items."
   },
   "Sort": {
-    "relevanceDesc": "Relevance",
+    "dateCreatedDesc": "Date created - Descending",
+    "dateCreatedAsc": "Date created - Ascending",
     "nameAsc": "Name - Ascending",
     "nameDesc": "Name - Descending",
     "createdAtDesc": "Date created",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -99,7 +99,7 @@
     "addedBy": "Added by <name></name>",
     "currentPublisher": "Current location of object",
     "noOrganizationFound": "No organization found.",
-    "dateCreated": "Date Made",
+    "dateCreated": "Date made",
     "dateCreatedSubTitle": "When was the object made? Could be an exact date or a range.",
     "beginOfRange": "Begin of range",
     "endOfRange": "End of range",
@@ -169,11 +169,11 @@
     "aboutFacetsText": "The data of these facet items are collected from multiple datasets. We are in the process of improving the quality of these facets items."
   },
   "Sort": {
-    "dateCreatedDesc": "Date created - Descending",
-    "dateCreatedAsc": "Date created - Ascending",
+    "dateCreatedDesc": "Date made - Descending",
+    "dateCreatedAsc": "Date made - Ascending",
     "nameAsc": "Name - Ascending",
     "nameDesc": "Name - Descending",
-    "createdAtDesc": "Date created",
+    "createdAtDesc": "Date made",
     "membershipCountDesc": "Number of members",
     "accessibilitySelectToChangeOrder": "Select to change the ordering of the result"
   },

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -169,11 +169,11 @@
     "aboutFacetsText": "De gegevens van deze facetten worden verzameld uit meerdere datasets. We zijn bezig de kwaliteit van deze facetten te verbeteren."
   },
   "Sort": {
-    "dateCreatedDesc": "Datum gecreeërd - Oplopend",
-    "dateCreatedAsc": "Datum gecreeërd - Aflopend",
+    "dateCreatedDesc": "Datum gemaakt - Oplopend",
+    "dateCreatedAsc": "Datum gemaakt - Aflopend",
     "nameAsc": "Naam - Oplopend",
     "nameDesc": "Naam - Aflopend",
-    "createdAtDesc": "Datum gecreeërd",
+    "createdAtDesc": "Datum gemaakt",
     "membershipCountDesc": "Aantal leden",
     "accessibilitySelectToChangeOrder": "Selecteer om de volgorde van het resultaat te wijzigen"
   },

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -169,7 +169,8 @@
     "aboutFacetsText": "De gegevens van deze facetten worden verzameld uit meerdere datasets. We zijn bezig de kwaliteit van deze facetten te verbeteren."
   },
   "Sort": {
-    "relevanceDesc": "Relevantie",
+    "dateCreatedDesc": "Datum gecreeërd - Oplopend",
+    "dateCreatedAsc": "Datum gecreeërd - Aflopend",
     "nameAsc": "Naam - Oplopend",
     "nameDesc": "Naam - Aflopend",
     "createdAtDesc": "Datum gecreeërd",


### PR DESCRIPTION
This PR:

1. Removes the 'sort by relevance' option from the 'heritage objects' API
2. Adds the 'sort by date made' option to the 'heritage objects' API

Beware: this PR only changes the API - the parts in the frontend using the API will break. @barbarah Could you determine how you want to integrate this API change in the frontend?