### PR TITLE
Run the end to end tests one by one

### DIFF
--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -9,6 +9,11 @@ on:
       - ".github/workflows/end-to-end-testing-researcher.yml"
       - "packages/**"
 
+concurrency:
+  # Clerk blocks the test user, if multiple tests are running at the same time
+  # Therefore, we limit the concurrency to 1
+  group: 'end-to-end-tests-with-login'
+
 jobs:
   run-end-to-end-tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Yesterday evening Dependabot created multiple pull request at once. This resulted in multiple end-to-end tests all running the same time. Clerk does not like this, and blocks the test user for the preview domains. 

To prevent this from happening run the tests one-by-one so Clerk does not block the test user.