### PR TITLE
feat: locale aware publisher and prov types

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/overview.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/overview.tsx
@@ -1,3 +1,4 @@
+import {useLocale} from 'next-intl';
 import heritageObjects from '@/lib/heritage-objects-instance';
 import DataTable from './data-table';
 import Timeline from './timeline';
@@ -5,10 +6,14 @@ import {getTranslations} from 'next-intl/server';
 import {sortEvents} from './sort-events';
 import {ProvenanceProvider} from './provenance-store';
 import {ToggleViewButtons} from './buttons';
+import {LocaleEnum} from '@/definitions';
 
 export default async function Provenance({objectId}: {objectId: string}) {
-  const events =
-    await heritageObjects.getProvenanceEventsByHeritageObjectId(objectId);
+  const locale = useLocale() as LocaleEnum;
+  const events = await heritageObjects.getProvenanceEventsByHeritageObjectId({
+    id: objectId,
+    locale,
+  });
   const t = await getTranslations('Provenance');
 
   if (!events || events.length === 0) {

--- a/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/page.tsx
@@ -44,7 +44,10 @@ export default async function Details({params}: Props) {
 
   let organization;
   if (object.isPartOf?.publisher?.id) {
-    organization = await organizations.getById(object.isPartOf.publisher.id);
+    organization = await organizations.getById({
+      id: object.isPartOf.publisher.id,
+      locale,
+    });
     organization && useObject.setState({organization});
   }
 

--- a/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.integration.test.ts
@@ -164,33 +164,14 @@ describe('getById', () => {
         publisher: {
           id: 'https://museum.example.org/',
           type: 'Organization',
-          name: 'Museum',
+          name: 'The Museum',
         },
       },
     });
   });
+});
 
-  it('returns a heritage object with default names', async () => {
-    const heritageObject = await heritageObjectFetcher.getById({
-      id: 'https://example.org/objects/2',
-    });
-
-    // Currently the only localized parts
-    expect(heritageObject).toMatchObject({
-      id: 'https://example.org/objects/2',
-      locationsCreated: expect.arrayContaining([
-        {
-          id: 'https://sws.geonames.org/1642911/',
-          name: 'Jakarta',
-          isPartOf: {
-            id: 'https://sws.geonames.org/1643084/',
-            name: 'Indonesia',
-          },
-        },
-      ]),
-    });
-  });
-
+describe('get with localized names', () => {
   it('returns a heritage object with English names', async () => {
     const heritageObject = await heritageObjectFetcher.getById({
       locale: 'en',
@@ -210,6 +191,13 @@ describe('getById', () => {
           },
         },
       ]),
+      isPartOf: {
+        id: 'https://example.org/datasets/13',
+        publisher: {
+          id: 'https://research.example.org/',
+          name: 'Research Organisation',
+        },
+      },
     });
   });
 
@@ -232,6 +220,13 @@ describe('getById', () => {
           },
         },
       ]),
+      isPartOf: {
+        id: 'https://example.org/datasets/13',
+        publisher: {
+          id: 'https://research.example.org/',
+          name: 'Onderzoeksinstelling',
+        },
+      },
     });
   });
 });

