### PR TITLE
Fix no license text

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
@@ -304,7 +304,10 @@ export default async function Details({params}: Props) {
           <aside className="w-full md:w-1/3 self-stretch order-1 md:order-2  md:mx-0 md:bg-consortiumBlue-900 p-1">
             {galleryImages.length > 0 && (
               <div className="flex flex-row md:flex-col gap-1 sticky top-4">
-                <Gallery images={galleryImages} />
+                <Gallery
+                  images={galleryImages}
+                  organizationName={organization?.name}
+                />
               </div>
             )}
           </aside>

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -192,7 +192,7 @@
   "Gallery": {
     "resetZoomButton": "Reset",
     "license": "License",
-    "noLicense": "This image has been published by {organizationName} without a license - for more information please contact {organizationName}."
+    "noLicense": "We could not find a license for this image - for more information please contact {organizationName}."
   },
   "ErrorPage": {
     "message": "Something went wrong!"

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -192,7 +192,7 @@
   "Gallery": {
     "resetZoomButton": "Reset",
     "license": "License",
-    "noLicense": "We could not find a license for this image - for more information please contact {organizationName}."
+    "noLicense": "No licence found for this image - for more information please contact {organizationName}."
   },
   "ErrorPage": {
     "message": "Something went wrong!"

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -192,7 +192,7 @@
   "Gallery": {
     "resetZoomButton": "Reset",
     "license": "Licentie",
-    "noLicense": "Deze afbeelding is door {organizationName} gepubliceerd zonder vermelding van een licentie - neem contact met {organizationName} op voor meer informatie."
+    "noLicense": "We konden geen licentie voor deze afbeelding vinden. Neem voor meer informatie contact op met {organizationName}."
   },
   "ErrorPage": {
     "message": "Er is iets fout gegaan!"

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -192,7 +192,7 @@
   "Gallery": {
     "resetZoomButton": "Reset",
     "license": "Licentie",
-    "noLicense": "We konden geen licentie voor deze afbeelding vinden. Neem voor meer informatie contact op met {organizationName}."
+    "noLicense": "Geen licentie gevonden voor deze afbeelding. Neem voor meer informatie contact op met {organizationName}."
   },
   "ErrorPage": {
     "message": "Er is iets fout gegaan!"


### PR DESCRIPTION
Ticket: https://github.com/colonial-heritage/sprints/issues/363
If there is no license, the text is: "This image has been published without a license - for more information, please contact {contact name}."

- BUG: {contact name} is always empty
- Nuance the text. "we could not find a license."

Example: 

- Production https://app.colonialcollections.nl/en/objects/https%3A%2F%2Fn2t%252Enet%2Fark%3A%2F27023%2F243efd83618d8e04d052071f051c3fd9
- New version: https://colonial-collections-researcher-oqlcykhox-colonial-heritage.vercel.app/nl/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F2