### PR TITLE
fix: dates

### DIFF
--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -38,6 +38,7 @@
     "@next/mdx": "14.0.4",
     "classnames": "2.3.2",
     "defu": "6.1.3",
+    "edtf": "4.6.0",
     "fetch-sparql-endpoint": "4.1.0",
     "iso-639-1-dir": "3.0.5",
     "jwt-decode": "^4.0.0",

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -40,8 +40,8 @@ export type Image = {
 
 export type TimeSpan = {
   id: string;
-  startDate?: Date; // TBD: change to string to allow for uncertain dates (e.g. EDTF)?
-  endDate?: Date; // TBD: change to string to allow for uncertain dates (e.g. EDTF)?
+  startDate?: Date;
+  endDate?: Date;
 };
 
 export type HeritageObject = {
@@ -84,8 +84,9 @@ export type SearchResultFilter = {
 export type ProvenanceEvent = {
   id: string;
   types?: Term[];
-  startDate?: Date;
-  endDate?: Date;
+  date?: TimeSpan;
+  startDate?: Date; // For BC; remove when prop date is in use
+  endDate?: Date; // For BC; remove when prop date is in use
   transferredFrom?: Agent;
   transferredTo?: Agent;
   description?: string;

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -22,7 +22,7 @@ describe('getByIds', () => {
       'https://unknown.org/',
     ]);
 
-    expect(heritageObjects).toStrictEqual([]);
+    expect(heritageObjects).toEqual([]);
   });
 
   it('returns the heritage objects that match the IDs', async () => {

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -14,7 +14,7 @@ describe('getByIds', () => {
   it('returns empty list if no IDs were provided', async () => {
     const heritageObjects = await heritageObjectFetcher.getByIds([]);
 
-    expect(heritageObjects).toStrictEqual([]);
+    expect(heritageObjects).toEqual([]);
   });
 
   it('returns empty list if no heritage objects match the IDs', async () => {

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -11,6 +11,12 @@ beforeEach(() => {
 });
 
 describe('getByIds', () => {
+  it('returns empty list if no IDs were provided', async () => {
+    const heritageObjects = await heritageObjectFetcher.getByIds([]);
+
+    expect(heritageObjects).toStrictEqual([]);
+  });
+
   it('returns empty list if no heritage objects match the IDs', async () => {
     const heritageObjects = await heritageObjectFetcher.getByIds([
       'https://unknown.org/',
@@ -114,8 +120,8 @@ describe('getById', () => {
         id: expect.stringContaining(
           'https://data.colonialcollections.nl/.well-known/genid/'
         ),
-        startDate: new Date('1901-01-01'),
-        endDate: new Date('1902-06-01'),
+        startDate: new Date('1901-01-01T00:00:00.000Z'),
+        endDate: new Date('1902-06-30T23:59:59.999Z'),
       },
       locationsCreated: expect.arrayContaining([
         {

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -154,6 +154,9 @@ export class HeritageObjectFetcher {
         OPTIONAL {
           ?object crm:P2_has_type ?type .
           ?type rdfs:label ?typeName .
+
+          # For BC; remove as soon as locale-aware names are in use
+          FILTER(LANG(?typeName) = "" || LANG(?typeName) = "en")
         }
 
         ####################
@@ -163,6 +166,9 @@ export class HeritageObjectFetcher {
         OPTIONAL {
           ?object crm:P62_depicts ?subject .
           ?subject rdfs:label ?subjectName .
+
+          # For BC; remove as soon as locale-aware names are in use
+          FILTER(LANG(?subjectName) = "" || LANG(?subjectName) = "en")
         }
 
         ####################
@@ -183,6 +189,9 @@ export class HeritageObjectFetcher {
         OPTIONAL {
           ?object crm:P45_consists_of ?material .
           ?material rdfs:label ?materialName .
+
+          # For BC; remove as soon as locale-aware names are in use
+          FILTER(LANG(?materialName) = "" || LANG(?materialName) = "en")
         }
 
         ####################
@@ -192,6 +201,9 @@ export class HeritageObjectFetcher {
         OPTIONAL {
           ?object crm:P108i_was_produced_by/crm:P32_used_general_technique ?technique .
           ?technique rdfs:label ?techniqueName .
+
+          # For BC; remove as soon as locale-aware names are in use
+          FILTER(LANG(?techniqueName) = "" || LANG(?techniqueName) = "en")
         }
 
         ####################
@@ -232,15 +244,12 @@ export class HeritageObjectFetcher {
 
         OPTIONAL {
           ?object crm:P108i_was_produced_by/crm:P7_took_place_at ?locationCreated .
-          ?locationCreated gn:name ?locationCreatedName ;
-            gn:featureCode ?featureCode .
-          FILTER(LANG(?locationCreatedName) = "" || LANGMATCHES(LANG(?locationCreatedName), "en"))
+          ?locationCreated gn:name ?locationCreatedName .
 
           # Country of which the location is a part
           OPTIONAL {
             ?locationCreated gn:parentCountry ?countryCreated .
             ?countryCreated gn:name ?countryCreatedName .
-            FILTER(LANG(?countryCreatedName) = "" || LANGMATCHES(LANG(?countryCreatedName), "en"))
           }
         }
 
@@ -261,7 +270,7 @@ export class HeritageObjectFetcher {
 
             OPTIONAL {
               ?digitalObjectLicense schema:name ?digitalObjectLicenseName .
-              FILTER(LANG(?digitalObjectLicenseName) = "" || LANGMATCHES(LANG(?digitalObjectLicenseName), "en"))
+              FILTER(LANG(?digitalObjectLicenseName) = "" || LANG(?digitalObjectLicenseName) = "en")
             }
           }
         }
@@ -279,7 +288,9 @@ export class HeritageObjectFetcher {
 
           OPTIONAL {
             ?dataset schema:name ?datasetName
-            FILTER(LANG(?datasetName) = "" || LANGMATCHES(LANG(?datasetName), "en"))
+
+            # For BC; remove as soon as locale-aware names are in use
+            FILTER(LANG(?datasetName) = "" || LANG(?datasetName) = "en")
           }
 
           ####################
@@ -290,6 +301,9 @@ export class HeritageObjectFetcher {
             ?dataset schema:publisher ?publisher .
             ?publisher schema:name ?publisherName ;
               rdf:type ?publisherTypeTemp .
+
+            # For BC; remove as soon as locale-aware names are in use
+            FILTER(LANG(?publisherName) = "" || LANG(?publisherName) = "en")
 
             VALUES (?publisherTypeTemp ?publisherType) {
               (schema:Organization ex:Organization)
@@ -391,6 +405,10 @@ export class HeritageObjectFetcher {
   }
 
   async getByIds(ids: string[]) {
+    if (ids.length === 0) {
+      return [];
+    }
+
     const triplesStream = await this.fetchTriples(ids);
     const heritageObjects = await this.fromTriplesToHeritageObjects(
       ids,

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -53,8 +53,15 @@ describe('getByHeritageObjectId', () => {
             },
           ],
           description: 'Bought at an auction in Amsterdam',
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1879-01-01T00:00:00.000Z'),
+            endDate: new Date('1879-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           endsBefore:
@@ -87,8 +94,15 @@ describe('getByHeritageObjectId', () => {
             },
           ],
           description: 'Found in a basement',
-          startDate: new Date('1939-01-01T00:00:00.000Z'),
-          endDate: new Date('1940-01-01T00:00:00.000Z'),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1939-01-01T00:00:00.000Z'),
+            endDate: new Date('1940-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1939-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1940-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
@@ -111,8 +125,15 @@ describe('getByHeritageObjectId', () => {
               name: 'theft (social issue)',
             },
           ],
-          startDate: new Date('1901-01-01T00:00:00.000Z'),
-          endDate: new Date('1901-01-01T00:00:00.000Z'),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1901-01-01T00:00:00.000Z'),
+            endDate: new Date('1901-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/5/activity/1',
           endsBefore:
@@ -138,8 +159,15 @@ describe('getByHeritageObjectId', () => {
             },
           ],
           description: 'Bought at an auction in The Hague',
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1879-01-01T00:00:00.000Z'),
+            endDate: new Date('1879-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/1/activity/1',
           endsBefore:
@@ -178,8 +206,15 @@ describe('getByHeritageObjectId', () => {
             },
           ],
           description: 'Bought for 1500 US dollars',
-          startDate: new Date('1855-01-01T00:00:00.000Z'),
-          endDate: new Date('1857-01-01T00:00:00.000Z'),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1855-01-01T00:00:00.000Z'),
+            endDate: new Date('1857-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1855-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1857-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           endsBefore:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {

--- a/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
+++ b/apps/researcher/src/lib/api/objects/rdf-helpers.test.ts
@@ -29,7 +29,7 @@ beforeAll(async () => {
       ex:subject ex:subject1, ex:subject2 ;
       ex:creator ex:creator1, ex:creator2, ex:creator3, ex:creator4 ;
       ex:image ex:image1, ex:image2, ex:image3 ;
-      ex:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3 ;
+      ex:dateCreated ex:dateCreated1, ex:dateCreated2, ex:dateCreated3, ex:dateCreated4 ;
       ex:locationCreated ex:location1, ex:location2 ;
       ex:isPartOf ex:dataset1, ex:dataset2, ex:dataset3 .
 
@@ -61,8 +61,8 @@ beforeAll(async () => {
     ex:image3 a ex:Image .
 
     ex:dateCreated1 a ex:TimeSpan ;
-      ex:startDate "1889"^^xsd:gYear ;
-      ex:endDate "1900"^^xsd:gYear .
+      ex:startDate "-1900"^^xsd:gYear ;
+      ex:endDate "-1889"^^xsd:gYear .
 
     # No end date
     ex:dateCreated2 a ex:TimeSpan ;
@@ -71,6 +71,10 @@ beforeAll(async () => {
     # No start date
     ex:dateCreated3 a ex:TimeSpan ;
       ex:endDate "1900"^^xsd:gYear .
+
+    # Invalid date
+    ex:dateCreated4 a ex:TimeSpan ;
+      ex:startDate "badValue" .
 
     ex:location1 a ex:Place ;
       ex:name "City 1" .
@@ -224,18 +228,23 @@ describe('createTimeSpan', () => {
     expect(timeSpans).toStrictEqual([
       {
         id: 'https://example.org/dateCreated1',
-        startDate: new Date('1889-01-01'),
-        endDate: new Date('1900-01-01'),
+        startDate: new Date('-001900-01-01T00:00:00.000Z'),
+        endDate: new Date('-001889-12-31T23:59:59.999Z'),
       },
       {
         id: 'https://example.org/dateCreated2',
-        startDate: new Date('1889-01-01'),
+        startDate: new Date('1889-01-01T00:00:00.000Z'),
         endDate: undefined,
       },
       {
         id: 'https://example.org/dateCreated3',
         startDate: undefined,
-        endDate: new Date('1900-01-01'),
+        endDate: new Date('1900-12-31T23:59:59.999Z'),
+      },
+      {
+        id: 'https://example.org/dateCreated4',
+        startDate: undefined,
+        endDate: undefined,
       },
     ]);
   });

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -61,21 +61,21 @@ describe('search', () => {
               id: expect.stringContaining(
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
-              name: 'Ink',
+              name: 'Paper',
             },
             {
               id: expect.stringContaining(
                 'https://data.colonialcollections.nl/.well-known/genid/'
               ),
-              name: 'Paper',
+              name: 'Ink',
             },
           ]),
           dateCreated: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
             ),
-            startDate: new Date('1725-01-01T00:00:00.000Z'),
-            endDate: new Date('1736-01-01T00:00:00.000Z'),
+            startDate: new Date('-001736-01-01T00:00:00.000Z'),
+            endDate: new Date('-001725-12-31T23:59:59.999Z'),
           },
           locationsCreated: expect.arrayContaining([
             {
@@ -103,36 +103,6 @@ describe('search', () => {
           name: 'Object 1',
           description:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultrices velit vitae vulputate tincidunt. Donec dictum tortor nec tempus mollis.',
-          types: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Painting',
-            },
-          ]),
-          subjects: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Celebrations',
-            },
-          ]),
-          materials: expect.arrayContaining([
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Oilpaint',
-            },
-            {
-              id: expect.stringContaining(
-                'https://data.colonialcollections.nl/.well-known/genid/'
-              ),
-              name: 'Canvas',
-            },
-          ]),
           creators: expect.arrayContaining([
             {
               id: expect.stringContaining(
@@ -147,7 +117,7 @@ describe('search', () => {
               'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             startDate: new Date('1889-05-01T00:00:00.000Z'),
-            endDate: new Date('1890-12-01T00:00:00.000Z'),
+            endDate: new Date('1890-12-31T23:59:59.999Z'),
           },
           locationsCreated: expect.arrayContaining([
             {
@@ -237,7 +207,7 @@ describe('search', () => {
               'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             startDate: new Date('1895-02-01T00:00:00.000Z'),
-            endDate: new Date('1895-02-15T00:00:00.000Z'),
+            endDate: new Date('1895-02-15T23:59:59.999Z'),
           },
           locationsCreated: expect.arrayContaining([
             {
@@ -327,7 +297,7 @@ describe('search', () => {
               'https://data.colonialcollections.nl/.well-known/genid/'
             ),
             startDate: new Date('1901-01-01T00:00:00.000Z'),
-            endDate: new Date('1902-06-01T00:00:00.000Z'),
+            endDate: new Date('1902-06-30T23:59:59.999Z'),
           },
           locationsCreated: expect.arrayContaining([
             {
@@ -400,25 +370,20 @@ describe('search', () => {
           },
           {
             totalCount: 1,
-            id: 'Painting',
-            name: 'Painting',
-          },
-          {
-            totalCount: 1,
             id: 'Photo',
             name: 'Photo',
           },
         ],
         subjects: [
           {
-            totalCount: 2,
-            id: 'Celebrations',
-            name: 'Celebrations',
-          },
-          {
             totalCount: 1,
             id: 'Castle',
             name: 'Castle',
+          },
+          {
+            totalCount: 1,
+            id: 'Celebrations',
+            name: 'Celebrations',
           },
           {
             totalCount: 1,
@@ -451,23 +416,23 @@ describe('search', () => {
         materials: [
           {
             totalCount: 2,
-            id: 'Canvas',
-            name: 'Canvas',
-          },
-          {
-            totalCount: 2,
-            id: 'Oilpaint',
-            name: 'Oilpaint',
-          },
-          {
-            totalCount: 2,
             id: 'Paper',
             name: 'Paper',
           },
           {
             totalCount: 1,
+            id: 'Canvas',
+            name: 'Canvas',
+          },
+          {
+            totalCount: 1,
             id: 'Ink',
             name: 'Ink',
+          },
+          {
+            totalCount: 1,
+            id: 'Oilpaint',
+            name: 'Oilpaint',
           },
         ],
         creators: [
@@ -495,16 +460,6 @@ describe('search', () => {
           },
           {
             totalCount: 1,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
-            totalCount: 1,
-            id: 'Onderzoeksinstelling',
-            name: 'Onderzoeksinstelling',
-          },
-          {
-            totalCount: 1,
             id: 'Research Organisation',
             name: 'Research Organisation',
           },
@@ -512,8 +467,8 @@ describe('search', () => {
         dateCreatedStart: [
           {
             totalCount: 1,
-            id: 1725,
-            name: 1725,
+            id: -1736,
+            name: -1736,
           },
           {
             totalCount: 1,
@@ -534,8 +489,8 @@ describe('search', () => {
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: 1736,
-            name: 1736,
+            id: -1725,
+            name: -1725,
           },
           {
             totalCount: 1,
@@ -565,11 +520,11 @@ describe('search', () => {
     });
 
     expect(result).toMatchObject({
-      totalCount: 2,
+      totalCount: 1,
       filters: {
         materials: [
-          {totalCount: 2, id: 'Canvas', name: 'Canvas'},
-          {totalCount: 2, id: 'Oilpaint', name: 'Oilpaint'},
+          {totalCount: 1, id: 'Canvas', name: 'Canvas'},
+          {totalCount: 1, id: 'Oilpaint', name: 'Oilpaint'},
         ],
       },
     });
@@ -578,14 +533,16 @@ describe('search', () => {
   it('finds heritage objects if "types" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        types: ['Painting'],
+        types: ['Canvas Painting'],
       },
     });
 
     expect(result).toMatchObject({
       totalCount: 1,
       filters: {
-        types: [{totalCount: 1, id: 'Painting', name: 'Painting'}],
+        types: [
+          {totalCount: 1, id: 'Canvas Painting', name: 'Canvas Painting'},
+        ],
       },
     });
   });
@@ -631,16 +588,16 @@ describe('search', () => {
     });
 
     expect(result).toMatchObject({
-      totalCount: 2,
+      totalCount: 1,
       filters: {
         materials: [
           {
-            totalCount: 2,
+            totalCount: 1,
             id: 'Canvas',
             name: 'Canvas',
           },
           {
-            totalCount: 2,
+            totalCount: 1,
             id: 'Oilpaint',
             name: 'Oilpaint',
           },
@@ -673,18 +630,18 @@ describe('search', () => {
   it('finds heritage objects if "publishers" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        publishers: ['Library'],
+        publishers: ['Museum'],
       },
     });
 
     expect(result).toMatchObject({
-      totalCount: 1,
+      totalCount: 3,
       filters: {
         publishers: [
           {
-            totalCount: 1,
-            id: 'Library',
-            name: 'Library',
+            totalCount: 3,
+            id: 'Museum',
+            name: 'Museum',
           },
         ],
       },
@@ -715,7 +672,7 @@ describe('search', () => {
   it('finds heritage objects if "dateCreatedEnd" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedEnd: 1736,
+        dateCreatedEnd: -1725,
       },
     });
 
@@ -725,8 +682,8 @@ describe('search', () => {
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: 1736,
-            name: 1736,
+            id: -1725,
+            name: -1725,
           },
         ],
       },
@@ -736,7 +693,7 @@ describe('search', () => {
   it('finds heritage objects between "dateCreatedStart" and "dateCreatedEnd", inclusive', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        dateCreatedStart: 1725,
+        dateCreatedStart: -1736,
         dateCreatedEnd: 1895,
       },
     });
@@ -747,8 +704,8 @@ describe('search', () => {
         dateCreatedStart: [
           {
             totalCount: 1,
-            id: 1725,
-            name: 1725,
+            id: -1736,
+            name: -1736,
           },
           {
             totalCount: 1,
@@ -764,8 +721,8 @@ describe('search', () => {
         dateCreatedEnd: [
           {
             totalCount: 1,
-            id: 1736,
-            name: 1736,
+            id: -1725,
+            name: -1725,
           },
           {
             totalCount: 1,

--- a/apps/researcher/src/lib/api/objects/types.d.ts
+++ b/apps/researcher/src/lib/api/objects/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'edtf';

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "@next/mdx": "14.0.4",
         "classnames": "2.3.2",
         "defu": "6.1.3",
+        "edtf": "4.6.0",
         "fetch-sparql-endpoint": "4.1.0",
         "iso-639-1-dir": "3.0.5",
         "jwt-decode": "^4.0.0",
@@ -5415,6 +5416,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -5508,6 +5514,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dreamopt": {
@@ -6094,6 +6109,17 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/edtf": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/edtf/-/edtf-4.6.0.tgz",
+      "integrity": "sha512-teU7GwHONv5v9L3PGXlki7d/ISi2HFxXbXSGx0mWh7Lq7ezYmxkmDYVKzBXdhFjhvASEUnDontPvGzIlYASYRA==",
+      "dependencies": {
+        "nearley": "^2.19.7"
+      },
+      "optionalDependencies": {
+        "randexp": "^0.5.3"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -10720,6 +10746,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10842,6 +10873,52 @@
       "dev": true,
       "bin": {
         "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/nearley/node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/nearley/node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/negotiator": {
@@ -11880,6 +11957,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "optional": true,
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rdf-data-factory": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
@@ -12419,6 +12514,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {


### PR DESCRIPTION
This PR fixes some issues that we have with dates of objects and provenance events:

1. Negative dates (e.g. `-1714`) are currently changed to positive dates (e.g. `1714`)
2. Dates with only years (e.g. `1948`) are currently changed to January 1 of these years (e.g `1948-01-01`), which could suggest that objects weren't made or provenance events didn't took place in that year.

The PR addresses these issues by introducing a new package, EDTF. This package parses the start date and end date of an object and its provenance events. It returns a string notation that respects the negative dates, sets a start date such as `1947` to `1947-01-01` and an end date such as `1948` to `1948-12-31`, to make clear that the object was created somewhere in that year or that a provenance event took place somewhere in that year.

In its slipstream this PR also fixes an issue where the API attempts to fetch results from its SPARQL endpoint even though Elasticsearch already made clear that there are no results.