### PR TITLE
Search object page

### DIFF
--- a/apps/researcher/src/app/[locale]/(home)/layout.tsx
+++ b/apps/researcher/src/app/[locale]/(home)/layout.tsx
@@ -1,12 +1,16 @@
 import BaseLayout from '@/components/base-layout';
-import {ListProvider, defaultSortBy} from '@colonial-collections/list-store';
+import {ListProvider} from '@colonial-collections/list-store';
+import {defaultSortByUserOption} from '../objects/sort-mapping';
 import {ReactNode} from 'react';
 
 export default function ObjectLayout({children}: {children: ReactNode}) {
   return (
     <body className="bg-consortiumGreen-300 text-consortiumBlue-800">
       <BaseLayout>
-        <ListProvider baseUrl="/objects" defaultSortBy={defaultSortBy}>
+        <ListProvider
+          baseUrl="/objects"
+          defaultSortBy={defaultSortByUserOption}
+        >
           {children}
         </ListProvider>
       </BaseLayout>

--- a/apps/researcher/src/app/[locale]/(home)/search-field.tsx
+++ b/apps/researcher/src/app/[locale]/(home)/search-field.tsx
@@ -9,7 +9,7 @@ export function SearchFieldHome() {
   const router = useRouter();
 
   const navigateOnSearch = (query: string) => {
-    if (query) {
+    if (query.length > 0) {
       const urlSearchParams = new URLSearchParams({query});
       router.replace(`/objects?${urlSearchParams}`);
     }

--- a/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/page.tsx
@@ -72,7 +72,10 @@ export default async function CommunityPage({params}: Props) {
     <>
       <div className="px-4 sm:px-10 -mt-3 -mb-3 sm:-mb-9 flex gap-2 flex-row sm:justify-between w-full max-w-[1800px] mx-auto">
         <div>
-          <ToFilteredListButton className="flex items-center gap-1 no-underline">
+          <ToFilteredListButton
+            baseUrl="/communities"
+            className="flex items-center gap-1 no-underline"
+          >
             <ChevronLeftIcon className="w-4 h-4 fill-neutral-500" />
             {t('backButton')}
           </ToFilteredListButton>

--- a/apps/researcher/src/app/[locale]/communities/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/page.tsx
@@ -60,6 +60,8 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
           query: query ?? '',
           sortBy,
           selectedFilters: {onlyMyCommunities},
+          baseUrl: '/communities',
+          defaultSortBy: SortBy.NameAsc,
         }}
       />
       <div className="flex flex-col sm:flex-row justify-between items-center h-full gap-6 w-full max-w-[1800px] mx-auto px-4 sm:px-10 pt-6">

--- a/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
@@ -62,7 +62,10 @@ export default async function Details({params}: Props) {
         <div className="bg-consortiumBlue-800 text-white w-full">
           <div className="px-4 sm:px-10 flex gap-2 flex-row sm:justify-between max-w-[1800px] mx-auto pt-10">
             <div>
-              <ToFilteredListButton className="no-underline rounded-full px-2 py-1 sm:px-4 sm:py-2 text-xs md:text-sm bg-consortiumBlue-100 text-consortiumBlue-800 flex gap-1 items-center">
+              <ToFilteredListButton
+                baseUrl="/objects"
+                className="no-underline rounded-full px-2 py-1 sm:px-4 sm:py-2 text-xs md:text-sm bg-consortiumBlue-100 text-consortiumBlue-800 flex gap-1 items-center"
+              >
                 <ChevronLeftIcon className="w-4 h-4 fill-consortiumBlue-800" />
                 {t('backButton')}
               </ToFilteredListButton>

--- a/apps/researcher/src/app/[locale]/objects/initial-search-field.tsx
+++ b/apps/researcher/src/app/[locale]/objects/initial-search-field.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import {SearchFieldWithLabel} from '@colonial-collections/ui/list';
+import {useRouter} from '@/navigation';
+
+export function InitialSearchField() {
+  const router = useRouter();
+
+  const navigateOnSearch = (query: string) => {
+    if (query) {
+      const urlSearchParams = new URLSearchParams({query});
+      router.replace(`/objects?${urlSearchParams}`);
+    }
+  };
+
+  return <SearchFieldWithLabel onSearch={navigateOnSearch} />;
+}

--- a/apps/researcher/src/app/[locale]/objects/initial-search-field.tsx
+++ b/apps/researcher/src/app/[locale]/objects/initial-search-field.tsx
@@ -7,7 +7,7 @@ export function InitialSearchField() {
   const router = useRouter();
 
   const navigateOnSearch = (query: string) => {
-    if (query) {
+    if (query.length > 0) {
       const urlSearchParams = new URLSearchParams({query});
       router.replace(`/objects?${urlSearchParams}`);
     }

--- a/apps/researcher/src/app/[locale]/objects/layout.tsx
+++ b/apps/researcher/src/app/[locale]/objects/layout.tsx
@@ -1,12 +1,16 @@
 import BaseLayout from '@/components/base-layout';
-import {ListProvider, defaultSortBy} from '@colonial-collections/list-store';
+import {ListProvider} from '@colonial-collections/list-store';
+import {defaultSortByUserOption} from './sort-mapping';
 import {ReactNode} from 'react';
 
 export default function ObjectLayout({children}: {children: ReactNode}) {
   return (
     <body>
       <BaseLayout>
-        <ListProvider baseUrl="/objects" defaultSortBy={defaultSortBy}>
+        <ListProvider
+          baseUrl="/objects"
+          defaultSortBy={defaultSortByUserOption}
+        >
           {children}
         </ListProvider>
       </BaseLayout>

--- a/apps/researcher/src/app/[locale]/objects/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/page.tsx
@@ -1,241 +1,51 @@
-import heritageObjects from '@/lib/heritage-objects-instance';
 import {getTranslations} from 'next-intl/server';
-import HeritageObjectList from './heritage-object-list';
-import {SortByUserOption, sortMapping} from './sort-mapping';
-import {
-  fromSearchParamsToSearchOptions,
-  getClientSortBy,
-  Type as SearchParamType,
-} from '@colonial-collections/list-store';
-import {
-  SearchResult,
-  SortBy,
-  SortByEnum,
-  SortOrder,
-  SortOrderEnum,
-} from '@/lib/api/objects';
-import {
-  MultiSelectFacet,
-  SearchableMultiSelectFacet,
-  Paginator,
-  SelectedFilters,
-  SearchFieldWithLabel,
-  OrderSelector,
-  DateRangeFacet,
-} from '@colonial-collections/ui/list';
-import {
-  SmallScreenSubMenu,
-  SubMenuButton,
-  SubMenuDialog,
-} from '@colonial-collections/ui';
-import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
-import {ElementType} from 'react';
-import {ListStoreUpdater} from '@/components/list-store-updater';
-import {redirect} from '@/navigation';
-import {LocaleEnum} from '@/definitions';
-import {useLocale} from 'next-intl';
+import SearchResults from './search-results';
+import {InformationCircleIcon} from '@heroicons/react/24/solid';
+import {InitialSearchField} from './initial-search-field';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
-
-interface FilterSetting {
-  name: keyof SearchResult['filters'];
-  searchParamType: SearchParamType;
-}
-
-const filterSettings: ReadonlyArray<FilterSetting> = [
-  {name: 'locations', searchParamType: 'array'},
-  {name: 'types', searchParamType: 'array'},
-  {name: 'subjects', searchParamType: 'array'},
-  {name: 'publishers', searchParamType: 'array'},
-  {name: 'materials', searchParamType: 'array'},
-  {name: 'creators', searchParamType: 'array'},
-  {name: 'dateCreatedStart', searchParamType: 'number'},
-  {name: 'dateCreatedEnd', searchParamType: 'number'},
-];
-
-interface Facet {
-  name: string;
-  // `Component` needs to be uppercase to be valid JSX
-  Component: ElementType;
-}
-
-interface DateRangeFacet extends Facet {
-  startDateKey: string;
-  endDateKey: string;
-}
-
-const facets: ReadonlyArray<Facet | DateRangeFacet> = [
-  {name: 'locations', Component: SearchableMultiSelectFacet},
-  {
-    name: 'dateCreated',
-    Component: DateRangeFacet,
-    startDateKey: 'dateCreatedStart',
-    endDateKey: 'dateCreatedEnd',
-  },
-  {name: 'types', Component: SearchableMultiSelectFacet},
-  {name: 'subjects', Component: MultiSelectFacet},
-  {name: 'materials', Component: SearchableMultiSelectFacet},
-  {name: 'creators', Component: SearchableMultiSelectFacet},
-  {name: 'publishers', Component: MultiSelectFacet},
-];
-
-interface FacetMenuProps {
-  filters: SearchResult['filters'];
-}
-
-async function FacetMenu({filters}: FacetMenuProps) {
-  const t = await getTranslations('Filters');
-
-  return (
-    <div className="w-full flex flex-col gap-6">
-      <SearchFieldWithLabel />
-      {facets.map(({name, Component, ...customProps}) => {
-        const facetProps = Object.keys(customProps).length
-          ? customProps
-          : {
-              filters: filters[name as keyof SearchResult['filters']],
-              filterKey: name,
-            };
-
-        return (
-          <Component
-            key={name}
-            title={t(`${name}Filter`)}
-            testId={`${name}Filter`}
-            {...facetProps}
-          />
-        );
-      })}
-    </div>
-  );
-}
 
 interface Props {
   searchParams?: {[filter: string]: string};
 }
 
-export default async function SearchResults({searchParams = {}}: Props) {
-  if (!searchParams.query) {
-    redirect('/');
-  }
+export default async function Page({searchParams = {}}: Props) {
+  const showResults =
+    Object.keys(searchParams).filter(paramKey => paramKey !== 'sortBy').length >
+    0;
 
-  const searchOptions = fromSearchParamsToSearchOptions({
-    sortOptions: {
-      SortOrderEnum,
-      defaultSortOrder: SortOrder.Descending,
-      SortByEnum,
-      defaultSortBy: SortBy.DateCreated,
-      sortMapping: sortMapping,
-    },
-    filterKeys: filterSettings.map(({name, searchParamType}) => ({
-      name,
-      type: searchParamType,
-    })),
-    searchParams,
-  });
-
-  const locale = useLocale() as LocaleEnum;
-
-  const sortBy = getClientSortBy({
-    sortMapping,
-    sortPair: {
-      sortBy: searchOptions.sortBy,
-      sortOrder: searchOptions.sortOrder,
-    },
-  });
-
-  let hasError;
-  let searchResult: SearchResult | undefined;
-  try {
-    searchResult = await heritageObjects.search({...searchOptions, locale});
-  } catch (err) {
-    hasError = true;
-    console.error(err);
-  }
-
-  const t = await getTranslations('ObjectSearchResults');
+  const t = await getTranslations('ObjectSearch');
 
   return (
-    <>
-      <div className="flex flex-col gap-8 pb-40 mt-20">
-        <div className="w-full max-w-[1800px] mx-auto">
-          <div className="flex flex-row h-full items-stretch grow content-stretch self-stretch gap-4 md:gap-16 w-full mx-auto px-10 ">
-            {hasError && (
-              <div
-                className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4 lg:col-span-3 xl:col-span-4"
-                role="alert"
-                data-testid="fetch-error"
-              >
-                <p>{t('fetchError')}</p>
-              </div>
-            )}
-
-            {searchResult && (
-              <>
-                <ListStoreUpdater
-                  {...{
-                    totalCount: searchResult.totalCount,
-                    offset: searchResult.offset,
-                    limit: searchResult.limit,
-                    query: searchOptions.query ?? '',
-                    sortBy,
-                    selectedFilters: searchOptions.filters,
-                  }}
-                />
-                <aside
-                  id="facets"
-                  className="hidden md:block w-full md:w-1/3 lg:w-1/5 order-2 md:order-1"
-                >
-                  <FacetMenu filters={searchResult.filters} />
-                </aside>
-
-                <main className="w-full md:w-2/3 lg:w-4/5 order-2 md:order-1">
-                  <SmallScreenSubMenu>
-                    <SubMenuButton className="md:hidden py-2 px-3 rounded-full bg-consortiumGreen-300 text-consortiumBlue-800 transition flex items-center gap-1 text-sm my-2">
-                      <AdjustmentsHorizontalIcon
-                        className="ml-1 h-4 w-4 flex-shrink-0 text-consortiumBlue-800"
-                        aria-hidden="true"
-                      />
-                      <span>{t('filters')}</span>
-                    </SubMenuButton>
-                    <SubMenuDialog title={t('filters')}>
-                      <FacetMenu filters={searchResult.filters} />
-                    </SubMenuDialog>
-                  </SmallScreenSubMenu>
-                  <div
-                    className="flex flex-col sm:flex-row sm:justify-between"
-                    id="search-results"
-                  >
-                    <h2 className="text-xl">
-                      {t('title', {totalDatasets: searchResult.totalCount})}
-                    </h2>
-                    <div className="flex flex-col sm:flex-row justify-end gap-2">
-                      <OrderSelector
-                        values={[
-                          SortByUserOption.DateCreatedDesc,
-                          SortByUserOption.DateCreatedAsc,
-                          SortByUserOption.NameDesc,
-                          SortByUserOption.NameAsc,
-                        ]}
-                      />
-                    </div>
+    <div className="flex flex-col gap-8 pb-40 mt-20">
+      <div className="w-full max-w-[1800px] mx-auto">
+        <div className="flex flex-row h-full items-stretch grow content-stretch self-stretch gap-4 md:gap-16 w-full mx-auto px-10 ">
+          {showResults ? (
+            <SearchResults searchParams={searchParams} />
+          ) : (
+            <>
+              <aside className="w-full md:w-1/3 lg:w-1/5  order-2 md:order-1">
+                <div className="w-full flex flex-col gap-6">
+                  <div className="w-full max-w-[450px] relative">
+                    <InitialSearchField />
                   </div>
-                  <SelectedFilters
-                    filters={searchResult.filters}
-                    filterSettings={filterSettings}
-                  />
-                  <HeritageObjectList
-                    heritageObjects={searchResult.heritageObjects}
-                    totalCount={searchResult.totalCount}
-                  />
-                  <Paginator />
-                </main>
-              </>
-            )}
-          </div>
+                </div>
+              </aside>
+              <main className="w-full md:w-2/3 lg:w-4/5  order-2 md:order-1">
+                <h2 className="text-xl">{t('title')}</h2>
+
+                <div className="flex flex-col gap-2 border rounded mt-6 p-6 max-w-3xl">
+                  <div>
+                    <InformationCircleIcon className="w-6 h-6 fill-neutral-500" />
+                  </div>
+                  <div className="whitespace-pre-line">{t('description')}</div>
+                </div>
+              </main>
+            </>
+          )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -1,0 +1,226 @@
+import heritageObjects from '@/lib/heritage-objects-instance';
+import {getTranslations} from 'next-intl/server';
+import HeritageObjectList from './heritage-object-list';
+import {SortByUserOption, sortMapping} from './sort-mapping';
+import {
+  fromSearchParamsToSearchOptions,
+  getClientSortBy,
+  Type as SearchParamType,
+} from '@colonial-collections/list-store';
+import {
+  SearchResult,
+  SortBy,
+  SortByEnum,
+  SortOrder,
+  SortOrderEnum,
+} from '@/lib/api/objects';
+import {
+  MultiSelectFacet,
+  SearchableMultiSelectFacet,
+  Paginator,
+  SelectedFilters,
+  SearchFieldWithLabel,
+  OrderSelector,
+  DateRangeFacet,
+} from '@colonial-collections/ui/list';
+import {
+  SmallScreenSubMenu,
+  SubMenuButton,
+  SubMenuDialog,
+} from '@colonial-collections/ui';
+import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
+import {ElementType} from 'react';
+import {ListStoreUpdater} from '@/components/list-store-updater';
+
+// Revalidate the page every n seconds
+export const revalidate = 60;
+
+interface FilterSetting {
+  name: keyof SearchResult['filters'];
+  searchParamType: SearchParamType;
+}
+
+const filterSettings: ReadonlyArray<FilterSetting> = [
+  {name: 'locations', searchParamType: 'array'},
+  {name: 'types', searchParamType: 'array'},
+  {name: 'subjects', searchParamType: 'array'},
+  {name: 'publishers', searchParamType: 'array'},
+  {name: 'materials', searchParamType: 'array'},
+  {name: 'creators', searchParamType: 'array'},
+  {name: 'dateCreatedStart', searchParamType: 'number'},
+  {name: 'dateCreatedEnd', searchParamType: 'number'},
+];
+
+interface Facet {
+  name: string;
+  // `Component` needs to be uppercase to be valid JSX
+  Component: ElementType;
+}
+
+interface DateRangeFacet extends Facet {
+  startDateKey: string;
+  endDateKey: string;
+}
+
+const facets: ReadonlyArray<Facet | DateRangeFacet> = [
+  {name: 'locations', Component: SearchableMultiSelectFacet},
+  {
+    name: 'dateCreated',
+    Component: DateRangeFacet,
+    startDateKey: 'dateCreatedStart',
+    endDateKey: 'dateCreatedEnd',
+  },
+  {name: 'types', Component: SearchableMultiSelectFacet},
+  {name: 'subjects', Component: MultiSelectFacet},
+  {name: 'materials', Component: SearchableMultiSelectFacet},
+  {name: 'creators', Component: SearchableMultiSelectFacet},
+  {name: 'publishers', Component: MultiSelectFacet},
+];
+
+interface FacetMenuProps {
+  filters: SearchResult['filters'];
+}
+
+async function FacetMenu({filters}: FacetMenuProps) {
+  const t = await getTranslations('Filters');
+
+  return (
+    <div className="w-full flex flex-col gap-6">
+      <SearchFieldWithLabel />
+      {facets.map(({name, Component, ...customProps}) => {
+        const facetProps = Object.keys(customProps).length
+          ? customProps
+          : {
+              filters: filters[name as keyof SearchResult['filters']],
+              filterKey: name,
+            };
+
+        return (
+          <Component
+            key={name}
+            title={t(`${name}Filter`)}
+            testId={`${name}Filter`}
+            {...facetProps}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface Props {
+  searchParams?: {[filter: string]: string};
+}
+
+export default async function SearchResults({searchParams = {}}: Props) {
+  const searchOptions = fromSearchParamsToSearchOptions({
+    sortOptions: {
+      SortOrderEnum,
+      defaultSortOrder: SortOrder.Descending,
+      SortByEnum,
+      defaultSortBy: SortBy.DateCreated,
+      sortMapping: sortMapping,
+    },
+    filterKeys: filterSettings.map(({name, searchParamType}) => ({
+      name,
+      type: searchParamType,
+    })),
+    searchParams,
+  });
+
+  const sortBy = getClientSortBy({
+    sortMapping,
+    sortPair: {
+      sortBy: searchOptions.sortBy,
+      sortOrder: searchOptions.sortOrder,
+    },
+  });
+
+  let hasError;
+  let searchResult: SearchResult | undefined;
+  try {
+    searchResult = await heritageObjects.search(searchOptions);
+  } catch (err) {
+    hasError = true;
+    console.error(err);
+  }
+
+  const t = await getTranslations('ObjectSearchResults');
+
+  return (
+    <>
+      {hasError && (
+        <div
+          className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4 lg:col-span-3 xl:col-span-4"
+          role="alert"
+          data-testid="fetch-error"
+        >
+          <p>{t('fetchError')}</p>
+        </div>
+      )}
+
+      {searchResult && (
+        <>
+          <ListStoreUpdater
+            {...{
+              totalCount: searchResult.totalCount,
+              offset: searchResult.offset,
+              limit: searchResult.limit,
+              query: searchOptions.query ?? '',
+              sortBy,
+              selectedFilters: searchOptions.filters,
+            }}
+          />
+          <aside
+            id="facets"
+            className="hidden md:block w-full md:w-1/3 lg:w-1/5 order-2 md:order-1"
+          >
+            <FacetMenu filters={searchResult.filters} />
+          </aside>
+
+          <main className="w-full md:w-2/3 lg:w-4/5 order-2 md:order-1">
+            <SmallScreenSubMenu>
+              <SubMenuButton className="md:hidden py-2 px-3 rounded-full bg-consortiumGreen-300 text-consortiumBlue-800 transition flex items-center gap-1 text-sm my-2">
+                <AdjustmentsHorizontalIcon
+                  className="ml-1 h-4 w-4 flex-shrink-0 text-consortiumBlue-800"
+                  aria-hidden="true"
+                />
+                <span>{t('filters')}</span>
+              </SubMenuButton>
+              <SubMenuDialog title={t('filters')}>
+                <FacetMenu filters={searchResult.filters} />
+              </SubMenuDialog>
+            </SmallScreenSubMenu>
+            <div
+              className="flex flex-col sm:flex-row sm:justify-between"
+              id="search-results"
+            >
+              <h2 className="text-xl">
+                {t('title', {totalDatasets: searchResult.totalCount})}
+              </h2>
+              <div className="flex flex-col sm:flex-row justify-end gap-2">
+                <OrderSelector
+                  values={[
+                    SortByUserOption.DateCreatedDesc,
+                    SortByUserOption.DateCreatedAsc,
+                    SortByUserOption.NameDesc,
+                    SortByUserOption.NameAsc,
+                  ]}
+                />
+              </div>
+            </div>
+            <SelectedFilters
+              filters={searchResult.filters}
+              filterSettings={filterSettings}
+            />
+            <HeritageObjectList
+              heritageObjects={searchResult.heritageObjects}
+              totalCount={searchResult.totalCount}
+            />
+            <Paginator />
+          </main>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -1,7 +1,11 @@
 import heritageObjects from '@/lib/heritage-objects-instance';
 import {getTranslations} from 'next-intl/server';
 import HeritageObjectList from './heritage-object-list';
-import {SortByUserOption, sortMapping} from './sort-mapping';
+import {
+  SortByUserOption,
+  defaultSortByUserOption,
+  sortMapping,
+} from './sort-mapping';
 import {
   fromSearchParamsToSearchOptions,
   getClientSortBy,
@@ -173,6 +177,8 @@ export default async function SearchResults({searchParams = {}}: Props) {
               query: searchOptions.query ?? '',
               sortBy,
               selectedFilters: searchOptions.filters,
+              baseUrl: '/objects',
+              defaultSortBy: defaultSortByUserOption,
             }}
           />
           <aside

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -31,6 +31,8 @@ import {
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import {ElementType} from 'react';
 import {ListStoreUpdater} from '@/components/list-store-updater';
+import {LocaleEnum} from '@/definitions';
+import {useLocale} from 'next-intl';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
@@ -113,6 +115,8 @@ interface Props {
 }
 
 export default async function SearchResults({searchParams = {}}: Props) {
+  const locale = useLocale() as LocaleEnum;
+
   const searchOptions = fromSearchParamsToSearchOptions({
     sortOptions: {
       SortOrderEnum,
@@ -139,7 +143,7 @@ export default async function SearchResults({searchParams = {}}: Props) {
   let hasError;
   let searchResult: SearchResult | undefined;
   try {
-    searchResult = await heritageObjects.search(searchOptions);
+    searchResult = await heritageObjects.search({...searchOptions, locale});
   } catch (err) {
     hasError = true;
     console.error(err);

--- a/apps/researcher/src/app/[locale]/objects/sort-mapping.ts
+++ b/apps/researcher/src/app/[locale]/objects/sort-mapping.ts
@@ -7,6 +7,8 @@ export enum SortByUserOption {
   NameDesc = 'nameDesc',
 }
 
+export const defaultSortByUserOption = SortByUserOption.DateCreatedDesc;
+
 export const sortMapping = {
   [SortByUserOption.DateCreatedDesc]: {
     sortBy: SortBySearchOption.DateCreated,

--- a/apps/researcher/src/app/[locale]/persons/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/[id]/page.tsx
@@ -61,7 +61,9 @@ export default async function Details({params}: Props) {
     <>
       <div className="bg-consortiumBlue-800 text-white flex flex-col gap-8 pt-9 pb-40">
         <div className="px-4 sm:px-10 max-w-[1800px] mx-auto w-full">
-          <ToFilteredListButton>{t('backButton')}</ToFilteredListButton>
+          <ToFilteredListButton baseUrl="/persons">
+            {t('backButton')}
+          </ToFilteredListButton>
           <div className="mt-10 mb-4">
             <PageHeader>
               <PageTitle id="about">

--- a/apps/researcher/src/app/[locale]/persons/page.tsx
+++ b/apps/researcher/src/app/[locale]/persons/page.tsx
@@ -4,6 +4,7 @@ import {getTranslations} from 'next-intl/server';
 import PersonList from './person-list';
 import {sortMapping} from './sort-mapping';
 import {
+  defaultSortBy,
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   Type as SearchParamType,
@@ -157,6 +158,8 @@ export default async function Home({searchParams = {}}: Props) {
                     query: searchOptions.query ?? '',
                     sortBy,
                     selectedFilters: searchOptions.filters,
+                    baseUrl: '/persons',
+                    defaultSortBy: defaultSortBy,
                   }}
                 />
                 <aside

--- a/apps/researcher/src/components/list-store-updater.tsx
+++ b/apps/researcher/src/components/list-store-updater.tsx
@@ -2,9 +2,11 @@
 
 import {useRouter} from '@/navigation';
 import {
+  getUrlWithSearchParams,
   useSearchParamsUpdate,
   useUpdateListStore,
 } from '@colonial-collections/list-store';
+import {saveLastSearch} from '@/lib/last-search';
 
 interface Props {
   totalCount: number;
@@ -15,12 +17,39 @@ interface Props {
   selectedFilters?: {
     [filterKey: string]: (string | number)[] | number | string | undefined;
   };
+  defaultSortBy: string;
+  baseUrl: string;
 }
 
-export function ListStoreUpdater(updateProps: Props) {
+export function ListStoreUpdater({
+  totalCount,
+  offset,
+  limit,
+  query,
+  sortBy,
+  selectedFilters,
+  defaultSortBy,
+  baseUrl,
+}: Props) {
   const router = useRouter();
-  useUpdateListStore(updateProps);
+  useUpdateListStore({
+    totalCount,
+    offset,
+    limit,
+    query,
+    sortBy,
+    selectedFilters,
+  });
   useSearchParamsUpdate(router.replace);
+  const url = getUrlWithSearchParams({
+    query,
+    offset,
+    sortBy,
+    filters: selectedFilters,
+    defaultSortBy,
+    baseUrl,
+  });
+  saveLastSearch(baseUrl, url);
 
   return null;
 }

--- a/apps/researcher/src/components/navigation.tsx
+++ b/apps/researcher/src/components/navigation.tsx
@@ -9,6 +9,7 @@ import {ConsortiumLogo} from '@colonial-collections/ui/branding';
 import {NavigationMenu} from '@colonial-collections/ui';
 import logoImage from '@colonial-collections/ui/branding/colonial-collections-consortium.png';
 import {useMemo} from 'react';
+import ToFilteredListButton from './to-filtered-list-button';
 
 interface Props {
   datasetBrowserUrl: string;
@@ -83,18 +84,18 @@ export default function Navigation({datasetBrowserUrl}: Props) {
           >
             {tNavigation('home')}
           </Link>
-          <Link
-            href="/objects"
+          <ToFilteredListButton
+            baseUrl="/objects"
             className="text-white font-semibold no-underline py-2 md:py-4 px-3 whitespace-nowrap"
           >
             {tNavigation('searchObjects')}
-          </Link>
-          <Link
-            href="/communities"
+          </ToFilteredListButton>
+          <ToFilteredListButton
+            baseUrl="/communities"
             className="text-white font-semibold no-underline py-2 md:py-4 px-3 whitespace-nowrap"
           >
             {tNavigation('communities')}
-          </Link>
+          </ToFilteredListButton>
           <NavigationMenu
             buttonText={tNavigation('subMenuButton')}
             menuItems={subMenuItems}

--- a/apps/researcher/src/components/navigation.tsx
+++ b/apps/researcher/src/components/navigation.tsx
@@ -84,6 +84,12 @@ export default function Navigation({datasetBrowserUrl}: Props) {
             {tNavigation('home')}
           </Link>
           <Link
+            href="/objects"
+            className="text-white font-semibold no-underline py-2 md:py-4 px-3 whitespace-nowrap"
+          >
+            {tNavigation('searchObjects')}
+          </Link>
+          <Link
             href="/communities"
             className="text-white font-semibold no-underline py-2 md:py-4 px-3 whitespace-nowrap"
           >

--- a/apps/researcher/src/components/to-filtered-list-button.tsx
+++ b/apps/researcher/src/components/to-filtered-list-button.tsx
@@ -1,16 +1,21 @@
 'use client';
 
+import {getLastSearch} from '@/lib/last-search';
 import {Link} from '@/navigation';
-import {useListHref} from '@colonial-collections/list-store';
 import {ReactNode} from 'react';
 
 interface Props {
   children: ReactNode;
   className?: string;
+  baseUrl: string;
 }
 
-export default function ToFilteredListButton({className, children}: Props) {
-  const href = useListHref();
+export default function ToFilteredListButton({
+  className,
+  baseUrl,
+  children,
+}: Props) {
+  const href = getLastSearch(baseUrl);
 
   return (
     <Link

--- a/apps/researcher/src/lib/last-search.ts
+++ b/apps/researcher/src/lib/last-search.ts
@@ -9,6 +9,5 @@ export function saveLastSearch(baseUrl: string, urlWithSearchParams: string) {
 }
 
 export function getLastSearch(baseUrl: string) {
-  console.log(useLastSearch.getState().lists.keys());
   return useLastSearch.getState().lists.get(baseUrl) || baseUrl;
 }

--- a/apps/researcher/src/lib/last-search.ts
+++ b/apps/researcher/src/lib/last-search.ts
@@ -1,0 +1,14 @@
+import {create} from 'zustand';
+
+export const useLastSearch = create(() => ({lists: new Map()}));
+
+export function saveLastSearch(baseUrl: string, urlWithSearchParams: string) {
+  useLastSearch.setState(prev => ({
+    lists: new Map(prev.lists).set(baseUrl, urlWithSearchParams),
+  }));
+}
+
+export function getLastSearch(baseUrl: string) {
+  console.log(useLastSearch.getState().lists.keys());
+  return useLastSearch.getState().lists.get(baseUrl) || baseUrl;
+}

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -11,6 +11,10 @@
     "communitiesDescription": "Every culture can start its own community on this platform. A community can create lists of objects that tells stories about their history. Communities can also add narratives to the objects in this collection.",
     "communitiesLink": "Here are some communities to inspire you. Or <link>take a look at all the communities</link>."
   },
+  "ObjectSearch": {
+    "title": "Search for heritage objects",
+    "description": "Start by typing a keyword to search.\n\nAfter this initial text search, search facets will appear to refine yor search results."
+  },
   "ObjectSearchResults": {
     "title": "{totalDatasets, plural, =0 {0 Heritage Objects} =1 {1 Heritage Object} other {# Heritage Objects}}",
     "noResults": "There are no results",
@@ -26,6 +30,7 @@
   "Navigation": {
     "name": "app",
     "home": "Home",
+    "searchObjects": "Search objects",
     "about": "About",
     "faq": "FAQ",
     "contact": "Contact",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -11,6 +11,10 @@
     "communitiesDescription": "Elke gemeenschap kan haar eigen community starten op dit platform. Een community kan lijsten met objecten maken die verhalen vertellen over hun geschiedenis. Communities kunnen ook verhalen toevoegen aan de objecten in deze collectie.",
     "communitiesLink": "Hier zijn enkele communities om je te inspireren. Of <link>bekijk alle communities</link>."
   },
+  "ObjectSearch": {
+    "title": "Zoek naar erfgoedobjecten",
+    "description": "Begin met zoeken door een trefwoord te typen.\n\nNa deze eerste tekstzoekopdracht verschijnen zoekfacetten om uw zoekresultaten te verfijnen."
+  },
   "ObjectSearchResults": {
     "title": "{totalDatasets, plural, =0 {0 Objecten} =1 {1 Object} other {# Objecten}}",
     "noResults": "Er zijn geen resultaten",
@@ -26,6 +30,7 @@
   "Navigation": {
     "name": "app",
     "home": "Home",
+    "searchObjects": "Objecten zoeken",
     "about": "Over de app",
     "faq": "FAQ",
     "contact": "Contact",

--- a/packages/ui/list/search-field.tsx
+++ b/packages/ui/list/search-field.tsx
@@ -100,11 +100,17 @@ function Label() {
   );
 }
 
-export function SearchFieldWithLabel() {
+interface SearchFieldWithLabelProps {
+  onSearch?: (query: string) => void;
+}
+
+export function SearchFieldWithLabel({
+  onSearch,
+}: SearchFieldWithLabelProps = {}) {
   return (
     <div className="w-full max-w-[450px] relative" id="facets">
       <Label />
-      <SearchField />
+      <SearchField onSearch={onSearch} />
     </div>
   );
 }


### PR DESCRIPTION
Ticket: https://github.com/colonial-heritage/sprints/issues/367

- Add **Search Objects** to top navigation (see https://gui-prototype.colonialcollections.nl/v2/search-init.html)
- If you click on this item, go to the faceted search page. Only a text search is available (see https://gui-prototype.colonialcollections.nl/v2/search-init.html)
- After the text search, the facets will appear. (https://gui-prototype.colonialcollections.nl/v2/search.html)
- Only after removing all facets/search will you go back to the initial page without facets (previously, it was after removing the search, even if there are still facets selected)
- If you navigate to 'search object' from a different page, the user will see the last search he made