### PR TITLE
Remove prefix in map

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/map/map.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/map/map.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import {MapContainer, TileLayer, Marker} from 'react-leaflet';
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  AttributionControl,
+} from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css';
 import 'leaflet-defaulticon-compatibility';
@@ -17,12 +22,14 @@ export default function Map({lat, lon}: Props) {
       zoom={7}
       scrollWheelZoom={false}
       style={{height: '100%', width: '100%'}}
+      attributionControl={false}
     >
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       <Marker position={[lat, lon]} />
+      <AttributionControl position="bottomright" prefix={false} />
     </MapContainer>
   );
 }


### PR DESCRIPTION
Solution found in:  https://github.com/PaulLeCam/react-leaflet/issues/102

The map is not visible in the preview environment because the test object does not contain a valid address. This is with production data:

![image](https://github.com/colonial-heritage/colonial-collections/assets/1481602/a581fc38-8070-4664-9ed4-01cb077552a2)

I did keep the `© OpenStreetMap contributors`. So, it's clear we did not create this map ourselves and have no influence on borders and naming.