### PR TITLE
Save end-to-end testing artifacts

### DIFF
--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -29,3 +29,18 @@ jobs:
           wait-on: ${{ steps.waitForPreview.outputs.url }}
         env:
           CYPRESS_BASE_URL: ${{ steps.waitForPreview.outputs.url }}
+      # Screenshots will be generated only if the test failed
+      # thus we store screenshots only on failures
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./apps/researcher/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - name: Upload videos
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos
+          path: ./apps/researcher/cypress/videos

--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: cypress-screenshots
           path: ./apps/dataset-browser/cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
+      # Test run video is always captured, so this action uses "always()" condition
       - name: Upload videos
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/end-to-end-testing-dataset-browser.yml
+++ b/.github/workflows/end-to-end-testing-dataset-browser.yml
@@ -36,11 +36,11 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: ./apps/researcher/cypress/screenshots
+          path: ./apps/dataset-browser/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - name: Upload videos
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: cypress-videos
-          path: ./apps/researcher/cypress/videos
+          path: ./apps/dataset-browser/cypress/videos

--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -29,3 +29,18 @@ jobs:
           wait-on: ${{ steps.waitForPreview.outputs.url }}
         env:
           CYPRESS_BASE_URL: ${{ steps.waitForPreview.outputs.url }}
+      # Screenshots will be generated only if the test failed
+      # thus we store screenshots only on failures
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./apps/researcher/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - name: Upload videos
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos
+          path: ./apps/researcher/cypress/videos

--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: cypress-screenshots
           path: ./apps/researcher/cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
+      # Test run video is always captured, so this action uses "always()" condition
       - name: Upload videos
         uses: actions/upload-artifact@v2
         if: always()

--- a/apps/dataset-browser/cypress.config.ts
+++ b/apps/dataset-browser/cypress.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
   },
+  video: true,
 });

--- a/apps/researcher/cypress.config.ts
+++ b/apps/researcher/cypress.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3001',
   },
+  video: true,
 });


### PR DESCRIPTION
Save screenshots and videos of the end-to-end tests for debugging failing tests.

Go to the failing tests and click on the summary to see the artifacts.

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/4a0adaaf-af76-43f3-9493-48918828aeee)
