### PR TITLE
Fix NaN member count on community page when filtering by 'Show only my communities

### DIFF
--- a/apps/researcher/src/app/[locale]/(home)/page.tsx
+++ b/apps/researcher/src/app/[locale]/(home)/page.tsx
@@ -15,6 +15,7 @@ export default async function Home() {
     communities = await getCommunities({
       sortBy: SortBy.CreatedAtDesc,
       limit: 4,
+      includeMembersCount: true,
     });
   } catch (err) {
     return <ErrorMessage error={t('error')} />;

--- a/apps/researcher/src/app/[locale]/communities/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/page.tsx
@@ -37,6 +37,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         sortBy,
         offset,
         limit: 24,
+        includeMembersCount: true,
       });
     } else {
       communities = await getCommunities({
@@ -44,6 +45,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         sortBy,
         offset,
         limit: 24,
+        includeMembersCount: true,
       });
     }
   } catch (err) {

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -107,14 +107,19 @@ export async function getMyCommunities({
   const communities = await Promise.all(
     organizations.map(async organization => {
       if (includeMembersCount) {
-        const members =
-          await clerkClient.organizations.getOrganizationMembershipList({
-            organizationId: organization.id,
+        try {
+          const members =
+            await clerkClient.organizations.getOrganizationMembershipList({
+              organizationId: organization.id,
+            });
+          return organizationToCommunity({
+            ...organization,
+            members_count: members.length,
           });
-        return organizationToCommunity({
-          ...organization,
-          members_count: members.length,
-        });
+        } catch (error) {
+          console.error('Error fetching members count', error);
+          return organizationToCommunity(organization);
+        }
       }
       return organizationToCommunity(organization);
     })

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -116,8 +116,8 @@ export async function getMyCommunities({
             ...organization,
             members_count: members.length,
           });
-        } catch (error) {
-          console.error('Error fetching members count', error);
+        } catch (err) {
+          console.error('Error fetching members count', err);
           return organizationToCommunity(organization);
         }
       }


### PR DESCRIPTION
**Problem**: On the community page (https://app.colonialcollections.nl/nl/communities), filtering communities by "Show only my communities" results in community cards displaying a NaN member count.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/a1c1ddba-7db5-412d-9267-212ff2a97f01)

**Cause**: This issue arises because the `getOrganizationMembershipList` function does not fetch or calculate the membership count, leading to NaN being displayed when the member count is processed in the UI.

**Solution**: If `getOrganizationMembershipList` is being called, collect the members for every membership individual.


**Note**:
Because including memberships is a heavy call, I have set `includeMembersCount` to `false` by default.