### PR TITLE
Add iri to community metadata on creation

### DIFF
--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -29,6 +29,7 @@
     "@colonial-collections/database": "*",
     "@colonial-collections/email-sender": "*",
     "@colonial-collections/enricher": "*",
+    "@colonial-collections/iris": "*",
     "@colonial-collections/list-store": "*",
     "@colonial-collections/ui": "*",
     "@headlessui/react": "1.7.18",

--- a/apps/researcher/src/app/[locale]/communities/[slug]/created/page.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/created/page.ts
@@ -1,0 +1,26 @@
+import {redirect} from 'next/navigation';
+import {revalidatePath} from 'next/cache';
+import {createPersistentIri} from '@colonial-collections/iris';
+import {getCommunityBySlug, addUriToCommunity} from '@/lib/community/actions';
+
+interface Props {
+  params: {
+    slug: string;
+  };
+}
+
+export default async function CommunityCreated({params}: Props) {
+  // Revalidate the communities page to show the new community.
+  revalidatePath('/[locale]/communities', 'page');
+
+  const community = await getCommunityBySlug(params.slug);
+
+  const iri = createPersistentIri();
+
+  await addUriToCommunity({
+    id: community.id,
+    iri,
+  });
+
+  redirect(`/communities/${params.slug}`);
+}

--- a/apps/researcher/src/app/[locale]/communities/[slug]/created/page.ts
+++ b/apps/researcher/src/app/[locale]/communities/[slug]/created/page.ts
@@ -1,7 +1,7 @@
 import {redirect} from 'next/navigation';
 import {revalidatePath} from 'next/cache';
 import {createPersistentIri} from '@colonial-collections/iris';
-import {getCommunityBySlug, addUriToCommunity} from '@/lib/community/actions';
+import {getCommunityBySlug, addIriToCommunity} from '@/lib/community/actions';
 
 interface Props {
   params: {
@@ -17,7 +17,7 @@ export default async function CommunityCreated({params}: Props) {
 
   const iri = createPersistentIri();
 
-  await addUriToCommunity({
+  await addIriToCommunity({
     id: community.id,
     iri,
   });

--- a/apps/researcher/src/app/[locale]/communities/buttons.tsx
+++ b/apps/researcher/src/app/[locale]/communities/buttons.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import {encodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 import {useCreateCommunity} from '@/lib/community/hooks';
 import {useTranslations} from 'next-intl';
 
@@ -13,12 +12,11 @@ export function AddCommunityButton() {
       data-testid="add-community"
       onClick={() =>
         openCreateCommunity({
+          // Skip the invitation screen, this is needed because the invitation screen can be closed.
+          // If the user closes the invitation screen the `afterCreateOrganizationUrl` won't be called.
+          skipInvitationScreen: true,
           afterCreateOrganizationUrl: organization =>
-            `/revalidate/?path=${encodeRouteSegment(
-              '/[locale]/communities'
-            )}&redirect=${encodeRouteSegment(
-              `/communities/${organization.slug}`
-            )}`,
+            `/communities/${organization.slug}/created`,
         })
       }
       className="p-1 sm:py-2 sm:px-3 rounded-full text-xs bg-consortiumBlue-800 text-consortiumGreen-300 transition flex items-center gap-1"

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -172,7 +172,7 @@ interface UpdateCommunityIriProps {
   iri: string;
 }
 
-export async function addUriToCommunity({id, iri}: UpdateCommunityIriProps) {
+export async function addIriToCommunity({id, iri}: UpdateCommunityIriProps) {
   noStore();
 
   const community = await getCommunityById(id);

--- a/apps/researcher/src/lib/community/actions.ts
+++ b/apps/researcher/src/lib/community/actions.ts
@@ -154,12 +154,38 @@ export async function updateCommunity({
 }: UpdateCommunityProps) {
   noStore();
 
+  const community = await getCommunityById(id);
+
   const organization = await clerkClient.organizations.updateOrganization(id, {
     name,
     publicMetadata: {
+      iri: community.iri,
       description,
     },
   });
 
   return organizationToCommunity(organization);
+}
+
+interface UpdateCommunityIriProps {
+  id: string;
+  iri: string;
+}
+
+export async function addUriToCommunity({id, iri}: UpdateCommunityIriProps) {
+  noStore();
+
+  const community = await getCommunityById(id);
+
+  // Only add the IRI if it is not already set
+  if (!community.iri) {
+    const organization =
+      await clerkClient.organizations.updateOrganizationMetadata(id, {
+        publicMetadata: {
+          iri,
+        },
+      });
+    return organizationToCommunity(organization);
+  }
+  return community;
 }

--- a/apps/researcher/src/lib/community/clerk-converters.ts
+++ b/apps/researcher/src/lib/community/clerk-converters.ts
@@ -14,6 +14,7 @@ export function organizationToCommunity(
     name: organization.name,
     // The type of `publicMetadata` is `{ [k: string]: unknown } | null `. Redeclare custom metadata.
     description: organization.publicMetadata?.description as string | undefined,
+    iri: organization.publicMetadata?.iri as string | undefined,
     slug: organization.slug!,
     imageUrl: organization.imageUrl,
     // In OrganizationResource `createdAt` is a `Date` object.

--- a/apps/researcher/src/lib/community/definitions.ts
+++ b/apps/researcher/src/lib/community/definitions.ts
@@ -3,6 +3,7 @@ export interface Community {
   name: string;
   slug: string;
   description?: string;
+  iri?: string;
   imageUrl: string;
   createdAt: number;
   membershipCount?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@colonial-collections/database": "*",
         "@colonial-collections/email-sender": "*",
         "@colonial-collections/enricher": "*",
+        "@colonial-collections/iris": "*",
         "@colonial-collections/list-store": "*",
         "@colonial-collections/ui": "*",
         "@headlessui/react": "1.7.18",

--- a/packages/iris/src/index.ts
+++ b/packages/iris/src/index.ts
@@ -1,1 +1,2 @@
 export * from './is-iri';
+export * from './create-persistent-iri';


### PR DESCRIPTION
In this pull request, the iri is added to the community after creation.

We create a community using the `openCreateCommunity` modal provided by Clerk. The `openCreateCommunity` has a `afterCreateOrganizationUrl` prop.

This is set to `/communities/${organization.slug}/created`.

The URI is set on this page, and the user is redirected to the community page.

I wouldn't say I like logic based on navigation to a URL, but this is the only entry `openCreateCommunity` gives us. The alternative is not using the clerk modal but creating the modal ourselves and creating the community using the Clerk API; this gives us more options, but it is more work.