### PR TITLE
Fix SignUp component

### DIFF
--- a/apps/researcher/src/app/[locale]/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/researcher/src/app/[locale]/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,14 @@
 import {SignIn} from '@clerk/nextjs';
-import {headers} from 'next/headers';
+import {getLocale} from 'next-intl/server';
+import {env} from 'node:process';
 
-export default function Page() {
-  // Get the path with the locale preset.
-  const activePath = headers().get('x-pathname') || '/sign-in';
+export default async function Page() {
+  const locale = await getLocale();
 
-  return <SignIn afterSignInUrl="/" path={activePath} />;
+  return (
+    <SignIn
+      redirectUrl="/"
+      path={`/${locale}${env.NEXT_PUBLIC_CLERK_SIGN_IN_URL}`}
+    />
+  );
 }

--- a/apps/researcher/src/app/[locale]/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/researcher/src/app/[locale]/sign-up/[[...sign-up]]/page.tsx
@@ -1,12 +1,10 @@
 import {SignUp} from '@clerk/nextjs';
-import {headers} from 'next/headers';
-import {getTranslations} from 'next-intl/server';
+import {getLocale, getTranslations} from 'next-intl/server';
+import {env} from 'node:process';
 
 export default async function Page() {
   const t = await getTranslations('SignUp');
-
-  // Get the path with the locale preset.
-  const activePath = headers().get('x-pathname') || '/sign-up';
+  const locale = await getLocale();
 
   return (
     <div>
@@ -46,7 +44,10 @@ export default async function Page() {
           <div className="w-full md:w-1/3 order-1 md:order-2">
             <div className="w-full p-4 md:sticky top-0 {{> styles/style_form }} rounded-lg min-h-[300px]">
               <div className="-translate-x-5 md:-translate-x-10">
-                <SignUp afterSignUpUrl="/" path={activePath} />
+                <SignUp
+                  redirectUrl="/"
+                  path={`/${locale}${env.NEXT_PUBLIC_CLERK_SIGN_UP_URL}`}
+                />
               </div>
             </div>
           </div>

--- a/apps/researcher/src/components/tabs.tsx
+++ b/apps/researcher/src/components/tabs.tsx
@@ -5,11 +5,13 @@ import {Link} from '@/navigation';
 import {headers} from 'next/headers';
 import {locales} from '@/navigation';
 
+// NOTE: The Tabs component is currently unused, because the '/persons' page is not visible yet.
+// If there is a final decision to remove the '/persons' page, this component can be removed.
+// If re-introduced, ensure to update the `activePath` variable as the `x-pathname` header
+// is no longer set by the middleware.
 export default function Tabs() {
   const t = useTranslations('Tabs');
 
-  // This header is removed, if we reintegrate this component,
-  // we need to find a way to pass the activePath
   const activePath = headers().get('x-pathname') || '/';
 
   const tabs = [

--- a/apps/researcher/src/components/tabs.tsx
+++ b/apps/researcher/src/components/tabs.tsx
@@ -8,6 +8,8 @@ import {locales} from '@/navigation';
 export default function Tabs() {
   const t = useTranslations('Tabs');
 
+  // This header is removed, if we reintegrate this component,
+  // we need to find a way to pass the activePath
   const activePath = headers().get('x-pathname') || '/';
 
   const tabs = [

--- a/apps/researcher/src/middleware.ts
+++ b/apps/researcher/src/middleware.ts
@@ -21,14 +21,7 @@ const handleI18nRouting = createIntlMiddleware({
 
 export default authMiddleware({
   beforeAuth(request) {
-    // Store current request pathname in the request header,
-    // this can be used to set the active menu/tab item.
-    // See issue: https://github.com/vercel/next.js/issues/43704
-    request.headers.set('x-pathname', request.nextUrl.pathname);
-
-    const response = handleI18nRouting(request);
-
-    return response;
+    return handleI18nRouting(request);
   },
   publicRoutes: ['/', '/(.*)'],
 });


### PR DESCRIPTION
**The problem**
After moving to a custom sign-up page, signing up with email no longer works.  After filling out the form, the URL changes to "/sign-up/verify-email-address". Normally, after the URL change, the sign-up component should update to the next step, but the component did not update, and no sign-up email was sent.

Some background about the code: The custom sign-up page was created a long time ago, but we never used it because the `NEXT_PUBLIC_CLERK_SIGN_UP_URL` environment variable was not set; without this variable, Cleck would not show the custom page but use its own page. This was never a problem because we did not really need a custom page. Now Bas has designed a page, so we need our custom page. So I set the environment variable, and our custom page was loaded.

Since we did not use our custom page, I'm not sure if our custom sign-up page ever worked.

**Cause**
The `<SignUp />` component needs the variable `path`. This should be set to `/en/sign-up` or `/nl/sign-up` depending on the locale. When I created this page, there was no way to get the locale in a server component, so I got the correct `path` by using the `x-pathname` header. But `x-pathname` changes to "/sign-up/verify-email-address" in the process, which is incorrect.

**Solution**
Not the path is set with the locale from `getLocale`, and everything works correctly again.

**Extra work**
I don't think `x-pathname` is needed any more, so I removed this header completely, I would like the middleware to be as similar as possible to the docs of [next-intl](https://next-intl-docs.vercel.app/docs/routing/middleware#example-integrating-with-clerk) and [Clerk](https://clerk.com/docs/references/nextjs/auth-middleware), because maybe our other Clerk problems has to do with problems in the middleware.

I have set `redirectUrl` to '/'. The description of `redirectUrl`: "Full URL or path to navigate after successful sign in or sign up.
The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value."