### PR TITLE
Don't use '/revalidate' on language change

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/buttons.tsx
+++ b/apps/researcher/src/app/[locale]/communities/buttons.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {encodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 import {useCreateCommunity} from '@/lib/community/hooks';
 import {useTranslations} from 'next-intl';
 
@@ -12,7 +13,11 @@ export function AddCommunityButton() {
       onClick={() =>
         openCreateCommunity({
           afterCreateOrganizationUrl: organization =>
-            `/revalidate/?path=/[locale]/communities&redirect=/communities/${organization.slug}`,
+            `/revalidate/?path=${encodeRouteSegment(
+              '/[locale]/communities'
+            )}&redirect=${encodeRouteSegment(
+              `/communities/${organization.slug}`
+            )}`,
         })
       }
       className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-consortiumBlue-800 text-consortiumGreen-300 transition flex items-center gap-1"

--- a/apps/researcher/src/components/navigation.tsx
+++ b/apps/researcher/src/components/navigation.tsx
@@ -10,6 +10,7 @@ import {NavigationMenu} from '@colonial-collections/ui';
 import logoImage from '@colonial-collections/ui/branding/colonial-collections-consortium.png';
 import {useMemo} from 'react';
 import ToFilteredListButton from './to-filtered-list-button';
+import {encodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 
 interface Props {
   datasetBrowserUrl: string;
@@ -46,9 +47,9 @@ export default function Navigation({datasetBrowserUrl}: Props) {
     () =>
       locales.map(localeItem => ({
         name: tLanguageSelector(localeItem),
-        href: `/revalidate/?path=/[locale]${pathname}&redirect=/${localeItem}${
-          pathname ?? `/${localeItem}`
-        }`,
+        href: `/revalidate/?path=${encodeRouteSegment(
+          `/[locale]${pathname}`
+        )}&redirect=${encodeRouteSegment(`/${localeItem}${pathname}`)}`,
         active: localeItem === locale,
         ariaLabel: tLanguageSelector('accessibilityLanguageSelector', {
           language: tLanguageSelector(locale),

--- a/apps/researcher/src/lib/community/hooks.tsx
+++ b/apps/researcher/src/lib/community/hooks.tsx
@@ -1,6 +1,7 @@
 import {useClerk, useUser} from '@clerk/nextjs';
 import {organizationToCommunity} from './clerk-converters';
 import {useMemo} from 'react';
+import {encodeRouteSegment} from '../clerk-route-segment-transformer';
 
 interface UseCommunityProfile {
   communitySlug: string;
@@ -21,7 +22,9 @@ export function useCommunityProfile({
     // We must place all pages in `customPage` to define the page order.
     // Pages not in `customPages` will load before the custom pages. So, we need to add all pages to control the first loaded page.
     openOrganizationProfile({
-      afterLeaveOrganizationUrl: `/revalidate/?path=/[locale]/communities/${communitySlug}&redirect=/communities/${communitySlug}`,
+      afterLeaveOrganizationUrl: `/revalidate/?path=${encodeRouteSegment(
+        `/[locale]/communities/${communitySlug}`
+      )}&redirect=${encodeRouteSegment(`/communities/${communitySlug}`)}`,
       customPages: ['settings', 'members']
         .sort((customPageA, customPageB) =>
           customPageA === firstPage ? -1 : customPageB === firstPage ? 1 : 0


### PR DESCRIPTION
We used '/revalidate' on language change, which always triggers a complete refresh. That fixed the auth problems on language change, but with this solution, we ran into another problem: 

You will get an error when you change the language from an object page.

**The problem**

If you take, for example, this object: 

`https://dev.app.colonialcollections.nl/nl/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5`

After a language change, you will go to this revalidate URL: 

`https://dev.app.colonialcollections.nl/revalidate/?path=/[locale]/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5&redirect=/en/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5`

And that will result in a redirect to:

`https://dev.app.colonialcollections.nl/en/objects/https:/example.org/objects/5`

Notice the object identifier encoding is wrong; this will result in an error.

**Tried solutions**

The redirect URL is in the search parameters. The search params are in the `searchParams` object in a server component. [docs](https://nextjs.org/docs/app/api-reference/file-conventions/page#searchparams-optional)

However, Next.js tries to decode the values, so the redirect param: 

`/en/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5`

This will result in:

`/[locale]/objects/https://example%2Eorg/objects/5`

I also tried using a route param instead of a `serchParams`, so the language switch URL would be:

`https://dev.app.colonialcollections.nl/revalidate/en/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5?path=/[locale]/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5`

And using the page `app/[locale]/revalidate/[...rest]/page.tsx`, would result in the `rest` parameter:

`[ 'en', 'objects', 'https%3A', '', 'example%252Eorg', 'objects', '5' ]`

Both options are not workable. This extra decoding by the Next.js app router only happens in a production build.

**Working solution**

Trying different ways to use the app router with URIs and encoding the search params will result in the correct `path` and `redirect` value in the `/revalidate` page.