### PR TITLE
Show whitespaces in object description

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
@@ -109,7 +109,7 @@ export async function MetadataEntry({
 
   return (
     <div className="border-t border-neutral-200 flex flex-col lg:flex-row justify-between gap-2 first:border-0 ">
-      <div className="w-full lg:w-2/3 py-3">
+      <div className="w-full lg:w-2/3 py-3 whitespace-pre-wrap">
         {children}
         {languageCode && (
           <div className="text-xs font-normal text-neutral-600">


### PR DESCRIPTION
Example object: https://app.colonialcollections.nl/nl/objects/https%3A%2F%2Fn2t%252Enet%2Fark%3A%2F27023%2F383a99b308758553f7ff6132f560a364

Descriptions do not show the whitespaces.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/8268b61e-e501-49f3-bc5d-7c749510f065)

With these changes.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/e6a635ac-3b3d-4c8a-9d44-06f1876d97b5)
