### PR TITLE
feat: add locale support for types and materials

### DIFF
--- a/packages/api/src/objects/fetcher.integration.test.ts
+++ b/packages/api/src/objects/fetcher.integration.test.ts
@@ -175,27 +175,51 @@ describe('get with localized names', () => {
   it('returns a heritage object with English names', async () => {
     const heritageObject = await heritageObjectFetcher.getById({
       locale: 'en',
-      id: 'https://example.org/objects/2',
+      id: 'https://example.org/objects/5',
     });
 
     // Currently the only localized parts
     expect(heritageObject).toMatchObject({
-      id: 'https://example.org/objects/2',
-      locationsCreated: expect.arrayContaining([
+      id: 'https://example.org/objects/5',
+      locationsCreated: [
         {
-          id: 'https://sws.geonames.org/1642911/',
-          name: 'Jakarta',
+          id: 'https://sws.geonames.org/1749659/',
+          name: 'Pulau Sebang',
           isPartOf: {
-            id: 'https://sws.geonames.org/1643084/',
-            name: 'Indonesia',
+            id: 'https://sws.geonames.org/1733045/',
+            name: 'Malaysia',
           },
+        },
+      ],
+      types: expect.arrayContaining([
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Canvas Painting',
+        },
+      ]),
+      materials: expect.arrayContaining([
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Oilpaint',
+        },
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Canvas',
         },
       ]),
       isPartOf: {
-        id: 'https://example.org/datasets/13',
+        id: 'https://example.org/datasets/1',
+        name: 'Dataset 1',
         publisher: {
-          id: 'https://research.example.org/',
-          name: 'Research Organisation',
+          id: 'https://museum.example.org/',
+          type: 'Organization',
+          name: 'The Museum',
         },
       },
     });
@@ -204,27 +228,51 @@ describe('get with localized names', () => {
   it('returns a heritage object with Dutch names', async () => {
     const heritageObject = await heritageObjectFetcher.getById({
       locale: 'nl',
-      id: 'https://example.org/objects/2',
+      id: 'https://example.org/objects/5',
     });
 
     // Currently the only localized parts
     expect(heritageObject).toMatchObject({
-      id: 'https://example.org/objects/2',
-      locationsCreated: expect.arrayContaining([
+      id: 'https://example.org/objects/5',
+      locationsCreated: [
         {
-          id: 'https://sws.geonames.org/1642911/',
-          name: 'Jakarta',
+          id: 'https://sws.geonames.org/1749659/',
+          name: 'Pulau Sebang',
           isPartOf: {
-            id: 'https://sws.geonames.org/1643084/',
-            name: 'Republiek Indonesië',
+            id: 'https://sws.geonames.org/1733045/',
+            name: 'Maleisië',
           },
+        },
+      ],
+      types: expect.arrayContaining([
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Schildering op doek',
+        },
+      ]),
+      materials: expect.arrayContaining([
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Olieverf',
+        },
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Canvas',
         },
       ]),
       isPartOf: {
-        id: 'https://example.org/datasets/13',
+        id: 'https://example.org/datasets/1',
+        name: 'Dataset 1',
         publisher: {
-          id: 'https://research.example.org/',
-          name: 'Onderzoeksinstelling',
+          id: 'https://museum.example.org/',
+          type: 'Organization',
+          name: 'Het Museum',
         },
       },
     });

--- a/packages/api/src/objects/fetcher.ts
+++ b/packages/api/src/objects/fetcher.ts
@@ -62,6 +62,7 @@ export class HeritageObjectFetcher {
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX schema: <https://schema.org/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
       CONSTRUCT {
         ?this a ex:HeritageObject ;
@@ -165,10 +166,17 @@ export class HeritageObjectFetcher {
 
         OPTIONAL {
           ?this crm:P2_has_type ?type .
-          ?type rdfs:label ?typeName .
 
-          # For BC; remove as soon as locale-aware names are in use
-          FILTER(LANG(?typeName) = "" || LANG(?typeName) = "en")
+          # Data providers use different predicates for the type
+          OPTIONAL {
+            ?type skos:prefLabel ?typeName
+            FILTER(LANG(?typeName) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?type rdfs:label ?typeName
+            FILTER(LANG(?typeName) = "" || LANG(?typeName) = "${options.locale}")
+          }
         }
 
         ####################
@@ -200,10 +208,17 @@ export class HeritageObjectFetcher {
 
         OPTIONAL {
           ?this crm:P45_consists_of ?material .
-          ?material rdfs:label ?materialName .
 
-          # For BC; remove as soon as locale-aware names are in use
-          FILTER(LANG(?materialName) = "" || LANG(?materialName) = "en")
+          # Data providers use different predicates for the material
+          OPTIONAL {
+            ?material skos:prefLabel ?materialName
+            FILTER(LANG(?materialName) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?material rdfs:label ?materialName
+            FILTER(LANG(?materialName) = "" || LANG(?materialName) = "${options.locale}")
+          }
         }
 
         ####################

--- a/packages/api/src/objects/searcher.integration.test.ts
+++ b/packages/api/src/objects/searcher.integration.test.ts
@@ -750,6 +750,25 @@ describe('search with localized names', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Malaysia', name: 'Malaysia'}],
+        types: [
+          {
+            totalCount: 1,
+            id: 'Canvas Painting',
+            name: 'Canvas Painting',
+          },
+        ],
+        materials: [
+          {
+            totalCount: 1,
+            id: 'Canvas',
+            name: 'Canvas',
+          },
+          {
+            totalCount: 1,
+            id: 'Oilpaint',
+            name: 'Oilpaint',
+          },
+        ],
         publishers: [
           {
             totalCount: 1,
@@ -774,6 +793,25 @@ describe('search with localized names', () => {
       totalCount: 1,
       filters: {
         locations: [{totalCount: 1, id: 'Maleisië', name: 'Maleisië'}],
+        types: [
+          {
+            totalCount: 1,
+            id: 'Schildering op doek',
+            name: 'Schildering op doek',
+          },
+        ],
+        materials: [
+          {
+            totalCount: 1,
+            id: 'Canvas',
+            name: 'Canvas',
+          },
+          {
+            totalCount: 1,
+            id: 'Olieverf',
+            name: 'Olieverf',
+          },
+        ],
         publishers: [
           {
             totalCount: 1,

--- a/packages/api/src/objects/searcher.ts
+++ b/packages/api/src/objects/searcher.ts
@@ -149,13 +149,15 @@ export class HeritageObjectSearcher {
 
   private buildRequest(options: SearchOptions) {
     const locationKey = `${RawKeys.CountryCreated}_${options.locale}.keyword`;
+    const typeKey = `${RawKeys.AdditionalType}_${options.locale}.keyword`;
+    const materialKey = `${RawKeys.Material}_${options.locale}.keyword`;
     const publisherKey = `${RawKeys.Publisher}_${options.locale}.keyword`;
 
     const aggregations = {
-      types: this.buildAggregation(`${RawKeys.AdditionalType}.keyword`),
+      types: this.buildAggregation(typeKey),
       subjects: this.buildAggregation(`${RawKeys.About}.keyword`),
       locations: this.buildAggregation(locationKey),
-      materials: this.buildAggregation(`${RawKeys.Material}.keyword`),
+      materials: this.buildAggregation(materialKey),
       creators: this.buildAggregation(`${RawKeys.Creator}.keyword`),
       publishers: this.buildAggregation(publisherKey),
       dateCreatedStart: this.buildAggregation(RawKeys.YearCreatedStart),
@@ -201,10 +203,10 @@ export class HeritageObjectSearcher {
     };
 
     const queryFilters: Map<string, string[] | undefined> = new Map([
-      [`${RawKeys.AdditionalType}.keyword`, options.filters?.types],
+      [typeKey, options.filters?.types],
       [`${RawKeys.About}.keyword`, options.filters?.subjects],
       [locationKey, options.filters?.locations],
-      [`${RawKeys.Material}.keyword`, options.filters?.materials],
+      [materialKey, options.filters?.materials],
       [`${RawKeys.Creator}.keyword`, options.filters?.creators],
       [publisherKey, options.filters?.publishers],
     ]);


### PR DESCRIPTION
This PR adds locale support for the fields 'Types' and 'Materials'. This allows users to see the values of these fields in either Dutch or English.