### PR TITLE
Fallback image in gallery and object card components

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/gallery.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/gallery.tsx
@@ -2,11 +2,10 @@
 
 import {Tab} from '@headlessui/react';
 import classNames from 'classnames';
-import Image from 'next/image';
 import {SlideOver, SlideOverOpenButton} from '@colonial-collections/ui';
 import dynamic from 'next/dynamic';
-import {Fragment} from 'react';
 import {useTranslations} from 'next-intl';
+import ImageWithFallback from '@/components/image-with-fallback';
 
 // SSR needs to be false for plugin 'openseadragon'
 const SlideOverGallery = dynamic(() => import('./slide-over-gallery'), {
@@ -40,7 +39,7 @@ export default function Gallery({images, organizationName}: Props) {
             <div>
               <SlideOver variant="gallery">
                 <SlideOverOpenButton className="w-full h-full justify-start items-start align-top">
-                  <Image
+                  <ImageWithFallback
                     width="0"
                     height="0"
                     src={image.src}
@@ -95,7 +94,7 @@ export default function Gallery({images, organizationName}: Props) {
               {({selected}) => (
                 <>
                   <span className="sr-only">{image.alt}</span>
-                  <Image
+                  <ImageWithFallback
                     width="0"
                     height="0"
                     src={image.src}

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
@@ -1,9 +1,9 @@
 import {Link} from '@/navigation';
 import {useTranslations} from 'next-intl';
 import {HeritageObject} from '@/lib/api/objects';
-import Image from 'next/image';
 import {encodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 import classNames from 'classnames';
+import ImageWithFallback from '@/components/image-with-fallback';
 
 interface Props {
   heritageObject: HeritageObject;
@@ -39,7 +39,7 @@ export default function HeritageObjectCard({heritageObject}: Props) {
       </div>
       {imageUrl ? (
         <div className="flex justify-start items-start border-l border-neutral-200">
-          <Image
+          <ImageWithFallback
             src={imageUrl}
             alt={heritageObject.name || ''}
             width="0"

--- a/apps/researcher/src/components/image-with-fallback.tsx
+++ b/apps/researcher/src/components/image-with-fallback.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React, {useState} from 'react';
+import Image, {ImageProps} from 'next/image';
+import {useTranslations} from 'next-intl';
+
+export default function ImageWithFallback({src, alt, ...rest}: ImageProps) {
+  const [hasError, setHasError] = useState(false);
+  const t = useTranslations('Image');
+
+  if (hasError) {
+    return (
+      <div className="border-b border-neutral-200 p-4">{t('errorText')}</div>
+    );
+  }
+
+  return (
+    <Image
+      {...rest}
+      alt={alt}
+      src={src}
+      onError={() => {
+        setHasError(true);
+      }}
+    />
+  );
+}

--- a/apps/researcher/src/components/image-with-fallback.tsx
+++ b/apps/researcher/src/components/image-with-fallback.tsx
@@ -15,13 +15,6 @@ export default function ImageWithFallback({src, alt, ...rest}: ImageProps) {
   }
 
   return (
-    <Image
-      {...rest}
-      alt={alt}
-      src={src}
-      onError={() => {
-        setHasError(true);
-      }}
-    />
+    <Image {...rest} alt={alt} src={src} onError={() => setHasError(true)} />
   );
 }

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -329,5 +329,8 @@
     "subjectRequired": "Subject is required",
     "subjectTooLarge": "Subject has a maximum of 250 characters",
     "bodyRequired": "Message is required"
+  },
+  "Image": {
+    "errorText": "Image currently not available"
   }
 }

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -329,5 +329,8 @@
      "subjectRequired": "Onderwerp is vereist",
      "subjectTooLarge": "Onderwerp mag maximaal 250 tekens bevatten",
      "bodyRequired": "Bericht is vereist"
-   }
+   },
+    "Image": {
+      "errorText": "Afbeelding momenteel niet beschikbaar"
+    }
 }


### PR DESCRIPTION
Ticket: https://github.com/colonial-heritage/sprints/issues/391

Design: https://gui-prototype.colonialcollections.nl/v2/search.html

This component can also easily be updated to have a loading state.