### PR TITLE
Provenance fixes

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/buttons.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/buttons.tsx
@@ -2,7 +2,7 @@
 
 import classNames from 'classnames';
 import {useProvenance} from './provenance-store';
-import {ButtonHTMLAttributes, ReactNode} from 'react';
+import {ButtonHTMLAttributes, MouseEvent, ReactNode} from 'react';
 import {useTranslations} from 'next-intl';
 
 interface SelectEventsButtonProps
@@ -15,12 +15,13 @@ export function SelectEventsButton({ids, children}: SelectEventsButtonProps) {
   const {setSelectedEvents, selectedEvents} = useProvenance();
   const selected = ids.some((id: string) => selectedEvents.includes(id));
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (selected) {
       setSelectedEvents(selectedEvents.filter(id => !ids.includes(id)));
     } else {
       setSelectedEvents(ids);
     }
+    event.stopPropagation();
   };
 
   return (

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
@@ -79,7 +79,7 @@ function ProvenanceEventRow({
   return (
     <div className="border-l-4 mb-16 border-consortiumBlue-950">
       <div className="mb-4 pl-4">
-        <strong>{dateRange}</strong>
+        <strong>{dateRange || t('noDate')}</strong>
       </div>
       <ul className="flex flex-col border-t border-consortiumBlue-500">
         {provenanceEvents.map(event => (

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import {SlideOut, SlideOutButton} from '@colonial-collections/ui';
+import {SlideOut, useSlideOut} from '@colonial-collections/ui';
 import type {LabeledProvenanceEvent} from './definitions';
 import {useLocale, useTranslations} from 'next-intl';
-import {InformationCircleIcon} from '@heroicons/react/24/outline';
 import {groupByDateRange} from './group-events';
 import {useProvenance} from './provenance-store';
 import {SelectEventsButton} from './buttons';
@@ -75,6 +74,7 @@ function ProvenanceEventRow({
   dateRange,
 }: ProvenanceEventRowProps) {
   const t = useTranslations('Provenance');
+  const {setIsVisible, isVisible} = useSlideOut();
 
   return (
     <div className="border-l-4 mb-16 border-consortiumBlue-950">
@@ -85,47 +85,48 @@ function ProvenanceEventRow({
         {provenanceEvents.map(event => (
           <li
             key={event.id}
-            className="list-none pl-4 w-full text-sm md:text-base border-b border-consortiumBlue-500"
+            className="list-none pl-4 w-full text-sm md:text-base border-b border-consortiumBlue-700 hover:bg-consortiumBlue-600 hover:cursor-pointer"
+            onClick={() =>
+              setIsVisible(
+                `eventDescription-${event.id}`,
+                !isVisible(`eventDescription-${event.id}`)
+              )
+            }
           >
-            <div className="w-full flex flex-col gap-2 lg:gap-4 sm:flex-row justify-between items-center py-2">
-              <div className="w-full md:w-1/12 flex flex-col lg:flex-row items-center gap-2">
-                <div className="flex flex-col gap-2">
-                  <div>
-                    <SelectEventsButton ids={[event.id]}>
-                      {event.label}
-                    </SelectEventsButton>
-                    {event.description && (
-                      <SlideOutButton
-                        id={`eventDescription-${event.id}`}
-                        className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-consortiumBlue-100 hover:bg-white text-consortiumBlue-800 transition flex items-center gap-1"
-                      >
-                        <InformationCircleIcon className="w-5 h-5 stroke-consortiumBlue-800" />
-                      </SlideOutButton>
-                    )}
+            <div
+              id={`eventDescription-${event.id}`}
+              className="w-full flex flex-col gap-2 lg:gap-4 sm:flex-row justify-between items-center py-2"
+            >
+              <>
+                <div className="w-full md:w-1/12 flex flex-col lg:flex-row items-center gap-2">
+                  <div className="flex flex-col gap-2">
+                    <div>
+                      <SelectEventsButton ids={[event.id]}>
+                        {event.label}
+                      </SelectEventsButton>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div className="w-full md:w-2/12">
-                <div>{event.types?.map(type => type.name).join(', ')}</div>
-              </div>
-              <div className="w-full md:w-3/12">
-                {event.transferredFrom?.name}
-              </div>
-              <div className="w-full md:w-3/12">
-                {event.transferredTo?.name}
-              </div>
-              <div className="w-full md:w-1/12">{event.location?.name}</div>
+                <div className="w-full md:w-2/12">
+                  <div>{event.types?.map(type => type.name).join(', ')}</div>
+                </div>
+                <div className="w-full md:w-3/12">
+                  {event.transferredFrom?.name}
+                </div>
+                <div className="w-full md:w-3/12">
+                  {event.transferredTo?.name}
+                </div>
+                <div className="w-full md:w-1/12">{event.location?.name}</div>
+              </>
             </div>
-            {event.description && (
-              <SlideOut id={`eventDescription-${event.id}`}>
-                <div className="w-full py-2 block" id="showProvDescrip">
-                  <div className="w-full max-w-2xl flex flex-col">
-                    <strong>{t('descriptionTitle')}</strong>
-                    {event.description}
-                  </div>
+            <SlideOut id={`eventDescription-${event.id}`}>
+              <div className="w-full py-2 block" id="showProvDescrip">
+                <div className="w-full max-w-2xl flex flex-col">
+                  <strong>{t('descriptionTitle')}</strong>
+                  {event.description || t('noDescription')}
                 </div>
-              </SlideOut>
-            )}
+              </div>
+            </SlideOut>
           </li>
         ))}
       </ul>

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/overview.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/overview.tsx
@@ -11,7 +11,7 @@ export default async function Provenance({objectId}: {objectId: string}) {
     await heritageObjects.getProvenanceEventsByHeritageObjectId(objectId);
   const t = await getTranslations('Provenance');
 
-  if (!events) {
+  if (!events || events.length === 0) {
     return (
       <div className="w-full">
         <div className="mx-auto px-4 sm:px-10 max-w-[1800px]">
@@ -50,12 +50,8 @@ export default async function Provenance({objectId}: {objectId: string}) {
               <ToggleViewButtons />
             </div>
           </div>
-          {labeledEvents.length > 0 ? (
-            <>
-              <Timeline />
-              <DataTable />
-            </>
-          ) : null}
+          <Timeline />
+          <DataTable />
         </div>
       </div>
     </ProvenanceProvider>

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -123,7 +123,7 @@
     "transferredTo": "Transferred to",
     "location": "Location",
     "descriptionTitle": "Description",
-    "noData": "No provenance events found",
+    "noData": "No provenance events provided for this object.",
     "dataTableTitle": "Provenance data table",
     "timelineTitle": "Provenance timeline",
     "timelineDescription": "In the timeline provenance events are plotted out by time. Click on an event to focus on that event.",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -133,7 +133,8 @@
     "hideTimelineButton": "Hide timeline",
     "showDataTableButton": "Show data table",
     "hideDataTableButton": "Hide data table",
-    "noDate": "No date"
+    "noDate": "No date",
+    "noDescription": "No description"
   },
   "PersonDetails": {
     "backButton": "Back to results",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -132,7 +132,8 @@
     "showTimelineButton": "Show timeline",
     "hideTimelineButton": "Hide timeline",
     "showDataTableButton": "Show data table",
-    "hideDataTableButton": "Hide data table"
+    "hideDataTableButton": "Hide data table",
+    "noDate": "No date"
   },
   "PersonDetails": {
     "backButton": "Back to results",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -132,7 +132,8 @@
     "showTimelineButton": "Tijdlijn weergeven",
     "hideTimelineButton": "Tijdlijn verbergen",
     "showDataTableButton": "Datatabel weergeven",
-    "hideDataTableButton": "Datatabel verbergen"
+    "hideDataTableButton": "Datatabel verbergen",
+    "noDate": "Geen datum"
   },
   "PersonDetails": {
     "backButton": "Terug naar resultaten",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -133,7 +133,8 @@
     "hideTimelineButton": "Tijdlijn verbergen",
     "showDataTableButton": "Datatabel weergeven",
     "hideDataTableButton": "Datatabel verbergen",
-    "noDate": "Geen datum"
+    "noDate": "Geen datum",
+    "noDescription": "Geen beschrijving"
   },
   "PersonDetails": {
     "backButton": "Terug naar resultaten",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -123,7 +123,7 @@
     "transferredTo": "Overgedragen aan",
     "location": "Locatie",
     "descriptionTitle": "Beschrijving",
-    "noData": "Geen herkomstgegevens gevonden.",
+    "noData": "Geen herkomstgegevens aangeleverd.",
     "dataTableTitle": "Herkomst data tabel",
     "timelineTitle": "Tijdlijn van herkomst",
     "timelineDescription": "In de tijdlijn worden de herkomstgebeurtenissen uitgezet op basis van de tijd. Klik op een gebeurtenis om de focus op de gebeurtenis te leggen.",


### PR DESCRIPTION
There were a few remarks on the provenance during the sprint review/planning/daily. I combined them in one pull request.

## Hide buttons if there are no provenance events

#### Old 
There is a "Hide timeline/data table" button, but no timeline and data table.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/a24703b2-1d29-4887-86cc-71ca5b9207c6)

#### New
Buttons are gone, text is visible.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/deae6338-557f-4b99-9301-93a7990bfd11)

## Change the text if there are no events

From: "No provenance events found"
To "No provenance events provided for this object."

## Add title to events without dates in the data table 

#### Old
Empty string for the event group title. In this example, the last events have no dates.
![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/794e22c7-6e7f-479f-aea8-ba63a640486e)


#### New
There is a placeholder text above the event groups without dates.
![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/75d10b97-9bad-4851-8ff3-f5f73816d07c)

## Remove (i) and click record to expand/collapse in the Provenance table
Ticket: https://github.com/colonial-heritage/sprints/issues/344

#### Old
There is a (i). Only events with a description can be expanded.

#### New
All events can be expanded by clicking on the row. If there is no description, there is a placeholder text.
![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/8996248f-8f27-41ac-8103-106a376c164c)

