### PR TITLE
Bugfix in Auth Health Check

### DIFF
--- a/apps/researcher/src/lib/auth-health-check/backend.ts
+++ b/apps/researcher/src/lib/auth-health-check/backend.ts
@@ -1,17 +1,16 @@
 'use server';
 
 import {auth, currentUser} from '@clerk/nextjs';
-import {UserResource} from '@clerk/types';
 
 interface props {
   message: string;
-  frontendUser?: UserResource | null;
+  frontendUserId?: string;
   isLoaded: boolean;
 }
 
 export async function logFailedAuthHealthCheck({
   message,
-  frontendUser,
+  frontendUserId,
   isLoaded,
 }: props) {
   const backendUser = await currentUser();
@@ -20,7 +19,7 @@ export async function logFailedAuthHealthCheck({
   console.error('AUTH HEATH CHECK FAILED');
   console.error(message);
   console.error('Frontend user loaded', isLoaded);
-  console.error('Frontend user', frontendUser);
+  console.error('Frontend user ID', frontendUserId);
   console.error('Backend `auth`', backendAuth);
   console.error('Backend `currentUser`', backendUser);
 }

--- a/apps/researcher/src/lib/auth-health-check/frontend.tsx
+++ b/apps/researcher/src/lib/auth-health-check/frontend.tsx
@@ -29,7 +29,7 @@ export default function FrontendHealthCheck({
         if (!isLoadedRef.current) {
           logFailedAuthHealthCheck({
             message: '`useUser().isLoaded` stays `false`, refresh page',
-            frontendUser: userRef.current,
+            frontendUserId: userRef.current?.id,
             isLoaded: isLoadedRef.current,
           });
           location.reload();
@@ -47,7 +47,7 @@ export default function FrontendHealthCheck({
     if (isLoaded && !user && !!backendUserId) {
       logFailedAuthHealthCheck({
         message: 'There is a backend user but no frontend user',
-        frontendUser: userRef.current,
+        frontendUserId: userRef.current?.id,
         isLoaded: isLoadedRef.current,
       });
     }
@@ -57,7 +57,7 @@ export default function FrontendHealthCheck({
     if (isLoaded && !!user && !backendUserId) {
       logFailedAuthHealthCheck({
         message: 'There is a frontend user but no backend user',
-        frontendUser: userRef.current,
+        frontendUserId: userRef.current?.id,
         isLoaded: isLoadedRef.current,
       });
     }


### PR DESCRIPTION
Fix the error:

`Application error: a client-side exception has occurred (see the browser console for more information).`

With the console warning:

`Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported.`