### PR TITLE
Community avatar square constrains

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/community-card.tsx
+++ b/apps/researcher/src/app/[locale]/communities/community-card.tsx
@@ -42,7 +42,7 @@ export default function CommunityCard({community}: CommunityCardProps) {
           height={144}
           src={community.imageUrl}
           alt=""
-          className="w-36 h-auto rounded-full border border-consortiumBlue-800 transition"
+          className="w-36 h-36 rounded-full border border-consortiumBlue-800 transition object-cover"
         />
       </div>
 


### PR DESCRIPTION
The avatar of the community had the shape of of the image but should be square. 