### PR TITLE
fix: fetch missing dataset and publisher of object

### DIFF
--- a/packages/api/src/objects/fetcher.ts
+++ b/packages/api/src/objects/fetcher.ts
@@ -291,7 +291,9 @@ export class HeritageObjectFetcher {
               crm:P2_has_type ?digitalObjectLicense .
 
             OPTIONAL {
-              ?digitalObjectLicense schema:name ?digitalObjectLicenseName .
+              ?digitalObjectLicense schema:name ?digitalObjectLicenseName
+
+              # For BC; remove as soon as locale-aware names are in use
               FILTER(LANG(?digitalObjectLicenseName) = "" || LANG(?digitalObjectLicenseName) = "en")
             }
           }
@@ -301,36 +303,34 @@ export class HeritageObjectFetcher {
         # Part of dataset
         ####################
 
+        ?this la:member_of ?dataset .
+
+        ####################
+        # Name of dataset
+        ####################
+
         OPTIONAL {
-          ?this la:member_of ?dataset .
+          ?dataset schema:name ?datasetName
 
-          ####################
-          # Name of dataset
-          ####################
+          # For BC; remove as soon as locale-aware names are in use
+          FILTER(LANG(?datasetName) = "" || LANG(?datasetName) = "en")
+        }
 
-          OPTIONAL {
-            ?dataset schema:name ?datasetName
+        ####################
+        # Publisher of dataset
+        ####################
 
-            # For BC; remove as soon as locale-aware names are in use
-            FILTER(LANG(?datasetName) = "" || LANG(?datasetName) = "en")
-          }
+        OPTIONAL {
+          ?dataset schema:publisher ?publisher .
+          ?publisher schema:name ?publisherName ;
+            rdf:type ?publisherTypeTemp .
 
-          ####################
-          # Publisher of dataset
-          ####################
+          FILTER(LANG(?publisherName) = "${options.locale}")
 
-          OPTIONAL {
-            ?dataset schema:publisher ?publisher .
-            ?publisher schema:name ?publisherName ;
-              rdf:type ?publisherTypeTemp .
-
-            FILTER(LANG(?publisherName) = "${options.locale}")
-
-            VALUES (?publisherTypeTemp ?publisherType) {
-              (schema:Organization ex:Organization)
-              (schema:Person ex:Person)
-              (UNDEF UNDEF)
-            }
+          VALUES (?publisherTypeTemp ?publisherType) {
+            (schema:Organization ex:Organization)
+            (schema:Person ex:Person)
+            (UNDEF UNDEF)
           }
         }
       }


### PR DESCRIPTION
This PR fixes a strange issue where the details of the dataset and its publisher aren't being fetched from the SPARQL endpoint (e.g. https://app.colonialcollections.nl/en/objects/https%3A%2F%2Fn2t%252Enet%2Fark%3A%2F27023%2F071463804aa5421843111c9dc6680fb0).

There appears to be an issue with (the way that we query) Virtuoso, our SPARQL backend. The query works just fine with Speedy, the alternate backend. This PR updates the query a bit so that Virtuoso returns the requested data.