### PR TITLE
feat: locale-aware API

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/[slug]/[listId]/object-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/[listId]/object-card.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export default async function ObjectCard({objectIri}: Props) {
-  const object = await heritageObjects.getById(objectIri);
+  const object = await heritageObjects.getById({id: objectIri});
 
   if (!object) {
     return null;

--- a/apps/researcher/src/app/[locale]/communities/[slug]/object.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/object.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 export default async function ObjectCard({objectIri}: Props) {
-  const object = await heritageObjects.getById(objectIri);
+  const object = await heritageObjects.getById({id: objectIri});
 
   if (!object) {
     return null;

--- a/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
@@ -81,7 +81,7 @@ function ContactDetailsSlideOver({datasetId}: {datasetId?: string}) {
 
 export default async function Details({params}: Props) {
   const id = decodeRouteSegment(params.id);
-  const object = await heritageObjects.getById(id);
+  const object = await heritageObjects.getById({id});
   const locale = useLocale();
   const t = await getTranslations('ObjectDetails');
   const format = await getFormatter();

--- a/apps/researcher/src/lib/api/definitions.ts
+++ b/apps/researcher/src/lib/api/definitions.ts
@@ -1,5 +1,7 @@
 import {z} from 'zod';
 
+export const localeSchema = z.enum(['en', 'nl']).optional().default('en');
+
 export const ontologyUrl = 'https://colonialcollections.nl/schema#'; // Internal ontology
 
 export type Thing = {

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -12,24 +12,23 @@ beforeEach(() => {
 
 describe('getByIds', () => {
   it('returns empty list if no IDs were provided', async () => {
-    const heritageObjects = await heritageObjectFetcher.getByIds([]);
+    const heritageObjects = await heritageObjectFetcher.getByIds({ids: []});
 
     expect(heritageObjects).toEqual([]);
   });
 
   it('returns empty list if no heritage objects match the IDs', async () => {
-    const heritageObjects = await heritageObjectFetcher.getByIds([
-      'https://unknown.org/',
-    ]);
+    const heritageObjects = await heritageObjectFetcher.getByIds({
+      ids: ['https://unknown.org/'],
+    });
 
     expect(heritageObjects).toEqual([]);
   });
 
   it('returns the heritage objects that match the IDs', async () => {
-    const heritageObjects = await heritageObjectFetcher.getByIds([
-      'https://example.org/objects/1',
-      'https://example.org/objects/5',
-    ]);
+    const heritageObjects = await heritageObjectFetcher.getByIds({
+      ids: ['https://example.org/objects/1', 'https://example.org/objects/5'],
+    });
 
     expect(heritageObjects).toMatchObject([
       {
@@ -44,23 +43,25 @@ describe('getByIds', () => {
 
 describe('getById', () => {
   it('returns undefined if a malformed ID is used', async () => {
-    const heritageObject = await heritageObjectFetcher.getById('malformedID');
+    const heritageObject = await heritageObjectFetcher.getById({
+      id: 'malformedID',
+    });
 
     expect(heritageObject).toBeUndefined();
   });
 
   it('returns undefined if no heritage object matches the ID', async () => {
-    const heritageObject = await heritageObjectFetcher.getById(
-      'https://unknown.org/'
-    );
+    const heritageObject = await heritageObjectFetcher.getById({
+      id: 'https://unknown.org/',
+    });
 
     expect(heritageObject).toBeUndefined();
   });
 
   it('returns the heritage object that matches the ID', async () => {
-    const heritageObject = await heritageObjectFetcher.getById(
-      'https://example.org/objects/5'
-    );
+    const heritageObject = await heritageObjectFetcher.getById({
+      id: 'https://example.org/objects/5',
+    });
 
     expect(heritageObject).toStrictEqual({
       id: 'https://example.org/objects/5',
@@ -166,6 +167,71 @@ describe('getById', () => {
           name: 'Museum',
         },
       },
+    });
+  });
+
+  it('returns a heritage object with default names', async () => {
+    const heritageObject = await heritageObjectFetcher.getById({
+      id: 'https://example.org/objects/2',
+    });
+
+    // Currently the only localized parts
+    expect(heritageObject).toMatchObject({
+      id: 'https://example.org/objects/2',
+      locationsCreated: expect.arrayContaining([
+        {
+          id: 'https://sws.geonames.org/1642911/',
+          name: 'Jakarta',
+          isPartOf: {
+            id: 'https://sws.geonames.org/1643084/',
+            name: 'Indonesia',
+          },
+        },
+      ]),
+    });
+  });
+
+  it('returns a heritage object with English names', async () => {
+    const heritageObject = await heritageObjectFetcher.getById({
+      locale: 'en',
+      id: 'https://example.org/objects/2',
+    });
+
+    // Currently the only localized parts
+    expect(heritageObject).toMatchObject({
+      id: 'https://example.org/objects/2',
+      locationsCreated: expect.arrayContaining([
+        {
+          id: 'https://sws.geonames.org/1642911/',
+          name: 'Jakarta',
+          isPartOf: {
+            id: 'https://sws.geonames.org/1643084/',
+            name: 'Indonesia',
+          },
+        },
+      ]),
+    });
+  });
+
+  it('returns a heritage object with Dutch names', async () => {
+    const heritageObject = await heritageObjectFetcher.getById({
+      locale: 'nl',
+      id: 'https://example.org/objects/2',
+    });
+
+    // Currently the only localized parts
+    expect(heritageObject).toMatchObject({
+      id: 'https://example.org/objects/2',
+      locationsCreated: expect.arrayContaining([
+        {
+          id: 'https://sws.geonames.org/1642911/',
+          name: 'Jakarta',
+          isPartOf: {
+            id: 'https://sws.geonames.org/1643084/',
+            name: 'Republiek Indonesië',
+          },
+        },
+      ]),
     });
   });
 });

--- a/apps/researcher/src/lib/api/objects/index.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/index.integration.test.ts
@@ -17,9 +17,9 @@ beforeEach(() => {
 
 describe('getById', () => {
   it('returns a heritage object', async () => {
-    const heritageObject = await heritageObjects.getById(
-      'https://example.org/objects/5'
-    );
+    const heritageObject = await heritageObjects.getById({
+      id: 'https://example.org/objects/5',
+    });
 
     expect(heritageObject).not.toBeUndefined();
   });

--- a/apps/researcher/src/lib/api/objects/index.ts
+++ b/apps/researcher/src/lib/api/objects/index.ts
@@ -1,4 +1,4 @@
-import {HeritageObjectFetcher} from './fetcher';
+import {GetByIdOptions, HeritageObjectFetcher} from './fetcher';
 import {ProvenanceEventsFetcher} from './provenance-events-fetcher';
 import {HeritageObjectSearcher, SearchOptions} from './searcher';
 import {z} from 'zod';
@@ -34,8 +34,8 @@ export class HeritageObjects {
     });
   }
 
-  async getById(id: string) {
-    return this.heritageObjectFetcher.getById(id);
+  async getById(options: GetByIdOptions) {
+    return this.heritageObjectFetcher.getById(options);
   }
 
   async getProvenanceEventsByHeritageObjectId(id: string) {

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -565,9 +565,8 @@ describe('search', () => {
     });
   });
 
-  it('finds heritage objects if "locations" filter matches in English', async () => {
+  it('finds heritage objects if "locations" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
-      locale: 'en',
       filters: {
         locations: ['Malaysia'],
       },
@@ -577,22 +576,6 @@ describe('search', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
-      },
-    });
-  });
-
-  it('finds heritage objects if "locations" filter matches in Dutch', async () => {
-    const result = await heritageObjectSearcher.search({
-      locale: 'nl',
-      filters: {
-        locations: ['Maleisië'],
-      },
-    });
-
-    expect(result).toMatchObject({
-      totalCount: 1,
-      filters: {
-        locations: [{totalCount: 1, id: 'Maleisië', name: 'Maleisië'}],
       },
     });
   });
@@ -752,6 +735,42 @@ describe('search', () => {
             name: 1895,
           },
         ],
+      },
+    });
+  });
+});
+
+describe('search with localized names', () => {
+  it('finds heritage objects with English names', async () => {
+    // Currently the only localized parts
+    const result = await heritageObjectSearcher.search({
+      locale: 'en',
+      filters: {
+        locations: ['Malaysia'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
+      },
+    });
+  });
+
+  it('finds heritage objects with Dutch names', async () => {
+    // Currently the only localized parts
+    const result = await heritageObjectSearcher.search({
+      locale: 'nl',
+      filters: {
+        locations: ['Maleisië'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        locations: [{totalCount: 1, id: 'Maleisië', name: 'Maleisië'}],
       },
     });
   });

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -565,8 +565,9 @@ describe('search', () => {
     });
   });
 
-  it('finds heritage objects if "locations" filter matches', async () => {
+  it('finds heritage objects if "locations" filter matches in English', async () => {
     const result = await heritageObjectSearcher.search({
+      locale: 'en',
       filters: {
         locations: ['Malaysia'],
       },
@@ -576,6 +577,22 @@ describe('search', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
+      },
+    });
+  });
+
+  it('finds heritage objects if "locations" filter matches in Dutch', async () => {
+    const result = await heritageObjectSearcher.search({
+      locale: 'nl',
+      filters: {
+        locations: ['Maleisië'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      filters: {
+        locations: [{totalCount: 1, id: 'Maleisië', name: 'Maleisië'}],
       },
     });
   });

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -1,4 +1,5 @@
 import {
+  localeSchema,
   SearchResultFilter,
   SortBy,
   SortByEnum,
@@ -37,7 +38,7 @@ const sortByToRawKeys = new Map<string, string>([
 ]);
 
 const searchOptionsSchema = z.object({
-  locale: z.string().default('en'),
+  locale: localeSchema,
   query: z.string().optional().default('*'), // If no query provided, match all
   offset: z.number().int().nonnegative().optional().default(0),
   limit: z.number().int().positive().optional().default(10),
@@ -276,7 +277,10 @@ export class HeritageObjectSearcher {
     const ids = rawHeritageObjects.map(
       rawHeritageObject => rawHeritageObject['@id']
     );
-    const heritageObjects = await this.heritageObjectFetcher.getByIds(ids);
+    const heritageObjects = await this.heritageObjectFetcher.getByIds({
+      locale: options.locale,
+      ids,
+    });
 
     const typeFilters = this.buildFilters(aggregations.types.buckets);
     const subjectFilters = this.buildFilters(aggregations.subjects.buckets);

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -36,8 +36,8 @@ const sortByToRawKeys = new Map<string, string>([
   [SortBy.DateCreated, RawKeys.YearCreatedStart],
 ]);
 
-// TBD: add language option, for returning results in a specific locale (e.g. 'nl', 'en')
 const searchOptionsSchema = z.object({
+  locale: z.string().default('en'),
   query: z.string().optional().default('*'), // If no query provided, match all
   offset: z.number().int().nonnegative().optional().default(0),
   limit: z.number().int().positive().optional().default(10),
@@ -147,10 +147,12 @@ export class HeritageObjectSearcher {
   }
 
   private buildRequest(options: SearchOptions) {
+    const locationKey = `${RawKeys.CountryCreated}_${options.locale}.keyword`;
+
     const aggregations = {
       types: this.buildAggregation(`${RawKeys.AdditionalType}.keyword`),
       subjects: this.buildAggregation(`${RawKeys.About}.keyword`),
-      locations: this.buildAggregation(`${RawKeys.CountryCreated}.keyword`),
+      locations: this.buildAggregation(locationKey),
       materials: this.buildAggregation(`${RawKeys.Material}.keyword`),
       creators: this.buildAggregation(`${RawKeys.Creator}.keyword`),
       publishers: this.buildAggregation(`${RawKeys.Publisher}.keyword`),
@@ -197,12 +199,12 @@ export class HeritageObjectSearcher {
     };
 
     const queryFilters: Map<string, string[] | undefined> = new Map([
-      [RawKeys.AdditionalType, options.filters?.types],
-      [RawKeys.About, options.filters?.subjects],
-      [RawKeys.CountryCreated, options.filters?.locations],
-      [RawKeys.Material, options.filters?.materials],
-      [RawKeys.Creator, options.filters?.creators],
-      [RawKeys.Publisher, options.filters?.publishers],
+      [`${RawKeys.AdditionalType}.keyword`, options.filters?.types],
+      [`${RawKeys.About}.keyword`, options.filters?.subjects],
+      [locationKey, options.filters?.locations],
+      [`${RawKeys.Material}.keyword`, options.filters?.materials],
+      [`${RawKeys.Creator}.keyword`, options.filters?.creators],
+      [`${RawKeys.Publisher}.keyword`, options.filters?.publishers],
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {
@@ -210,7 +212,7 @@ export class HeritageObjectSearcher {
         const andFilters = filters.map(filter => {
           return {
             terms: {
-              [`${rawHeritageObjectKey}.keyword`]: [filter],
+              [rawHeritageObjectKey]: [filter],
             },
           };
         });


### PR DESCRIPTION
This PR adds basic locale support to the heritage objects API, resolving [1]:

1. When searching for objects (Elasticsearch) or fetching details of an object (SPARQL), you can now provide a `locale`. The supported locales are `en` and `nl`; if not given, the API defaults to `en`. The API will then return the search results or the details in that locale.
2. Our datastores currently have limited locale-awareness; the details of objects are mostly in Dutch. This PR localizes the names of locations. Hopefully more localizations can be implemented in the next couple of weeks (e.g. names of types, materials and data providers).

[1] https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=50246637