### PR TITLE
Mock system date in unit tests

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.test.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.test.ts
@@ -179,11 +179,14 @@ describe('getEarliestDate', () => {
     expect(result).toEqual(new Date('2022-01-01'));
   });
 
-  it('returns the earliest date when there are no events', () => {
+  it('returns today when there are no events', () => {
+    const now = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+
     const events: LabeledProvenanceEvent[] = [];
 
     const result = getEarliestDate(events);
 
-    expect(result).toEqual(new Date());
+    expect(result).toEqual(now);
   });
 });


### PR DESCRIPTION
Sometimes the QA fails, because of a small time difference. 

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/5caf5d1b-96e7-4b90-84bb-efa7a5017257)
