### PR TITLE
Display licence Id if name is empty

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/gallery.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/gallery.tsx
@@ -70,7 +70,7 @@ export default function Gallery({images, organizationName}: Props) {
               <div className=" text-neutral-600">{t('license')}:</div>
               {image.license ? (
                 <a target="_blank" href={image.license.id}>
-                  {image.license.name}
+                  {image.license.name || image.license.id}
                 </a>
               ) : (
                 <p>


### PR DESCRIPTION
A minor bug I noticed during the daily when this object was opened: https://app.colonialcollections.nl/nl/objects/https%3A%2F%2Fn2t%252Enet%2Fark%3A%2F27023%2F233a902404f1e8defbbd988cb9aec542

When an object has a licence but no licence text, the licence is not visible.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/16c2ffb5-eca2-4cf5-9c46-5d7ef8b49612)


Show the ID if there is no license text. The example object will now be displayed as:

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/99f30ee4-1387-4db4-be90-7777bc8d1be9)
