### PR TITLE
Encode the route segments using 'hex' encoding

### DIFF
--- a/apps/researcher/src/lib/clerk-route-segment-transformer.test.ts
+++ b/apps/researcher/src/lib/clerk-route-segment-transformer.test.ts
@@ -7,14 +7,16 @@ import {
 describe('encodeRouteSegment', () => {
   it('encodes a string with dots', () => {
     const encodedUri = encodeRouteSegment('https://museum.example.org/');
-    expect(encodedUri).toBe('https%3A%2F%2Fmuseum%252Eexample%252Eorg%2F');
+    expect(encodedUri).toBe(
+      '68747470733a2f2f6d757365756d2e6578616d706c652e6f72672f'
+    );
   });
 });
 
 describe('decodeRouteSegment', () => {
   it('decodes a string with dots', () => {
     const decodedUri = decodeRouteSegment(
-      'https%3A%2F%2Fmuseum%252Eexample%252Eorg%2F'
+      '68747470733a2f2f6d757365756d2e6578616d706c652e6f72672f'
     );
     expect(decodedUri).toBe('https://museum.example.org/');
   });

--- a/apps/researcher/src/lib/clerk-route-segment-transformer.ts
+++ b/apps/researcher/src/lib/clerk-route-segment-transformer.ts
@@ -1,8 +1,7 @@
 export function encodeRouteSegment(routeSegment: string) {
-  // If the dynamic routes segments contain dots, the Clerk middleware will throw an error, so encode the dots.
-  return encodeURIComponent(routeSegment.replaceAll('.', '%2E'));
+  return Buffer.from(routeSegment).toString('hex');
 }
 
 export function decodeRouteSegment(routeSegment: string) {
-  return decodeURIComponent(routeSegment).replaceAll('%2E', '.');
+  return Buffer.from(routeSegment, 'hex').toString('utf8');
 }


### PR DESCRIPTION
This is a different solution for the problem in https://github.com/colonial-heritage/colonial-collections/pull/477

We need to choose one.

This solution will encode the URI identifiers in the routes differently, using hex encoding. Hex encoding has no special characters.

Old URL of an object:

https://dev.app.colonialcollections.nl/nl/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F1

New URL of the same object in preview environment:

https://colonial-collections-researcher-git-ur-0fae83-colonial-heritage.vercel.app/nl/objects/68747470733a2f2f6578616d706c652e6f72672f6f626a656374732f31