--- a/apps/researcher/src/lib/api/objects/fetcher.ts
+++ b/apps/researcher/src/lib/api/objects/fetcher.ts
@@ -326,8 +326,7 @@ export class HeritageObjectFetcher {
             ?publisher schema:name ?publisherName ;
               rdf:type ?publisherTypeTemp .
 
-            # For BC; remove as soon as locale-aware names are in use
-            FILTER(LANG(?publisherName) = "" || LANG(?publisherName) = "en")
+            FILTER(LANG(?publisherName) = "${options.locale}")
 
             VALUES (?publisherTypeTemp ?publisherType) {
               (schema:Organization ex:Organization)

--- a/apps/researcher/src/lib/api/objects/index.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/index.integration.test.ts
@@ -28,9 +28,9 @@ describe('getById', () => {
 describe('getProvenanceEventsByHeritageObjectId', () => {
   it('returns the provenance events of a heritage object', async () => {
     const provenanceEvents =
-      await heritageObjects.getProvenanceEventsByHeritageObjectId(
-        'https://example.org/objects/1'
-      );
+      await heritageObjects.getProvenanceEventsByHeritageObjectId({
+        id: 'https://example.org/objects/1',
+      });
 
     expect(provenanceEvents).toHaveLength(5);
   });

--- a/apps/researcher/src/lib/api/objects/index.ts
+++ b/apps/researcher/src/lib/api/objects/index.ts
@@ -1,5 +1,8 @@
 import {GetByIdOptions, HeritageObjectFetcher} from './fetcher';
-import {ProvenanceEventsFetcher} from './provenance-events-fetcher';
+import {
+  GetByIdOptions as GetProvenanceEventsByHeritageObjectIdOptions,
+  ProvenanceEventsFetcher,
+} from './provenance-events-fetcher';
 import {HeritageObjectSearcher, SearchOptions} from './searcher';
 import {z} from 'zod';
 
@@ -38,8 +41,10 @@ export class HeritageObjects {
     return this.heritageObjectFetcher.getById(options);
   }
 
-  async getProvenanceEventsByHeritageObjectId(id: string) {
-    return this.provenanceEventsFetcher.getByHeritageObjectId(id);
+  async getProvenanceEventsByHeritageObjectId(
+    options: GetProvenanceEventsByHeritageObjectIdOptions
+  ) {
+    return this.provenanceEventsFetcher.getByHeritageObjectId(options);
   }
 
   async search(options?: SearchOptions) {

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -59,8 +59,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1901-01-01T00:00:00.000Z'),
             endDate: new Date('1901-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1901-01-01T00:00:00.000Z'),
-          endDate: new Date('1901-01-01T00:00:00.000Z'),
+          startDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/5/activity/1',
           endsBefore:
@@ -95,8 +95,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           endsBefore:
@@ -138,8 +138,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1939-01-01T00:00:00.000Z'),
             endDate: new Date('1940-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1939-01-01T00:00:00.000Z'),
-          endDate: new Date('1940-01-01T00:00:00.000Z'),
+          startDate: new Date('1939-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1940-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
@@ -172,8 +172,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'),
-          endDate: new Date('1879-01-01T00:00:00.000Z'),
+          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           startsAfter:
             'https://example.org/objects/1/provenance/event/1/activity/1',
           endsBefore:
@@ -219,8 +219,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1855-01-01T00:00:00.000Z'),
             endDate: new Date('1857-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1855-01-01T00:00:00.000Z'),
-          endDate: new Date('1857-01-01T00:00:00.000Z'),
+          startDate: new Date('1855-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          endDate: new Date('1857-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
           endsBefore:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {

--- a/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/provenance-events-fetcher.integration.test.ts
@@ -12,46 +12,81 @@ beforeEach(() => {
 
 describe('getByHeritageObjectId', () => {
   it('returns undefined if a malformed ID is used', async () => {
-    const heritageObject =
-      await provenanceEventsFetcher.getByHeritageObjectId('malformedID');
+    const heritageObject = await provenanceEventsFetcher.getByHeritageObjectId({
+      id: 'malformedID',
+    });
 
     expect(heritageObject).toBeUndefined();
   });
 
   it('returns undefined if no heritage object matches the ID', async () => {
-    const heritageObject = await provenanceEventsFetcher.getByHeritageObjectId(
-      'https://unknown.org/'
-    );
+    const heritageObject = await provenanceEventsFetcher.getByHeritageObjectId({
+      id: 'https://unknown.org/',
+    });
 
     expect(heritageObject).toBeUndefined();
   });
 
   it('returns empty array if heritage object does not have provenance events', async () => {
     const provenanceEvents =
-      await provenanceEventsFetcher.getByHeritageObjectId(
-        'https://example.org/objects/5'
-      );
+      await provenanceEventsFetcher.getByHeritageObjectId({
+        id: 'https://example.org/objects/5',
+      });
 
     expect(provenanceEvents).toEqual([]);
   });
 
-  it('returns the provenance events of the heritage object', async () => {
+  it('returns the provenance events', async () => {
     const provenanceEvents =
-      await provenanceEventsFetcher.getByHeritageObjectId(
-        'https://example.org/objects/1'
-      );
+      await provenanceEventsFetcher.getByHeritageObjectId({
+        id: 'https://example.org/objects/1',
+      });
 
-    // For now ignore order of elements in the array (until the events are sorted)
     expect(provenanceEvents).toEqual(
       expect.arrayContaining([
         {
+          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300055292',
+              name: 'theft (social issue)',
+            },
+          ]),
+          date: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            startDate: new Date('1901-01-01T00:00:00.000Z'),
+            endDate: new Date('1901-12-31T23:59:59.999Z'),
+          },
+          startDate: new Date('1901-01-01T00:00:00.000Z'),
+          endDate: new Date('1901-01-01T00:00:00.000Z'),
+          startsAfter:
+            'https://example.org/objects/1/provenance/event/5/activity/1',
+          endsBefore:
+            'https://example.org/objects/1/provenance/event/4/activity/1',
+          location: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            name: 'Amsterdam',
+          },
+          transferredFrom: {
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
+            type: 'Organization',
+            name: 'Organization A',
+          },
+        },
+        {
           id: 'https://example.org/objects/1/provenance/event/5/activity/1',
-          types: [
+          types: expect.arrayContaining([
             {
               id: 'http://vocab.getty.edu/aat/300417642',
               name: 'purchase (method of acquisition)',
             },
-          ],
+          ]),
           description: 'Bought at an auction in Amsterdam',
           date: {
             id: expect.stringContaining(
@@ -60,8 +95,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
           startsAfter:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           endsBefore:
@@ -80,19 +115,21 @@ describe('getByHeritageObjectId', () => {
             name: 'Jonathan Hansen',
           },
           transferredTo: {
-            id: 'https://museum.example.org/',
+            id: expect.stringContaining(
+              'https://data.colonialcollections.nl/.well-known/genid/'
+            ),
             type: 'Organization',
-            name: 'Museum',
+            name: 'Organization A',
           },
         },
         {
           id: 'https://example.org/objects/1/provenance/event/4/activity/1',
-          types: [
+          types: expect.arrayContaining([
             {
               id: 'http://vocab.getty.edu/aat/300445014',
               name: 'returning',
             },
-          ],
+          ]),
           description: 'Found in a basement',
           date: {
             id: expect.stringContaining(
@@ -101,8 +138,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1939-01-01T00:00:00.000Z'),
             endDate: new Date('1940-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1939-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1940-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          startDate: new Date('1939-01-01T00:00:00.000Z'),
+          endDate: new Date('1940-01-01T00:00:00.000Z'),
           startsAfter:
             'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
@@ -112,52 +149,21 @@ describe('getByHeritageObjectId', () => {
             name: 'Paris',
           },
           transferredTo: {
-            id: 'https://museum.example.org/',
-            type: 'Organization',
-            name: 'Museum',
-          },
-        },
-        {
-          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300055292',
-              name: 'theft (social issue)',
-            },
-          ],
-          date: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
             ),
-            startDate: new Date('1901-01-01T00:00:00.000Z'),
-            endDate: new Date('1901-12-31T23:59:59.999Z'),
-          },
-          startDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          startsAfter:
-            'https://example.org/objects/1/provenance/event/5/activity/1',
-          endsBefore:
-            'https://example.org/objects/1/provenance/event/4/activity/1',
-          location: {
-            id: expect.stringContaining(
-              'https://data.colonialcollections.nl/.well-known/genid/'
-            ),
-            name: 'Amsterdam',
-          },
-          transferredFrom: {
-            id: 'https://museum.example.org/',
             type: 'Organization',
-            name: 'Museum',
+            name: 'Organization A',
           },
         },
         {
           id: 'https://example.org/objects/1/provenance/event/2/activity/1',
-          types: [
+          types: expect.arrayContaining([
             {
               id: 'http://vocab.getty.edu/aat/300417642',
               name: 'purchase (method of acquisition)',
             },
-          ],
+          ]),
           description: 'Bought at an auction in The Hague',
           date: {
             id: expect.stringContaining(
@@ -166,8 +172,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          startDate: new Date('1879-01-01T00:00:00.000Z'),
+          endDate: new Date('1879-01-01T00:00:00.000Z'),
           startsAfter:
             'https://example.org/objects/1/provenance/event/1/activity/1',
           endsBefore:
@@ -195,16 +201,16 @@ describe('getByHeritageObjectId', () => {
         },
         {
           id: 'https://example.org/objects/1/provenance/event/1/activity/1',
-          types: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'purchase (method of acquisition)',
-            },
+          types: expect.arrayContaining([
             {
               id: 'http://vocab.getty.edu/aat/300417644',
               name: 'transfer (method of acquisition)',
             },
-          ],
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ]),
           description: 'Bought for 1500 US dollars',
           date: {
             id: expect.stringContaining(
@@ -213,8 +219,8 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1855-01-01T00:00:00.000Z'),
             endDate: new Date('1857-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1855-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1857-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
+          startDate: new Date('1855-01-01T00:00:00.000Z'),
+          endDate: new Date('1857-01-01T00:00:00.000Z'),
           endsBefore:
             'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {
@@ -238,6 +244,106 @@ describe('getByHeritageObjectId', () => {
             name: 'Jan de Vries',
           },
         },
+      ])
+    );
+  });
+});
+
+describe('get with localized names', () => {
+  it('returns the provenance events with English names', async () => {
+    const provenanceEvents =
+      await provenanceEventsFetcher.getByHeritageObjectId({
+        locale: 'en',
+        id: 'https://example.org/objects/1',
+      });
+
+    // Currently the only localized parts
+    expect(provenanceEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300055292',
+              name: 'theft (social issue)',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/5/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/4/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300445014',
+              name: 'returning',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
+          types: expect.arrayContaining([
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'purchase (method of acquisition)',
+            },
+            {
+              id: 'http://vocab.getty.edu/aat/300417644',
+              name: 'transfer (method of acquisition)',
+            },
+          ]),
+        }),
+      ])
+    );
+  });
+
+  it('returns the provenance events with Dutch names', async () => {
+    const provenanceEvents =
+      await provenanceEventsFetcher.getByHeritageObjectId({
+        locale: 'nl',
+        id: 'https://example.org/objects/1',
+      });
+
+    // Currently the only localized parts
+    expect(provenanceEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/3/activity/1',
+          types: [
+            {
+              id: 'http://vocab.getty.edu/aat/300055292',
+              name: 'diefstal',
+            },
+          ],
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/5/activity/1',
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/4/activity/1',
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/2/activity/1',
+        }),
+        expect.objectContaining({
+          id: 'https://example.org/objects/1/provenance/event/1/activity/1',
+        }),
       ])
     );
   });

--- a/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.integration.test.ts
@@ -90,11 +90,7 @@ describe('search', () => {
           isPartOf: {
             id: 'https://example.org/datasets/10',
             name: 'Dataset 10',
-            publisher: {
-              id: 'https://library.example.org/',
-              type: 'Organization',
-              name: 'Library',
-            },
+            publisher: undefined,
           },
         },
         {
@@ -151,7 +147,7 @@ describe('search', () => {
             publisher: {
               id: 'https://museum.example.org/',
               type: 'Organization',
-              name: 'Museum',
+              name: 'The Museum',
             },
           },
         },
@@ -339,7 +335,7 @@ describe('search', () => {
             publisher: {
               id: 'https://museum.example.org/',
               type: 'Organization',
-              name: 'Museum',
+              name: 'The Museum',
             },
           },
         },
@@ -351,7 +347,7 @@ describe('search', () => {
             publisher: {
               id: 'https://museum.example.org/',
               type: 'Organization',
-              name: 'Museum',
+              name: 'The Museum',
             },
           },
         },
@@ -455,8 +451,8 @@ describe('search', () => {
         publishers: [
           {
             totalCount: 3,
-            id: 'Museum',
-            name: 'Museum',
+            id: 'The Museum',
+            name: 'The Museum',
           },
           {
             totalCount: 1,
@@ -630,7 +626,7 @@ describe('search', () => {
   it('finds heritage objects if "publishers" filter matches', async () => {
     const result = await heritageObjectSearcher.search({
       filters: {
-        publishers: ['Museum'],
+        publishers: ['The Museum'],
       },
     });
 
@@ -640,8 +636,8 @@ describe('search', () => {
         publishers: [
           {
             totalCount: 3,
-            id: 'Museum',
-            name: 'Museum',
+            id: 'The Museum',
+            name: 'The Museum',
           },
         ],
       },
@@ -754,6 +750,13 @@ describe('search with localized names', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
+        publishers: [
+          {
+            totalCount: 1,
+            id: 'The Museum',
+            name: 'The Museum',
+          },
+        ],
       },
     });
   });
@@ -771,6 +774,13 @@ describe('search with localized names', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Maleisië', name: 'Maleisië'}],
+        publishers: [
+          {
+            totalCount: 1,
+            id: 'Het Museum',
+            name: 'Het Museum',
+          },
+        ],
       },
     });
   });

--- a/apps/researcher/src/lib/api/objects/searcher.ts
+++ b/apps/researcher/src/lib/api/objects/searcher.ts
@@ -149,6 +149,7 @@ export class HeritageObjectSearcher {
 
   private buildRequest(options: SearchOptions) {
     const locationKey = `${RawKeys.CountryCreated}_${options.locale}.keyword`;
+    const publisherKey = `${RawKeys.Publisher}_${options.locale}.keyword`;
 
     const aggregations = {
       types: this.buildAggregation(`${RawKeys.AdditionalType}.keyword`),
@@ -156,7 +157,7 @@ export class HeritageObjectSearcher {
       locations: this.buildAggregation(locationKey),
       materials: this.buildAggregation(`${RawKeys.Material}.keyword`),
       creators: this.buildAggregation(`${RawKeys.Creator}.keyword`),
-      publishers: this.buildAggregation(`${RawKeys.Publisher}.keyword`),
+      publishers: this.buildAggregation(publisherKey),
       dateCreatedStart: this.buildAggregation(RawKeys.YearCreatedStart),
       dateCreatedEnd: this.buildAggregation(RawKeys.YearCreatedEnd),
     };
@@ -205,7 +206,7 @@ export class HeritageObjectSearcher {
       [locationKey, options.filters?.locations],
       [`${RawKeys.Material}.keyword`, options.filters?.materials],
       [`${RawKeys.Creator}.keyword`, options.filters?.creators],
-      [`${RawKeys.Publisher}.keyword`, options.filters?.publishers],
+      [publisherKey, options.filters?.publishers],
     ]);
 
     for (const [rawHeritageObjectKey, filters] of queryFilters) {

--- a/apps/researcher/src/lib/api/organizations/fetcher.integration.test.ts
+++ b/apps/researcher/src/lib/api/organizations/fetcher.integration.test.ts
@@ -12,28 +12,30 @@ beforeEach(() => {
 
 describe('getById', () => {
   it('returns undefined if a malformed ID is used', async () => {
-    const heritageObject = await organizationFetcher.getById('malformedID');
+    const heritageObject = await organizationFetcher.getById({
+      id: 'malformedID',
+    });
 
     expect(heritageObject).toBeUndefined();
   });
 
   it('returns undefined if no organization matches the ID', async () => {
-    const organization = await organizationFetcher.getById(
-      'https://unknown.org/'
-    );
+    const organization = await organizationFetcher.getById({
+      id: 'https://unknown.org/',
+    });
 
     expect(organization).toBeUndefined();
   });
 
   it('returns the organization that matches the ID', async () => {
-    const organization = await organizationFetcher.getById(
-      'https://museum.example.org/'
-    );
+    const organization = await organizationFetcher.getById({
+      id: 'https://museum.example.org/',
+    });
 
     expect(organization).toStrictEqual({
       type: 'Organization',
       id: 'https://museum.example.org/',
-      name: 'Museum',
+      name: 'The Museum',
       url: 'http://www.example.org',
       address: {
         id: expect.stringContaining(
@@ -43,6 +45,46 @@ describe('getById', () => {
         postalCode: '1234 AB',
         addressLocality: 'Museum Place',
         addressCountry: 'Netherlands',
+      },
+    });
+  });
+});
+
+describe('get with localized names', () => {
+  it('returns the organization with English names', async () => {
+    const organization = await organizationFetcher.getById({
+      locale: 'en',
+      id: 'https://museum.example.org/',
+    });
+
+    // Currently the only localized parts
+    expect(organization).toMatchObject({
+      id: 'https://museum.example.org/',
+      name: 'The Museum',
+      address: {
+        streetAddress: 'Museum Street 1',
+        postalCode: '1234 AB',
+        addressLocality: 'Museum Place',
+        addressCountry: 'Netherlands',
+      },
+    });
+  });
+
+  it('returns the organization with Dutch names', async () => {
+    const organization = await organizationFetcher.getById({
+      locale: 'nl',
+      id: 'https://museum.example.org/',
+    });
+
+    // Currently the only localized parts
+    expect(organization).toMatchObject({
+      id: 'https://museum.example.org/',
+      name: 'Het Museum',
+      address: {
+        streetAddress: 'Museum Street 1',
+        postalCode: '1234 AB',
+        addressLocality: 'Museumplaats',
+        addressCountry: 'Nederland',
       },
     });
   });

--- a/apps/researcher/src/lib/api/organizations/index.integration.test.ts
+++ b/apps/researcher/src/lib/api/organizations/index.integration.test.ts
@@ -16,9 +16,9 @@ beforeEach(() => {
 
 describe('getById', () => {
   it('returns an organization', async () => {
-    const organization = await organizations.getById(
-      'https://museum.example.org/'
-    );
+    const organization = await organizations.getById({
+      id: 'https://museum.example.org/',
+    });
 
     expect(organization).not.toBeUndefined();
   });

--- a/apps/researcher/src/lib/api/organizations/index.ts
+++ b/apps/researcher/src/lib/api/organizations/index.ts
@@ -1,4 +1,4 @@
-import {OrganizationFetcher} from './fetcher';
+import {GetByIdOptions, OrganizationFetcher} from './fetcher';
 import {z} from 'zod';
 
 // Re-export definitions for ease of use in consuming apps
@@ -23,7 +23,7 @@ export class Organizations {
     });
   }
 
-  async getById(id: string) {
-    return this.organizationFetcher.getById(id);
+  async getById(options: GetByIdOptions) {
+    return this.organizationFetcher.getById(options);
   }
 }


### PR DESCRIPTION
This PR makes the names of publishers/organizations and the names of provenance types locale-aware (similar to the previous PR, in which the names of locations were made locale-aware).

Beware: do not merge this PR just yet - the Elasticsearch indexes on production do not yet have the locale names.