### PR TITLE
feat: store and retrieve community of creator from nanopublication

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
@@ -13,7 +13,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import type {
-  Agent,
+  Actor,
   HeritageObjectEnrichmentType,
 } from '@colonial-collections/enricher';
 import ISO6391, {LanguageCode} from 'iso-639-1';
@@ -93,7 +93,7 @@ interface MetadataEntryProps {
   isCurrentPublisher?: boolean;
   dateCreated?: Date;
   citation?: string;
-  creator?: Agent;
+  creator?: Actor;
   languageCode?: LanguageCode;
   translationKey: string;
   children?: ReactNode;

--- a/packages/enricher/src/creator.integration.test.ts
+++ b/packages/enricher/src/creator.integration.test.ts
@@ -29,6 +29,10 @@ describe('addText', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/community',
+            name: 'Community',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -73,6 +77,10 @@ describe('addProvenanceEvent', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/community',
+            name: 'Community',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },

--- a/packages/enricher/src/definitions.ts
+++ b/packages/enricher/src/definitions.ts
@@ -20,6 +20,12 @@ export const basicEnrichmentBeingCreatedSchema = z.object({
     creator: z.object({
       id: z.string().url(),
       name: z.string(),
+      isPartOf: z
+        .object({
+          id: z.string().url(),
+          name: z.string(),
+        })
+        .optional(),
     }),
     license: z.string().url(),
   }),
@@ -32,7 +38,9 @@ export type Thing = {
 
 export type Term = Thing;
 export type Place = Thing;
-export type Agent = Thing;
+export type Actor = Thing & {
+  isPartOf?: Actor; // E.g. a group such as a community
+};
 
 export type TimeSpan = {
   id: string;
@@ -41,7 +49,7 @@ export type TimeSpan = {
 };
 
 export type PubInfo = {
-  creator: Agent;
+  creator: Actor;
   license: string;
   dateCreated: Date;
 };

--- a/packages/enricher/src/objects/fetcher.integration.test.ts
+++ b/packages/enricher/src/objects/fetcher.integration.test.ts
@@ -34,6 +34,10 @@ beforeAll(async () => {
       creator: {
         id: 'http://example.com/person1',
         name: 'Person 1',
+        isPartOf: {
+          id: 'http://example.com/group1',
+          name: 'Group 1',
+        },
       },
       license: 'https://creativecommons.org/licenses/by/4.0/',
     },
@@ -48,6 +52,10 @@ beforeAll(async () => {
       creator: {
         id: 'http://example.com/person2',
         name: 'Person 2',
+        isPartOf: {
+          id: 'http://example.com/group2',
+          name: 'Group 2',
+        },
       },
       license: 'https://creativecommons.org/licenses/by/4.0/',
     },
@@ -85,6 +93,10 @@ describe('getById', () => {
           creator: {
             id: 'http://example.com/person1',
             name: 'Person 1',
+            isPartOf: {
+              id: 'http://example.com/group1',
+              name: 'Group 1',
+            },
           },
           license: 'https://creativecommons.org/licenses/by/4.0/',
           dateCreated: expect.any(Date),
@@ -100,6 +112,10 @@ describe('getById', () => {
           creator: {
             id: 'http://example.com/person2',
             name: 'Person 2',
+            isPartOf: {
+              id: 'http://example.com/group2',
+              name: 'Group 2',
+            },
           },
           license: 'https://creativecommons.org/licenses/by/4.0/',
           dateCreated: expect.any(Date),

--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -57,7 +57,11 @@ export class HeritageObjectEnrichmentFetcher {
           ex:dateCreated ?dateCreated .
 
         ?creator a ex:Actor ;
-          ex:name ?creatorName .
+          ex:name ?creatorName ;
+          ex:isPartOf ?group .
+
+        ?group a ex:Actor ;
+          ex:name ?groupName .
       }
       WHERE {
         BIND(<${iri}> AS ?source)
@@ -79,6 +83,11 @@ export class HeritageObjectEnrichmentFetcher {
             dcterms:license ?license .
 
           ?creator rdfs:label ?creatorName .
+
+          OPTIONAL {
+            ?creator dcterms:isPartOf ?group .
+            ?group rdfs:label ?groupName
+          }
 
           ?np a ?additionalType
           FILTER(?additionalType != cc:Nanopub)

--- a/packages/enricher/src/objects/rdf-helpers.test.ts
+++ b/packages/enricher/src/objects/rdf-helpers.test.ts
@@ -24,23 +24,26 @@ beforeAll(async () => {
     ex:basicEnrichment a ex:HeritageObjectEnrichment ;
       ex:additionalType <${ontologyUrl}Material${ontologyVersionIdentifier}> ;
       ex:isPartOf <https://example.com/object> ;
-      ex:creator ex:creator1 ;
+      ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date .
 
     ex:fullEnrichment a ex:HeritageObjectEnrichment ;
       ex:additionalType <${ontologyUrl}Material${ontologyVersionIdentifier}> ;
       ex:isPartOf <https://example.com/object> ;
-      ex:creator ex:creator1 ;
+      ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date ;
       ex:citation "Citation" ;
       ex:description "Description" ;
       ex:inLanguage "en" .
 
-    ex:creator1 a ex:Actor ;
-      ex:id <https://example.com/creator> ;
-      ex:name "Creator Name" .
+    ex:myPerson a ex:Actor ;
+      ex:name "Person" ;
+      ex:isPartOf ex:myGroup .
+
+    ex:myGroup a ex:Actor ;
+      ex:name "Group" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -64,8 +67,12 @@ describe('toHeritageObjectEnrichment', () => {
       about: 'https://example.com/object',
       pubInfo: {
         creator: {
-          id: 'https://example.org/creator1',
-          name: 'Creator Name',
+          id: 'https://example.org/myPerson',
+          name: 'Person',
+          isPartOf: {
+            id: 'https://example.org/myGroup',
+            name: 'Group',
+          },
         },
         license: 'https://example.com/license',
         dateCreated: new Date('2023-01-01T00:00:00.000Z'),
@@ -82,8 +89,12 @@ describe('toHeritageObjectEnrichment', () => {
       about: 'https://example.com/object',
       pubInfo: {
         creator: {
-          id: 'https://example.org/creator1',
-          name: 'Creator Name',
+          id: 'https://example.org/myPerson',
+          name: 'Person',
+          isPartOf: {
+            id: 'https://example.org/myGroup',
+            name: 'Group',
+          },
         },
         license: 'https://example.com/license',
         dateCreated: new Date('2023-01-01T00:00:00.000Z'),

--- a/packages/enricher/src/objects/rdf-helpers.ts
+++ b/packages/enricher/src/objects/rdf-helpers.ts
@@ -1,9 +1,8 @@
-import {Agent} from '../definitions';
 import {fromClassToType} from './helpers';
 import {HeritageObjectEnrichment} from './definitions';
 import {
+  createActors,
   createDates,
-  createThings,
   getPropertyValue,
   onlyOne,
 } from '../rdf-helpers';
@@ -13,7 +12,7 @@ import type {Resource} from 'rdf-object';
 export function toHeritageObjectEnrichment(rawEnrichment: Resource) {
   const additionalType = getPropertyValue(rawEnrichment, 'ex:additionalType');
   const about = getPropertyValue(rawEnrichment, 'ex:isPartOf')!;
-  const creator = onlyOne(createThings<Agent>(rawEnrichment, 'ex:creator'))!;
+  const creator = onlyOne(createActors(rawEnrichment, 'ex:creator'))!;
   const license = getPropertyValue(rawEnrichment, 'ex:license')!;
   const dateCreated = onlyOne(createDates(rawEnrichment, 'ex:dateCreated'))!;
   const citation = getPropertyValue(rawEnrichment, 'ex:citation');

--- a/packages/enricher/src/objects/storer.integration.test.ts
+++ b/packages/enricher/src/objects/storer.integration.test.ts
@@ -28,6 +28,10 @@ describe('add', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/community',
+            name: 'Community',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },

--- a/packages/enricher/src/objects/storer.ts
+++ b/packages/enricher/src/objects/storer.ts
@@ -110,13 +110,35 @@ export class HeritageObjectEnrichmentStorer {
     // The server automatically adds 'dcterms:creator'.
     // A creator can change his or her name later on, but the name at the time of
     // creation is preserved.
+    const creatorNode = DF.namedNode(opts.pubInfo.creator.id);
+
     publicationStore.addQuad(
       DF.quad(
-        DF.namedNode(opts.pubInfo.creator.id),
+        creatorNode,
         DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
         DF.literal(opts.pubInfo.creator.name)
       )
     );
+
+    if (opts.pubInfo.creator.isPartOf !== undefined) {
+      const groupNode = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
+
+      publicationStore.addQuad(
+        DF.quad(
+          creatorNode,
+          DF.namedNode('http://purl.org/dc/terms/isPartOf'),
+          groupNode
+        )
+      );
+
+      publicationStore.addQuad(
+        DF.quad(
+          groupNode,
+          DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+          DF.literal(opts.pubInfo.creator.isPartOf.name)
+        )
+      );
+    }
 
     assertionStore.addQuad(
       DF.quad(

--- a/packages/enricher/src/provenance-events/definitions.ts
+++ b/packages/enricher/src/provenance-events/definitions.ts
@@ -1,6 +1,6 @@
 import {
   basicEnrichmentBeingCreatedSchema,
-  Agent,
+  Actor,
   Place,
   PubInfo,
   Term,
@@ -72,8 +72,8 @@ export type ProvenanceEventEnrichment = {
   type: ProvenanceEventType;
   additionalTypes?: Term[];
   date?: TimeSpan;
-  transferredFrom?: Agent;
-  transferredTo?: Agent;
+  transferredFrom?: Actor;
+  transferredTo?: Actor;
   location?: Place;
   description?: string;
   citation?: string;

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -52,8 +52,12 @@ beforeAll(async () => {
     about: resourceId,
     pubInfo: {
       creator: {
-        id: 'http://example.com/person',
-        name: 'Person',
+        id: 'http://example.com/person1',
+        name: 'Person 1',
+        isPartOf: {
+          id: 'http://example.com/group1',
+          name: 'Group 1',
+        },
       },
       license: 'https://creativecommons.org/licenses/by/4.0/',
     },
@@ -87,8 +91,12 @@ beforeAll(async () => {
     about: resourceId,
     pubInfo: {
       creator: {
-        id: 'http://example.com/person',
-        name: 'Person',
+        id: 'http://example.com/person2',
+        name: 'Person 2',
+        isPartOf: {
+          id: 'http://example.com/group2',
+          name: 'Group 2',
+        },
       },
       license: 'https://creativecommons.org/licenses/by/4.0/',
     },
@@ -122,8 +130,12 @@ describe('getById', () => {
           about: resourceId,
           pubInfo: {
             creator: {
-              id: 'http://example.com/person',
-              name: 'Person',
+              id: 'http://example.com/person1',
+              name: 'Person 1',
+              isPartOf: {
+                id: 'http://example.com/group1',
+                name: 'Group 1',
+              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),
@@ -162,8 +174,12 @@ describe('getById', () => {
           about: resourceId,
           pubInfo: {
             creator: {
-              id: 'http://example.com/person',
-              name: 'Person',
+              id: 'http://example.com/person2',
+              name: 'Person 2',
+              isPartOf: {
+                id: 'http://example.com/group2',
+                name: 'Group 2',
+              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -73,7 +73,11 @@ export class ProvenanceEventEnrichmentFetcher {
           ex:endDate ?endOfTheEnd .
 
         ?creator a ex:Actor ;
-          ex:name ?creatorName .
+          ex:name ?creatorName ;
+          ex:isPartOf ?group .
+
+        ?group a ex:Actor ;
+          ex:name ?groupName .
       }
       WHERE {
         BIND(<${iri}> AS ?source)
@@ -95,6 +99,11 @@ export class ProvenanceEventEnrichmentFetcher {
             dcterms:license ?license .
 
           ?creator rdfs:label ?creatorName .
+
+          OPTIONAL {
+            ?creator dcterms:isPartOf ?group .
+            ?group rdfs:label ?groupName
+          }
         }
 
         graph ?assertion {

--- a/packages/enricher/src/provenance-events/rdf-helpers.test.ts
+++ b/packages/enricher/src/provenance-events/rdf-helpers.test.ts
@@ -22,46 +22,46 @@ beforeAll(async () => {
 
     ex:basicEnrichment a ex:TransferOfCustody ;
       ex:about <https://example.com/object> ;
-      ex:creator ex:creator1 ;
+      ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date .
 
     ex:fullEnrichment a ex:Acquisition ;
       ex:about <https://example.com/object> ;
-      ex:creator ex:creator1 ;
+      ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date ;
-      ex:additionalType ex:additionalType1 ;
+      ex:additionalType ex:myAdditionalType ;
       ex:citation "Citation" ;
       ex:description "Description" ;
       ex:inLanguage "en" ;
-      ex:date ex:timeSpan1 ;
-      ex:transferredFrom ex:transferredFrom1 ;
-      ex:transferredTo ex:transferredTo1 ;
-      ex:location ex:location1 .
+      ex:date ex:myTimeSpan ;
+      ex:transferredFrom ex:myTransferredFrom ;
+      ex:transferredTo ex:myTransferredTo ;
+      ex:location ex:myLocation .
 
-    ex:creator1 a ex:Actor ;
-      ex:id <https://example.com/creator> ;
-      ex:name "Creator Name" .
+    ex:myPerson a ex:Actor ;
+      ex:name "Person" ;
+      ex:isPartOf ex:myGroup .
 
-    ex:additionalType1 a ex:DefinedTerm ;
-      ex:name "Term Name" .
+    ex:myGroup a ex:Actor ;
+      ex:name "Group" .
 
-    ex:timeSpan1 a ex:TimeSpan ;
+    ex:myAdditionalType a ex:DefinedTerm ;
+      ex:name "Term" .
+
+    ex:myTimeSpan a ex:TimeSpan ;
       ex:startDate "1889"^^xsd:gYear ;
       ex:endDate "1900"^^xsd:gYear .
 
-    ex:transferredFrom1 a ex:Actor ;
-      ex:id <https://example.com/transferredFrom> ;
-      ex:name "Transferred From Name" .
+    ex:myTransferredFrom a ex:Actor ;
+      ex:name "Transferred From" .
 
-    ex:transferredTo1 a ex:Actor ;
-      ex:id <https://example.com/transferredTo> ;
-      ex:name "Transferred To Name" .
+    ex:myTransferredTo a ex:Actor ;
+      ex:name "Transferred To" .
 
-    ex:location1 a ex:Place ;
-      ex:id <https://example.com/location> ;
-      ex:name "Location Name" .
+    ex:myLocation a ex:Place ;
+      ex:name "Location" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -85,8 +85,12 @@ describe('toProvenanceEventEnrichment', () => {
       about: 'https://example.com/object',
       pubInfo: {
         creator: {
-          id: 'https://example.org/creator1',
-          name: 'Creator Name',
+          id: 'https://example.org/myPerson',
+          name: 'Person',
+          isPartOf: {
+            id: 'https://example.org/myGroup',
+            name: 'Group',
+          },
         },
         license: 'https://example.com/license',
         dateCreated: new Date('2023-01-01T00:00:00.000Z'),
@@ -103,37 +107,41 @@ describe('toProvenanceEventEnrichment', () => {
       about: 'https://example.com/object',
       pubInfo: {
         creator: {
-          id: 'https://example.org/creator1',
-          name: 'Creator Name',
+          id: 'https://example.org/myPerson',
+          name: 'Person',
+          isPartOf: {
+            id: 'https://example.org/myGroup',
+            name: 'Group',
+          },
         },
         license: 'https://example.com/license',
         dateCreated: new Date('2023-01-01T00:00:00.000Z'),
       },
       additionalTypes: [
         {
-          id: 'https://example.org/additionalType1',
-          name: 'Term Name',
+          id: 'https://example.org/myAdditionalType',
+          name: 'Term',
         },
       ],
       citation: 'Citation',
       description: 'Description',
       inLanguage: 'en',
       date: {
-        id: 'https://example.org/timeSpan1',
+        id: 'https://example.org/myTimeSpan',
         startDate: new Date('1889-01-01T00:00:00.000Z'),
         endDate: new Date('1900-12-31T23:59:59.999Z'),
       },
       transferredFrom: {
-        id: 'https://example.org/transferredFrom1',
-        name: 'Transferred From Name',
+        id: 'https://example.org/myTransferredFrom',
+        name: 'Transferred From',
       },
       transferredTo: {
-        id: 'https://example.org/transferredTo1',
-        name: 'Transferred To Name',
+        id: 'https://example.org/myTransferredTo',
+        name: 'Transferred To',
       },
       location: {
-        id: 'https://example.org/location1',
-        name: 'Location Name',
+        id: 'https://example.org/myLocation',
+        name: 'Location',
       },
     });
   });

--- a/packages/enricher/src/provenance-events/rdf-helpers.ts
+++ b/packages/enricher/src/provenance-events/rdf-helpers.ts
@@ -1,6 +1,7 @@
-import {Agent, Place, Term} from '../definitions';
+import {Place, Term} from '../definitions';
 import {ProvenanceEventEnrichment, ProvenanceEventType} from './definitions';
 import {
+  createActors,
   createDates,
   createThings,
   createTimeSpans,
@@ -19,7 +20,7 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
       : ProvenanceEventType.TransferOfCustody;
 
   const about = getPropertyValue(rawEnrichment, 'ex:about')!;
-  const creator = onlyOne(createThings<Agent>(rawEnrichment, 'ex:creator'))!;
+  const creator = onlyOne(createActors(rawEnrichment, 'ex:creator'))!;
   const license = getPropertyValue(rawEnrichment, 'ex:license')!;
   const dateCreated = onlyOne(createDates(rawEnrichment, 'ex:dateCreated'))!;
   const citation = getPropertyValue(rawEnrichment, 'ex:citation');
@@ -27,10 +28,10 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
   const inLanguage = getPropertyValue(rawEnrichment, 'ex:inLanguage');
   const location = onlyOne(createThings<Place>(rawEnrichment, 'ex:location'));
   const transferredFrom = onlyOne(
-    createThings<Agent>(rawEnrichment, 'ex:transferredFrom')
+    createActors(rawEnrichment, 'ex:transferredFrom')
   );
   const transferredTo = onlyOne(
-    createThings<Agent>(rawEnrichment, 'ex:transferredTo')
+    createActors(rawEnrichment, 'ex:transferredTo')
   );
   const date = onlyOne(createTimeSpans(rawEnrichment, 'ex:date'));
   const additionalTypes = createThings<Term>(

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -46,6 +46,10 @@ describe('add', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/community',
+            name: 'Community',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -90,6 +94,10 @@ describe('add', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/community',
+            name: 'Community',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },

--- a/packages/enricher/src/provenance-events/storer.ts
+++ b/packages/enricher/src/provenance-events/storer.ts
@@ -117,13 +117,35 @@ export class ProvenanceEventEnrichmentStorer {
     // The server automatically adds 'dcterms:creator'.
     // A creator can change his or her name later on, but the name at the time of
     // creation is preserved.
+    const creatorNode = DF.namedNode(opts.pubInfo.creator.id);
+
     publicationStore.addQuad(
       DF.quad(
-        DF.namedNode(opts.pubInfo.creator.id),
+        creatorNode,
         DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
         DF.literal(opts.pubInfo.creator.name)
       )
     );
+
+    if (opts.pubInfo.creator.isPartOf !== undefined) {
+      const groupNode = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
+
+      publicationStore.addQuad(
+        DF.quad(
+          creatorNode,
+          DF.namedNode('http://purl.org/dc/terms/isPartOf'),
+          groupNode
+        )
+      );
+
+      publicationStore.addQuad(
+        DF.quad(
+          groupNode,
+          DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+          DF.literal(opts.pubInfo.creator.isPartOf.name)
+        )
+      );
+    }
 
     // Type of the provenance event
     const type = isAcquisition ? 'E8_Acquisition' : 'E10_Transfer_of_Custody';
@@ -172,7 +194,7 @@ export class ProvenanceEventEnrichmentStorer {
       )
     );
 
-    // Constituent who owned or kept the object
+    // Actor who owned or kept the object
     if (opts.transferredFrom !== undefined) {
       const transferredFromNode = DF.namedNode(opts.transferredFrom.id);
 
@@ -180,7 +202,7 @@ export class ProvenanceEventEnrichmentStorer {
         ? 'P23_transferred_title_from'
         : 'P28_custody_surrendered_by';
 
-      // An IRI from a constituent source, e.g. Wikidata
+      // An IRI from an actor source, e.g. Wikidata
       assertionStore.addQuad(
         DF.quad(
           enrichmentId,
@@ -191,7 +213,7 @@ export class ProvenanceEventEnrichmentStorer {
         )
       );
 
-      // The name of the constituent
+      // The name of the actor
       assertionStore.addQuad(
         DF.quad(
           transferredFromNode,
@@ -201,7 +223,7 @@ export class ProvenanceEventEnrichmentStorer {
       );
     }
 
-    // Constituent who received the object
+    // Actor who received the object
     if (opts.transferredTo !== undefined) {
       const transferredToNode = DF.namedNode(opts.transferredTo.id);
 
@@ -209,7 +231,7 @@ export class ProvenanceEventEnrichmentStorer {
         ? 'P22_transferred_title_to'
         : 'P29_custody_received_by';
 
-      // An IRI from a constituent source, e.g. Wikidata
+      // An IRI from an actor source, e.g. Wikidata
       assertionStore.addQuad(
         DF.quad(
           enrichmentId,
@@ -220,7 +242,7 @@ export class ProvenanceEventEnrichmentStorer {
         )
       );
 
-      // The name of the constituent
+      // The name of the actor
       assertionStore.addQuad(
         DF.quad(
           transferredToNode,

--- a/packages/enricher/src/rdf-helpers.test.ts
+++ b/packages/enricher/src/rdf-helpers.test.ts
@@ -130,7 +130,7 @@ describe('createThings', () => {
     expect(things).toBeUndefined();
   });
 
-  it('returns things if properties exist', () => {
+  it('returns things', () => {
     const things = createThings(enrichmentResource, 'ex:type');
 
     expect(things).toStrictEqual([
@@ -147,7 +147,7 @@ describe('createDates', () => {
     expect(things).toBeUndefined();
   });
 
-  it('returns dates if properties exist', () => {
+  it('returns dates', () => {
     const dates = createDates(enrichmentResource, 'ex:dateCreated');
 
     expect(dates).toStrictEqual([new Date('2023-01-01')]);
@@ -161,7 +161,7 @@ describe('createTimeSpans', () => {
     expect(timeSpans).toBeUndefined();
   });
 
-  it('returns time spans if properties exist', () => {
+  it('returns time spans', () => {
     const timeSpans = createTimeSpans(enrichmentResource, 'ex:timeSpan');
 
     expect(timeSpans).toStrictEqual([
@@ -196,7 +196,7 @@ describe('createActors', () => {
     expect(actors).toBeUndefined();
   });
 
-  it('returns actors if properties exist', () => {
+  it('returns actors', () => {
     const actors = createActors(enrichmentResource, 'ex:creator');
 
     expect(actors).toStrictEqual([

--- a/packages/enricher/src/rdf-helpers.test.ts
+++ b/packages/enricher/src/rdf-helpers.test.ts
@@ -1,7 +1,9 @@
 import {
+  createActors,
   createDates,
   createThings,
   createTimeSpans,
+  getProperty,
   getPropertyValue,
   onlyOne,
 } from './rdf-helpers';
@@ -26,30 +28,43 @@ beforeAll(async () => {
 
     ex:enrichment1 a ex:Enrichment ;
       ex:name "Name" ;
-      ex:type ex:type1, ex:type2 ;
+      ex:type ex:myType1, ex:myType2 ;
       ex:dateCreated "2023-01-01"^^xsd:date ;
-      ex:timeSpan ex:timeSpan1, ex:timeSpan2, ex:timeSpan3, ex:timeSpan4 .
+      ex:timeSpan ex:myTimeSpan1, ex:myTimeSpan2, ex:myTimeSpan3, ex:myTimeSpan4 ;
+      ex:creator ex:myPerson1, ex:myPerson2 .
 
-    ex:type1 a ex:DefinedTerm ;
+    ex:myType1 a ex:DefinedTerm ;
       ex:name "Term" .
 
-    ex:type2 a ex:DefinedTerm .
+    ex:myType2 a ex:DefinedTerm .
 
-    ex:timeSpan1 a ex:TimeSpan ;
+    ex:myTimeSpan1 a ex:TimeSpan ;
       ex:startDate "-1900"^^xsd:gYear ;
       ex:endDate "-1889"^^xsd:gYear .
 
     # No end date
-    ex:timeSpan2 a ex:TimeSpan ;
+    ex:myTimeSpan2 a ex:TimeSpan ;
       ex:startDate "1889"^^xsd:gYear .
 
     # No start date
-    ex:timeSpan3 a ex:TimeSpan ;
+    ex:myTimeSpan3 a ex:TimeSpan ;
       ex:endDate "1900"^^xsd:gYear .
 
     # Invalid date
-    ex:timeSpan4 a ex:TimeSpan ;
+    ex:myTimeSpan4 a ex:TimeSpan ;
       ex:startDate "badValue" .
+
+    # Is not a part of another actor
+    ex:myPerson1 a ex:Actor ;
+      ex:name "Person 1" .
+
+    # Is a part of another actor (e.g. a community)
+    ex:myPerson2 a ex:Actor ;
+      ex:name "Person 2" ;
+      ex:isPartOf ex:myGroup .
+
+    ex:myGroup a ex:Actor ;
+      ex:name "Group" .
   `;
 
   const stringStream = streamifyString(triples);
@@ -58,6 +73,20 @@ beforeAll(async () => {
   await loader.import(streamParser);
 
   enrichmentResource = loader.resources['https://example.org/enrichment1'];
+});
+
+describe('getProperty', () => {
+  it('returns undefined if property does not exist', () => {
+    const property = getProperty(enrichmentResource, 'ex:unknown');
+
+    expect(property).toBeUndefined();
+  });
+
+  it('returns property if it exists', () => {
+    const property = getProperty(enrichmentResource, 'ex:name');
+
+    expect(property).toBeInstanceOf(Resource);
+  });
 });
 
 describe('getPropertyValue', () => {
@@ -105,8 +134,8 @@ describe('createThings', () => {
     const things = createThings(enrichmentResource, 'ex:type');
 
     expect(things).toStrictEqual([
-      {id: 'https://example.org/type1', name: 'Term'},
-      {id: 'https://example.org/type2', name: undefined},
+      {id: 'https://example.org/myType1', name: 'Term'},
+      {id: 'https://example.org/myType2', name: undefined},
     ]);
   });
 });
@@ -125,7 +154,7 @@ describe('createDates', () => {
   });
 });
 
-describe('createTimeSpan', () => {
+describe('createTimeSpans', () => {
   it('returns undefined if properties do not exist', () => {
     const timeSpans = createTimeSpans(enrichmentResource, 'ex:unknown');
 
@@ -137,24 +166,51 @@ describe('createTimeSpan', () => {
 
     expect(timeSpans).toStrictEqual([
       {
-        id: 'https://example.org/timeSpan1',
+        id: 'https://example.org/myTimeSpan1',
         startDate: new Date('-001900-01-01T00:00:00.000Z'),
         endDate: new Date('-001889-12-31T23:59:59.999Z'),
       },
       {
-        id: 'https://example.org/timeSpan2',
+        id: 'https://example.org/myTimeSpan2',
         startDate: new Date('1889-01-01T00:00:00.000Z'),
         endDate: undefined,
       },
       {
-        id: 'https://example.org/timeSpan3',
+        id: 'https://example.org/myTimeSpan3',
         startDate: undefined,
         endDate: new Date('1900-12-31T23:59:59.999Z'),
       },
       {
-        id: 'https://example.org/timeSpan4',
+        id: 'https://example.org/myTimeSpan4',
         startDate: undefined,
         endDate: undefined,
+      },
+    ]);
+  });
+});
+
+describe('createActors', () => {
+  it('returns undefined if properties do not exist', () => {
+    const actors = createActors(enrichmentResource, 'ex:unknown');
+
+    expect(actors).toBeUndefined();
+  });
+
+  it('returns actors if properties exist', () => {
+    const actors = createActors(enrichmentResource, 'ex:creator');
+
+    expect(actors).toStrictEqual([
+      {
+        id: 'https://example.org/myPerson1',
+        name: 'Person 1',
+      },
+      {
+        id: 'https://example.org/myPerson2',
+        name: 'Person 2',
+        isPartOf: {
+          id: 'https://example.org/myGroup',
+          name: 'Group',
+        },
       },
     ]);
   });


### PR DESCRIPTION
This PR expands the `enricher` package: in addition to storing and retrieving the `creator` of an enrichment, it's now possible to also store and retrieve the community to which the creator belongs [1].

Some notes:
1. The data model used for storing the community information in the backing nanopublication could change - Kinsuk is still looking into this. This shouldn't impact the frontend, though
2. The PR also harmonizes some names: the `enricher` package referred to 'actor', 'agent' and 'constituent' - different names for essentially the same thing. It now uses 'actor' in all places
3. The PR also improves some tests
4. The code of the package could become more DRY. I'll do this in a future PR, if the functionality of this PR is stable

[1] For storing the community, see e.g. https://github.com/colonial-heritage/colonial-collections/blob/feat-enricher-community/packages/enricher/src/creator.integration.test.ts#L32-L34. For retrieving the community, see e.g. https://github.com/colonial-heritage/colonial-collections/blob/feat-enricher-community/packages/enricher/src/objects/fetcher.integration.test.ts#L96-L98