### PR TITLE
refactor: provenance API

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.test.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.test.ts
@@ -3,11 +3,11 @@ import {getEarliestDate, categorizeEvents} from './categorize-timeline-events';
 import {LabeledProvenanceEvent} from './definitions';
 
 describe('categorizeEvents', () => {
-  it('categorizes events without dates correctly', () => {
+  it('categorizes events without a date time span correctly', () => {
     const eventGroups = {
       group1: [
-        {id: 'event1', startDate: undefined, endDate: undefined},
-        {id: 'event2', startDate: undefined, endDate: undefined},
+        {id: 'event1', date: undefined},
+        {id: 'event2', date: undefined},
       ],
     };
 
@@ -15,8 +15,27 @@ describe('categorizeEvents', () => {
     const result = categorizeEvents(eventGroups);
 
     expect(result.eventsWithoutDates).toEqual([
-      {id: 'event1', startDate: undefined, endDate: undefined},
-      {id: 'event2', startDate: undefined, endDate: undefined},
+      {id: 'event1', date: undefined},
+      {id: 'event2', date: undefined},
+    ]);
+    expect(result.rangeEvents).toEqual([]);
+    expect(result.singleEvents).toEqual([]);
+  });
+
+  it('categorizes events with a date time span without dates correctly', () => {
+    const eventGroups = {
+      group1: [
+        {id: 'event1', date: {startDate: undefined, endDate: undefined}},
+        {id: 'event2', date: {startDate: undefined, endDate: undefined}},
+      ],
+    };
+
+    // @ts-expect-error:TS2345
+    const result = categorizeEvents(eventGroups);
+
+    expect(result.eventsWithoutDates).toEqual([
+      {id: 'event1', date: {startDate: undefined, endDate: undefined}},
+      {id: 'event2', date: {startDate: undefined, endDate: undefined}},
     ]);
     expect(result.rangeEvents).toEqual([]);
     expect(result.singleEvents).toEqual([]);
@@ -28,14 +47,20 @@ describe('categorizeEvents', () => {
         {
           id: 'event1',
           label: 'P1',
-          startDate: new Date('2022-01-01'),
-          endDate: new Date('2022-01-03'),
+          date: {
+            id: 'timespan1',
+            startDate: new Date('2022-01-01'),
+            endDate: new Date('2022-01-03'),
+          },
         },
         {
           id: 'event2',
           label: 'P2',
-          startDate: new Date('2022-01-01'),
-          endDate: new Date('2022-01-03'),
+          date: {
+            id: 'timespan2',
+            startDate: new Date('2022-01-01'),
+            endDate: new Date('2022-01-03'),
+          },
         },
       ],
     };
@@ -61,16 +86,22 @@ describe('categorizeEvents', () => {
         {
           id: 'event1',
           label: 'P1',
-          startDate: new Date('2022-01-01'),
-          endDate: new Date('2022-01-01'),
+          date: {
+            id: 'timespan1',
+            startDate: new Date('2022-01-01'),
+            endDate: new Date('2022-01-01'),
+          },
         },
       ],
       group2: [
         {
           id: 'event2',
           label: 'P2',
-          startDate: undefined,
-          endDate: new Date('2022-02-01'),
+          date: {
+            id: 'timespan2',
+            startDate: undefined,
+            endDate: new Date('2022-02-01'),
+          },
         },
       ],
     };
@@ -100,22 +131,32 @@ describe('categorizeEvents', () => {
   it('categorizes mixed events correctly', () => {
     const eventGroups = {
       group1: [
-        {id: 'event1', label: 'P1', startDate: undefined, endDate: undefined},
+        {
+          id: 'event1',
+          label: 'P1',
+          date: undefined,
+        },
       ],
       group2: [
         {
           id: 'event2',
           label: 'P2',
-          startDate: new Date('2022-01-01'),
-          endDate: new Date('2022-01-02'),
+          date: {
+            id: 'timespan2',
+            startDate: new Date('2022-01-01'),
+            endDate: new Date('2022-01-02'),
+          },
         },
       ],
       group3: [
         {
           id: 'event3',
           label: 'P3',
-          startDate: new Date('2022-03-01'),
-          endDate: undefined,
+          date: {
+            id: 'timespan3',
+            startDate: new Date('2022-03-01'),
+            endDate: undefined,
+          },
         },
         {
           id: 'event4',
@@ -155,9 +196,9 @@ describe('categorizeEvents', () => {
 describe('getEarliestDate', () => {
   it('returns the earliest date from the events', () => {
     const events = [
-      {startDate: new Date('2022-01-01')},
-      {startDate: new Date('2022-02-01')},
-      {startDate: new Date('2022-03-01')},
+      {date: {startDate: new Date('2022-01-01')}},
+      {date: {startDate: new Date('2022-02-01')}},
+      {date: {startDate: new Date('2022-03-01')}},
     ];
 
     // @ts-expect-error:TS2345
@@ -168,9 +209,9 @@ describe('getEarliestDate', () => {
 
   it('returns the earliest date when there are duplicate dates', () => {
     const events = [
-      {startDate: new Date('2022-01-01')},
-      {startDate: new Date('2022-01-01')},
-      {startDate: new Date('2022-02-01')},
+      {date: {startDate: new Date('2022-01-01')}},
+      {date: {startDate: new Date('2022-01-01')}},
+      {date: {startDate: new Date('2022-02-01')}},
     ];
 
     // @ts-expect-error:TS2345

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/categorize-timeline-events.ts
@@ -23,7 +23,7 @@ export function categorizeEvents(eventGroups: {
     (categorizedEvents, [id, eventGroups]) => {
       // All events in the group have the same dates, so we can just take the first one
       const firstEvent = eventGroups[0];
-      if (!firstEvent.startDate && !firstEvent.endDate) {
+      if (!firstEvent.date?.startDate && !firstEvent.date?.endDate) {
         return {
           ...categorizedEvents,
           eventsWithoutDates: [
@@ -32,11 +32,12 @@ export function categorizeEvents(eventGroups: {
           ],
         };
       } else {
+        const timeSpan = firstEvent.date;
         const timelineEvent = {
           id,
           // The timeline plugin expects both a start and end date
-          startDate: (firstEvent.startDate || firstEvent.endDate) as Date,
-          endDate: (firstEvent.endDate || firstEvent.startDate) as Date,
+          startDate: (timeSpan.startDate || timeSpan.endDate) as Date,
+          endDate: (timeSpan.endDate || timeSpan.startDate) as Date,
           selectIds: eventGroups.map(event => event.id),
           labels: eventGroups.map(event => event.label),
         };
@@ -65,8 +66,8 @@ export function categorizeEvents(eventGroups: {
 
 export function getEarliestDate(events: LabeledProvenanceEvent[]): Date {
   return events.reduce((earliestDate, event) => {
-    if (event.startDate && event.startDate < earliestDate) {
-      return event.startDate;
+    if (event.date?.startDate && event.date.startDate < earliestDate) {
+      return event.date.startDate;
     }
     return earliestDate;
   }, new Date());

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/group-events.test.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/group-events.test.ts
@@ -21,20 +21,28 @@ describe('groupByDateRange', () => {
   it('groups events by date range', () => {
     const events = [
       {
-        startDate: new Date('2022-01-01'),
-        endDate: new Date('2022-01-05'),
+        date: {
+          startDate: new Date('2022-01-01'),
+          endDate: new Date('2022-01-05'),
+        },
       },
       {
-        startDate: new Date('2022-01-03'),
-        endDate: new Date('2022-01-07'),
+        date: {
+          startDate: new Date('2022-01-03'),
+          endDate: new Date('2022-01-07'),
+        },
       },
       {
-        startDate: new Date('2022-01-03'),
-        endDate: new Date('2022-01-07'),
+        date: {
+          startDate: new Date('2022-01-03'),
+          endDate: new Date('2022-01-07'),
+        },
       },
       {
-        startDate: new Date('2022-01-06'),
-        endDate: new Date('2022-01-10'),
+        date: {
+          startDate: new Date('2022-01-06'),
+          endDate: new Date('2022-01-10'),
+        },
       },
     ];
 

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/group-events.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/group-events.ts
@@ -14,11 +14,7 @@ export function groupByDateRange({
 }: GroupByDateRangeProps) {
   return events.reduce(
     (eventGroups: {[dateRange: string]: LabeledProvenanceEvent[]}, event) => {
-      const dateRange =
-        formatDateRange({
-          startDate: event.startDate,
-          endDate: event.endDate,
-        }) || '';
+      const dateRange = formatDateRange(event.date || {}) || '';
       if (!eventGroups[dateRange]) {
         eventGroups[dateRange] = [];
       }

--- a/packages/api/src/definitions.ts
+++ b/packages/api/src/definitions.ts
@@ -86,8 +86,6 @@ export type ProvenanceEvent = {
   id: string;
   types?: Term[];
   date?: TimeSpan;
-  startDate?: Date; // For BC; remove when prop date is in use
-  endDate?: Date; // For BC; remove when prop date is in use
   transferredFrom?: Agent;
   transferredTo?: Agent;
   description?: string;

--- a/packages/api/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/api/src/provenance-events/fetcher.integration.test.ts
@@ -59,12 +59,6 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1901-01-01T00:00:00.000Z'),
             endDate: new Date('1901-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1901-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          startsAfter:
-            'https://example.org/objects/1/provenance/event/5/activity/1',
-          endsBefore:
-            'https://example.org/objects/1/provenance/event/4/activity/1',
           location: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
@@ -95,12 +89,6 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          startsAfter:
-            'https://example.org/objects/1/provenance/event/2/activity/1',
-          endsBefore:
-            'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
@@ -138,10 +126,6 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1939-01-01T00:00:00.000Z'),
             endDate: new Date('1940-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1939-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1940-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          startsAfter:
-            'https://example.org/objects/1/provenance/event/3/activity/1',
           location: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
@@ -172,12 +156,6 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1879-01-01T00:00:00.000Z'),
             endDate: new Date('1879-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1879-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          startsAfter:
-            'https://example.org/objects/1/provenance/event/1/activity/1',
-          endsBefore:
-            'https://example.org/objects/1/provenance/event/5/activity/1',
           location: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'
@@ -219,10 +197,6 @@ describe('getByHeritageObjectId', () => {
             startDate: new Date('1855-01-01T00:00:00.000Z'),
             endDate: new Date('1857-12-31T23:59:59.999Z'),
           },
-          startDate: new Date('1855-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endDate: new Date('1857-01-01T00:00:00.000Z'), // For BC; remove when prop date is in use
-          endsBefore:
-            'https://example.org/objects/1/provenance/event/2/activity/1',
           location: {
             id: expect.stringContaining(
               'https://data.colonialcollections.nl/.well-known/genid/'

--- a/packages/api/src/provenance-events/fetcher.ts
+++ b/packages/api/src/provenance-events/fetcher.ts
@@ -54,14 +54,10 @@ export class ProvenanceEventsFetcher {
         ?acquisition a ex:Event ;
           ex:additionalType ?acquisitionType ;
           ex:date ?acquisitionTimeSpan ;
-          ex:startDate ?acquisitionBeginOfTheBegin ; # For BC; remove when prop date is in use
-          ex:endDate ?acquisitionEndOfTheEnd ; # For BC; remove when prop date is in use
           ex:transferredFrom ?acquisitionOwnerFrom ;
           ex:transferredTo ?acquisitionOwnerTo ;
           ex:description ?acquisitionDescription ;
-          ex:location ?acquisitionLocation ;
-          ex:startsAfter ?acquisitionStartsAfterTheEndOf ;
-          ex:endsBefore ?acquisitionEndsBeforeTheStartOf .
+          ex:location ?acquisitionLocation .
 
         ?acquisitionTimeSpan a ex:TimeSpan ;
           ex:startDate ?acquisitionBeginOfTheBegin ;
@@ -82,14 +78,10 @@ export class ProvenanceEventsFetcher {
         ?transferOfCustody a ex:Event ;
           ex:additionalType ?transferOfCustodyType ;
           ex:date ?transferOfCustodyTimeSpan ;
-          ex:startDate ?transferOfCustodyBeginOfTheBegin ; # For BC; remove when prop date is in use
-          ex:endDate ?transferOfCustodyEndOfTheEnd ; # For BC; remove when prop date is in use
           ex:transferredFrom ?transferOfCustodyCustodianFrom ;
           ex:transferredTo ?transferOfCustodyCustodianTo ;
           ex:description ?transferOfCustodyDescription ;
-          ex:location ?transferOfCustodyLocation ;
-          ex:startsAfter ?transferOfCustodyStartsAfterTheEndOf ;
-          ex:endsBefore ?transferOfCustodyEndsBeforeTheStartOf .
+          ex:location ?transferOfCustodyLocation .
 
         ?transferOfCustodyTimeSpan a ex:TimeSpan ;
           ex:startDate ?transferOfCustodyBeginOfTheBegin ;
@@ -113,13 +105,12 @@ export class ProvenanceEventsFetcher {
         ?this a crm:E22_Human-Made_Object .
 
         ####################
-        # Provenance: acquisition
+        # Acquisition
         ####################
 
         OPTIONAL {
           ?this crm:P24i_changed_ownership_through ?acquisition .
-          ?acquisition a crm:E8_Acquisition ;
-            crm:P9i_forms_part_of ?acquisitionProvEvent .
+          ?acquisition a crm:E8_Acquisition .
 
           ####################
           # Acquisition type
@@ -137,13 +128,15 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?acquisition crm:P23_transferred_title_from ?acquisitionOwnerFrom .
-            ?acquisitionOwnerFrom rdfs:label ?acquisitionOwnerFromName ;
-              rdf:type ?acquisitionOwnerFromTypeTmp .
+            ?acquisitionOwnerFrom rdfs:label ?acquisitionOwnerFromName .
 
-            VALUES (?acquisitionOwnerFromTypeTmp ?acquisitionOwnerFromType) {
-              (crm:E74_Group ex:Organization)
-              (crm:E21_Person ex:Person)
-              (UNDEF UNDEF)
+            OPTIONAL {
+              ?acquisitionOwnerFrom rdf:type ?acquisitionOwnerFromTypeTmp .
+              VALUES (?acquisitionOwnerFromTypeTmp ?acquisitionOwnerFromType) {
+                (crm:E74_Group ex:Organization)
+                (crm:E21_Person ex:Person)
+                (UNDEF UNDEF)
+              }
             }
           }
 
@@ -153,29 +146,27 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?acquisition crm:P22_transferred_title_to ?acquisitionOwnerTo .
-            ?acquisitionOwnerTo rdfs:label ?acquisitionOwnerToName ;
-              rdf:type ?acquisitionOwnerToTypeTmp .
+            ?acquisitionOwnerTo rdfs:label ?acquisitionOwnerToName .
 
-            VALUES (?acquisitionOwnerToTypeTmp ?acquisitionOwnerToType) {
-              (crm:E74_Group ex:Organization)
-              (crm:E21_Person ex:Person)
-              (UNDEF UNDEF)
+            OPTIONAL {
+              ?acquisitionOwnerTo rdf:type ?acquisitionOwnerToTypeTmp .
+              VALUES (?acquisitionOwnerToTypeTmp ?acquisitionOwnerToType) {
+                (crm:E74_Group ex:Organization)
+                (crm:E21_Person ex:Person)
+                (UNDEF UNDEF)
+              }
             }
           }
-
-          ?acquisitionProvEvent a crm:E7_Activity .
 
           ####################
           # Earliest start date and latest end date of the acquisition
           ####################
 
           OPTIONAL {
-            ?acquisitionProvEvent crm:P4_has_time-span ?acquisitionTimeSpan .
-
+            ?acquisition crm:P4_has_time-span ?acquisitionTimeSpan .
             OPTIONAL {
               ?acquisitionTimeSpan crm:P82a_begin_of_the_begin ?acquisitionBeginOfTheBegin .
             }
-
             OPTIONAL {
               ?acquisitionTimeSpan crm:P82b_end_of_the_end ?acquisitionEndOfTheEnd .
             }
@@ -186,7 +177,7 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?acquisitionProvEvent crm:P67i_is_referred_to_by [
+            ?acquisition crm:P67i_is_referred_to_by [
               crm:P2_has_type <http://vocab.getty.edu/aat/300444174> ; # Provenance statement
               crm:P190_has_symbolic_content ?acquisitionDescription ;
             ] ;
@@ -197,33 +188,18 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?acquisitionProvEvent crm:P7_took_place_at ?acquisitionLocation .
+            ?acquisition crm:P7_took_place_at ?acquisitionLocation .
             ?acquisitionLocation rdfs:label ?acquisitionLocationName .
-          }
-
-          ####################
-          # Relationships to the previous and next acquisition
-          ####################
-
-          OPTIONAL {
-            ?acquisitionProvEvent crm:P183i_starts_after_the_end_of ?acquisitionProvEventStartsAfterTheEndOf .
-            ?acquisitionProvEventStartsAfterTheEndOf crm:P9_consists_of ?acquisitionStartsAfterTheEndOf .
-          }
-
-          OPTIONAL {
-            ?acquisitionProvEvent crm:P183_ends_before_the_start_of ?acquisitionProvEventEndsBeforeTheStartOf .
-            ?acquisitionProvEventEndsBeforeTheStartOf crm:P9_consists_of ?acquisitionEndsBeforeTheStartOf .
           }
         }
 
         ####################
-        # Provenance: transfer of custody
+        # Transfer of custody
         ####################
 
         OPTIONAL {
           ?this crm:P30i_custody_transferred_through ?transferOfCustody .
-          ?transferOfCustody a crm:E10_Transfer_of_Custody ;
-            crm:P9i_forms_part_of ?transferOfCustodyProvEvent .
+          ?transferOfCustody a crm:E10_Transfer_of_Custody .
 
           ####################
           # Transfer of custody type
@@ -241,13 +217,15 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?transferOfCustody crm:P28_custody_surrendered_by ?transferOfCustodyCustodianFrom .
-            ?transferOfCustodyCustodianFrom rdfs:label ?transferOfCustodyCustodianFromName ;
-              rdf:type ?transferOfCustodyCustodianFromTypeTemp .
+            ?transferOfCustodyCustodianFrom rdfs:label ?transferOfCustodyCustodianFromName .
 
-            VALUES (?transferOfCustodyCustodianFromTypeTemp ?transferOfCustodyCustodianFromType) {
-              (crm:E74_Group ex:Organization)
-              (crm:E21_Person ex:Person)
-              (UNDEF UNDEF)
+            OPTIONAL {
+              ?transferOfCustodyCustodianFrom rdf:type ?transferOfCustodyCustodianFromTypeTemp .
+              VALUES (?transferOfCustodyCustodianFromTypeTemp ?transferOfCustodyCustodianFromType) {
+                (crm:E74_Group ex:Organization)
+                (crm:E21_Person ex:Person)
+                (UNDEF UNDEF)
+              }
             }
           }
 
@@ -257,29 +235,27 @@ export class ProvenanceEventsFetcher {
 
           OPTIONAL {
             ?transferOfCustody crm:P29_custody_received_by ?transferOfCustodyCustodianTo .
-            ?transferOfCustodyCustodianTo rdfs:label ?transferOfCustodyCustodianToName ;
-              rdf:type ?transferOfCustodyCustodianToTypeTemp .
+            ?transferOfCustodyCustodianTo rdfs:label ?transferOfCustodyCustodianToName .
 
-            VALUES (?transferOfCustodyCustodianToTypeTemp ?transferOfCustodyCustodianToType) {
-              (crm:E74_Group ex:Organization)
-              (crm:E21_Person ex:Person)
-              (UNDEF UNDEF)
+            OPTIONAL {
+              ?transferOfCustodyCustodianTo rdf:type ?transferOfCustodyCustodianToTypeTemp .
+              VALUES (?transferOfCustodyCustodianToTypeTemp ?transferOfCustodyCustodianToType) {
+                (crm:E74_Group ex:Organization)
+                (crm:E21_Person ex:Person)
+                (UNDEF UNDEF)
+              }
             }
           }
-
-          ?transferOfCustodyProvEvent a crm:E7_Activity .
 
           ####################
           # Earliest start date and latest end date of the transfer of custody
           ####################
 
           OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P4_has_time-span ?transferOfCustodyTimeSpan .
-
+            ?transferOfCustody crm:P4_has_time-span ?transferOfCustodyTimeSpan .
             OPTIONAL {
               ?transferOfCustodyTimeSpan crm:P82a_begin_of_the_begin ?transferOfCustodyBeginOfTheBegin .
             }
-
             OPTIONAL {
               ?transferOfCustodyTimeSpan crm:P82b_end_of_the_end ?transferOfCustodyEndOfTheEnd .
             }
@@ -290,7 +266,7 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P67i_is_referred_to_by [
+            ?transferOfCustody crm:P67i_is_referred_to_by [
               crm:P2_has_type <http://vocab.getty.edu/aat/300444174> ; # Provenance statement
               crm:P190_has_symbolic_content ?transferOfCustodyDescription ;
             ] ;
@@ -301,22 +277,8 @@ export class ProvenanceEventsFetcher {
           ####################
 
           OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P7_took_place_at ?transferOfCustodyLocation .
+            ?transferOfCustody crm:P7_took_place_at ?transferOfCustodyLocation .
             ?transferOfCustodyLocation rdfs:label ?transferOfCustodyLocationName .
-          }
-
-          ####################
-          # Relationships to the previous and next transfer of custody
-          ####################
-
-          OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P183i_starts_after_the_end_of ?transferOfCustodyProvEventStartsAfterTheEndOf .
-            ?transferOfCustodyProvEventStartsAfterTheEndOf crm:P9_consists_of ?transferOfCustodyStartsAfterTheEndOf .
-          }
-
-          OPTIONAL {
-            ?transferOfCustodyProvEvent crm:P183_ends_before_the_start_of ?transferOfCustodyProvEventEndsBeforeTheStartOf .
-            ?transferOfCustodyProvEventEndsBeforeTheStartOf crm:P9_consists_of ?transferOfCustodyEndsBeforeTheStartOf .
           }
         }
       }
@@ -328,8 +290,6 @@ export class ProvenanceEventsFetcher {
   private toProvenanceEvent(rawProvenanceEvent: Resource) {
     const id = rawProvenanceEvent.value;
     const date = onlyOne(createTimeSpans(rawProvenanceEvent, 'ex:date'));
-    const startDate = getPropertyValue(rawProvenanceEvent, 'ex:startDate'); // For BC; remove when prop date is in use
-    const endDate = getPropertyValue(rawProvenanceEvent, 'ex:endDate'); // For BC; remove when prop date is in use
     const description = getPropertyValue(rawProvenanceEvent, 'ex:description');
     const startsAfter = getPropertyValue(rawProvenanceEvent, 'ex:startsAfter');
     const endsBefore = getPropertyValue(rawProvenanceEvent, 'ex:endsBefore');
@@ -347,8 +307,6 @@ export class ProvenanceEventsFetcher {
       types,
       description,
       date,
-      startDate: startDate !== undefined ? new Date(startDate) : undefined, // For BC; remove when prop date is in use
-      endDate: endDate !== undefined ? new Date(endDate) : undefined, // For BC; remove when prop date is in use
       startsAfter,
       endsBefore,
       location,


### PR DESCRIPTION
This **backward-incompatible** PR updates the API for fetching the provenance information of an object. These changes are in sync with the datamodel that Kinsuk uses for the provenance information of NMVW.

This PR also removes the `startDate` and `endDate` props from the `ProvenanceEvent` type that were deprecated some weeks ago, in favor of the `date` prop.