### PR TITLE
Clerk bugs

### DIFF
--- a/apps/researcher/src/components/base-layout.tsx
+++ b/apps/researcher/src/components/base-layout.tsx
@@ -4,6 +4,7 @@ import {getTranslations} from 'next-intl/server';
 import {WipMessage} from '@colonial-collections/ui';
 import {Link} from '@/navigation';
 import {env} from 'node:process';
+import AuthHealthCheck from '@/lib/auth-health-check';
 
 interface Props {
   children: ReactNode;
@@ -15,6 +16,7 @@ export default async function BaseLayout({children, wrapperClassName}: Props) {
 
   return (
     <>
+      <AuthHealthCheck />
       <WipMessage Link={Link} />
 
       <div className="sr-only">

--- a/apps/researcher/src/components/navigation.tsx
+++ b/apps/researcher/src/components/navigation.tsx
@@ -46,7 +46,9 @@ export default function Navigation({datasetBrowserUrl}: Props) {
     () =>
       locales.map(localeItem => ({
         name: tLanguageSelector(localeItem),
-        href: `/${localeItem}${pathname ?? `/${localeItem}`}`,
+        href: `/revalidate/?path=/[locale]${pathname}&redirect=/${localeItem}${
+          pathname ?? `/${localeItem}`
+        }`,
         active: localeItem === locale,
         ariaLabel: tLanguageSelector('accessibilityLanguageSelector', {
           language: tLanguageSelector(locale),

--- a/apps/researcher/src/lib/auth-health-check/backend.ts
+++ b/apps/researcher/src/lib/auth-health-check/backend.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import {auth, currentUser} from '@clerk/nextjs';
+import {UserResource} from '@clerk/types';
+
+interface props {
+  message: string;
+  frontendUser?: UserResource | null;
+  isLoaded: boolean;
+}
+
+export async function logFailedAuthHealthCheck({
+  message,
+  frontendUser,
+  isLoaded,
+}: props) {
+  const backendUser = await currentUser();
+  const backendAuth = await auth();
+
+  console.error('AUTH HEATH CHECK FAILED');
+  console.error(message);
+  console.error('Frontend user loaded', isLoaded);
+  console.error('Frontend user', frontendUser);
+  console.error('Backend `auth`', backendAuth);
+  console.error('Backend `currentUser`', backendUser);
+}

--- a/apps/researcher/src/lib/auth-health-check/frontend.tsx
+++ b/apps/researcher/src/lib/auth-health-check/frontend.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {useUser} from '@clerk/nextjs';
+import {logFailedAuthHealthCheck} from './backend';
+import {useEffect, useRef} from 'react';
+
+export default function FrontendHealthCheck({
+  backendUserId,
+}: {
+  backendUserId?: string;
+}) {
+  const {user, isLoaded} = useUser();
+
+  // Place `isLoaded` and `user` in a ref, so new values are accessible after a timeout.
+  // https://github.com/facebook/react/issues/14010
+  const isLoadedRef = useRef(isLoaded);
+  const userRef = useRef(user);
+
+  useEffect(() => {
+    isLoadedRef.current = isLoaded;
+    userRef.current = user;
+  }, [isLoaded, user]);
+
+  // There is a bug within the clerk logic: sometimes, the user never loads.
+  // Refresh the page if `isLoading` stays `false` too long.
+  useEffect(() => {
+    if (!isLoaded) {
+      const delayDebounceFn = setTimeout(() => {
+        if (!isLoadedRef.current) {
+          logFailedAuthHealthCheck({
+            message: '`useUser().isLoaded` stays `false`, refresh page',
+            frontendUser: userRef.current,
+            isLoaded: isLoadedRef.current,
+          });
+          location.reload();
+        }
+      }, 10000);
+
+      return () => clearTimeout(delayDebounceFn);
+    }
+    return () => null;
+  }, [isLoaded]);
+
+  // The user in the frontend code using `useUser` and the user from the backend code using
+  // `currentUser` should always be the same. Log differences for debugging purposes.
+  useEffect(() => {
+    if (isLoaded && !user && !!backendUserId) {
+      logFailedAuthHealthCheck({
+        message: 'There is a backend user but no frontend user',
+        frontendUser: userRef.current,
+        isLoaded: isLoadedRef.current,
+      });
+    }
+  }, [backendUserId, isLoaded, user]);
+
+  useEffect(() => {
+    if (isLoaded && !!user && !backendUserId) {
+      logFailedAuthHealthCheck({
+        message: 'There is a frontend user but no backend user',
+        frontendUser: userRef.current,
+        isLoaded: isLoadedRef.current,
+      });
+    }
+  }, [backendUserId, isLoaded, user]);
+
+  return null;
+}

--- a/apps/researcher/src/lib/auth-health-check/index.tsx
+++ b/apps/researcher/src/lib/auth-health-check/index.tsx
@@ -1,0 +1,8 @@
+import {currentUser} from '@clerk/nextjs';
+import FrontendHealthCheck from './frontend';
+
+export default async function AuthHealthCheck() {
+  const user = await currentUser();
+
+  return <FrontendHealthCheck backendUserId={user?.id} />;
+}

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -88,6 +88,7 @@ export async function getMyCommunities({
   const {userId} = await auth();
 
   if (!userId) {
+    console.error('`getMyCommunities()` called without a user');
     return [];
   }
 

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -86,6 +86,11 @@ export async function getMyCommunities({
 }: GetCommunitiesProps = {}) {
   noStore();
   const {userId} = await auth();
+
+  if (!userId) {
+    return [];
+  }
+
   const memberships = userId
     ? await clerkClient.users.getOrganizationMembershipList({
         userId,


### PR DESCRIPTION
This pull request does a few things:

1. Changing the language will revalidate the page, which helps the `user` object to reload properly. But even with the revalidation of `isLoading` from `useUser,` it sometimes stays `false`.
2. If `isLoading` from `users` is false after 10 seconds reload the page. Hopefully resulting in a loaded `user` object.
3. Log multiple failing auth scenarios.
4. Don't error if `auth` returns null values.