### PR TITLE
feat: create persistent IRI

### DIFF
--- a/packages/iris/src/create-persistent-iri.test.ts
+++ b/packages/iris/src/create-persistent-iri.test.ts
@@ -1,0 +1,10 @@
+import {createPersistentIri} from './create-persistent-iri';
+import {describe, expect, it} from '@jest/globals';
+
+describe('createPersistentIri', () => {
+  it('returns a persistent IRI', () => {
+    expect(createPersistentIri()).toMatch(
+      /^https:\/\/n2t\.net\/ark:\/27023\/.{32}$/
+    );
+  });
+});

--- a/packages/iris/src/create-persistent-iri.ts
+++ b/packages/iris/src/create-persistent-iri.ts
@@ -1,0 +1,11 @@
+import crypto from 'node:crypto';
+
+// ARK with the NAAN identifier of the Colonial Collections Consortium
+const IRI_PREFIX = 'https://n2t.net/ark:/27023/';
+
+export function createPersistentIri() {
+  const uuid = crypto.randomUUID();
+  const md5 = crypto.createHash('md5').update(uuid).digest('hex');
+
+  return `${IRI_PREFIX}${md5}`;
+}


### PR DESCRIPTION
This PR adds a little helper function for creating persistent IRIs. We can use this helper e.g. when creating communities and adding the IRIs to the metadata of the communities in Clerk.