### PR TITLE
feat: search Geonames for locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Create the file `apps/researcher/.env.production.local` and set the endpoint URL
     SENDGRID_API_KEY=
     TO_EMAIL_ADDRESS=
     FROM_EMAIL_ADDRESS=
+    GEONAMES_USERNAME=
 
 Then run:
 
@@ -115,6 +116,7 @@ Create the file `.env.production.local` in the root and set the endpoint URLs:
     SENDGRID_API_KEY=
     TO_EMAIL_ADDRESS=
     FROM_EMAIL_ADDRESS=
+    GEONAMES_USERNAME=
 
 Then run:
 

--- a/packages/api/src/enrichments/searcher-locations-geonames.integration.test.ts
+++ b/packages/api/src/enrichments/searcher-locations-geonames.integration.test.ts
@@ -1,0 +1,70 @@
+import {GeoNamesLocationSearcher} from './searcher-locations-geonames';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {env} from 'node:process';
+
+let locationSearcher: GeoNamesLocationSearcher;
+
+beforeEach(() => {
+  locationSearcher = new GeoNamesLocationSearcher({
+    endpointUrl: 'http://api.geonames.org',
+    username: env.GEONAMES_USERNAME as string,
+  });
+});
+
+describe('search', () => {
+  it('finds locations that match the query in the specified locale', async () => {
+    const result = await locationSearcher.search({
+      query: 'groning',
+      locale: 'nl',
+      limit: 3,
+    });
+
+    expect(result).toStrictEqual({
+      things: [
+        {
+          id: 'https://sws.geonames.org/5028921/',
+          name: 'Groningen',
+          description: 'Minnesota, VS',
+        },
+        {
+          id: 'https://sws.geonames.org/2904901/',
+          name: 'Heynburg',
+          description: 'Saksen-Anhalt, Duitsland',
+        },
+        {
+          id: 'https://sws.geonames.org/2755249/',
+          name: 'Provincie Groningen',
+          description: 'Groningen, Nederland',
+        },
+      ],
+    });
+  });
+
+  it('finds locations that match the query in the specified locale', async () => {
+    const result = await locationSearcher.search({
+      query: 'groning',
+      locale: 'en',
+      limit: 3,
+    });
+
+    expect(result).toStrictEqual({
+      things: [
+        {
+          id: 'https://sws.geonames.org/5028921/',
+          name: 'Groningen',
+          description: 'Minnesota, United States',
+        },
+        {
+          id: 'https://sws.geonames.org/2904901/',
+          name: 'Heynburg',
+          description: 'Saxony-Anhalt, Germany',
+        },
+        {
+          id: 'https://sws.geonames.org/2755249/',
+          name: 'Provincie Groningen',
+          description: 'Groningen, The Netherlands',
+        },
+      ],
+    });
+  });
+});

--- a/packages/api/src/enrichments/searcher-locations-geonames.ts
+++ b/packages/api/src/enrichments/searcher-locations-geonames.ts
@@ -1,0 +1,111 @@
+import {searchOptionsSchema, SearchOptions, SearchResult} from './definitions';
+import {Thing} from '../definitions';
+import {z} from 'zod';
+
+const constructorOptionsSchema = z.object({
+  endpointUrl: z.string(),
+  username: z.string(),
+});
+
+export type GeoNamesLocationSearcherConstructorOptions = z.infer<
+  typeof constructorOptionsSchema
+>;
+
+const rawSearchResponseSchema = z.object({
+  geonames: z.array(
+    z.object({
+      geonameId: z.number(),
+      toponymName: z.string(),
+      countryName: z.string(),
+      adminName1: z.string(),
+    })
+  ),
+});
+
+type RawSearchResponse = z.infer<typeof rawSearchResponseSchema>;
+
+export class GeoNamesLocationSearcher {
+  private readonly endpointUrl: string;
+  private readonly username: string;
+
+  constructor(options: GeoNamesLocationSearcherConstructorOptions) {
+    const opts = constructorOptionsSchema.parse(options);
+
+    this.endpointUrl = opts.endpointUrl;
+    this.username = opts.username;
+  }
+
+  private buildRequest(options: SearchOptions) {
+    const searchParams: [string, string][] = [
+      ['username', this.username],
+      ['name_startsWith', options.query],
+      ['maxRows', options.limit!.toString()],
+      ['lang', options.locale!],
+      ['featureCode', 'ADM1'], // Country, state, region, ...
+      ['featureCode', 'PPL'], // City, village, ...
+      ['type', 'json'],
+    ];
+
+    const urlSearchParams = new URLSearchParams(searchParams);
+    const url = `${this.endpointUrl}/search?${urlSearchParams.toString()}`;
+
+    return url;
+  }
+
+  async makeRequest(url: string) {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to retrieve information: ${response.statusText} (${response.status})`
+      );
+    }
+
+    return response.json();
+  }
+
+  private buildResult(rawSearchResponse: RawSearchResponse) {
+    const {geonames} = rawSearchResponse;
+
+    const things = geonames.map(rawPlace => {
+      const descriptionParts: string[] = [];
+      if (rawPlace.adminName1) {
+        descriptionParts.push(rawPlace.adminName1);
+      }
+      if (rawPlace.countryName) {
+        descriptionParts.push(rawPlace.countryName);
+      }
+
+      const thing: Thing = {
+        id: `https://sws.geonames.org/${rawPlace.geonameId}/`,
+        name: rawPlace.toponymName,
+        description:
+          descriptionParts.length > 0 ? descriptionParts.join(', ') : undefined,
+      };
+
+      return thing;
+    });
+
+    things.sort((a, b) => {
+      return a.name && b.name ? a.name.localeCompare(b.name) : 0;
+    });
+
+    const searchResult: SearchResult = {
+      things,
+    };
+
+    return searchResult;
+  }
+
+  async search(options: SearchOptions) {
+    const opts = searchOptionsSchema.parse(options);
+
+    const url = this.buildRequest(opts);
+
+    const rawResponse = await this.makeRequest(url);
+    const searchResponse = rawSearchResponseSchema.parse(rawResponse);
+    const searchResult = this.buildResult(searchResponse);
+
+    return searchResult;
+  }
+}


### PR DESCRIPTION
This PR adds support for searching for locations in GeoNames. This functionality can be used in the frontend, in the form for adding new provenance information (field "Location"): https://gui-prototype.colonialcollections.nl/object.html

The GeoNames API requires a `username` for making authenticated requests. This value can be found in [Vercel](https://vercel.com/colonial-heritage/colonial-collections-researcher/settings/environment-variables). [There are usage limits in place, though](https://www.geonames.org/export/):

> 10'000 [credits](https://www.geonames.org/export/credits.html) daily limit per application (identified by the parameter 'username'), the hourly limit is 1000 [credit](https://www.geonames.org/export/credits.html)s. A credit is a web service request hit for most services. An [exception](https://www.geonames.org/export/webservice-exception.html) is thrown when the limit is exceeded.

The current `username` is a free account for testing. We can upgrade to a paid account if we run out of credits.