### PR TITLE
enricher: improve tests for adding and retrieving prov events

### DIFF
--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -10,102 +10,6 @@ const fetcher = new ProvenanceEventEnrichmentFetcher({
   endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,
 });
 
-const resourceId = `http://example.org/${Date.now()}`;
-
-// Create some enrichments
-beforeAll(async () => {
-  const nanopubClient = new NanopubClient({
-    endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
-    proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
-  });
-
-  const creator = new EnrichmentCreator({
-    knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-    nanopubClient,
-  });
-
-  await creator.addProvenanceEvent({
-    type: ProvenanceEventType.Acquisition,
-    additionalType: {
-      id: 'http://vocab.getty.edu/aat/300417642',
-      name: 'Purchase',
-    },
-    transferredFrom: {
-      id: 'http://www.wikidata.org/entity/Q517',
-      name: 'Napoleon',
-    },
-    transferredTo: {
-      id: 'http://www.wikidata.org/entity/Q171480',
-      name: 'Joséphine de Beauharnais',
-    },
-    location: {
-      id: 'https://sws.geonames.org/2988507/',
-      name: 'Paris',
-    },
-    date: {
-      startDate: '1805',
-      endDate: '1806',
-    },
-    description: 'A comment',
-    citation: 'A citation or reference to a work that supports the information',
-    inLanguage: 'en',
-    about: resourceId,
-    pubInfo: {
-      creator: {
-        id: 'http://example.com/person1',
-        name: 'Person 1',
-        isPartOf: {
-          id: 'http://example.com/group1',
-          name: 'Group 1',
-        },
-      },
-      license: 'https://creativecommons.org/licenses/by/4.0/',
-    },
-  });
-
-  await creator.addProvenanceEvent({
-    type: ProvenanceEventType.TransferOfCustody,
-    additionalType: {
-      id: 'http://vocab.getty.edu/aat/300445014',
-      name: 'Returning',
-    },
-    transferredFrom: {
-      id: 'http://www.wikidata.org/entity/Q131691',
-      name: 'Arthur Wellesley',
-    },
-    transferredTo: {
-      id: 'http://www.wikidata.org/entity/Q9439',
-      name: 'Victoria',
-    },
-    location: {
-      id: 'https://sws.geonames.org/2643743/',
-      name: 'London',
-    },
-    date: {
-      startDate: '1850-02',
-      endDate: '1850-07-13',
-    },
-    description: 'Returned to the owner',
-    citation: 'A citation or reference to a work that supports the information',
-    inLanguage: 'en',
-    about: resourceId,
-    pubInfo: {
-      creator: {
-        id: 'http://example.com/person2',
-        name: 'Person 2',
-        isPartOf: {
-          id: 'http://example.com/group2',
-          name: 'Group 2',
-        },
-      },
-      license: 'https://creativecommons.org/licenses/by/4.0/',
-    },
-  });
-
-  // Wait a bit: storing the nanopubs takes some time
-  await setTimeout(2000);
-});
-
 describe('getById', () => {
   it('returns undefined if the ID of the resource is invalid', async () => {
     const enrichments = await fetcher.getById('badValue');
@@ -117,6 +21,185 @@ describe('getById', () => {
     const enrichments = await fetcher.getById('http://example.org/unknown');
 
     expect(enrichments).toEqual([]);
+  });
+});
+
+describe('getById - basic enrichments, with only required properties', () => {
+  const resourceId = `http://example.org/${Date.now()}`;
+
+  // Create some enrichments
+  beforeAll(async () => {
+    const nanopubClient = new NanopubClient({
+      endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
+      proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
+    });
+
+    const creator = new EnrichmentCreator({
+      knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+      nanopubClient,
+    });
+
+    await creator.addProvenanceEvent({
+      type: ProvenanceEventType.Acquisition,
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    await creator.addProvenanceEvent({
+      type: ProvenanceEventType.TransferOfCustody,
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person2',
+          name: 'Person 2',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    // Wait a bit: storing the nanopubs takes some time
+    await setTimeout(2000);
+  });
+
+  it('gets the enrichments of a resource', async () => {
+    const enrichments = await fetcher.getById(resourceId);
+
+    expect(enrichments).toEqual(
+      expect.arrayContaining([
+        {
+          id: expect.stringContaining('https://'),
+          type: ProvenanceEventType.Acquisition,
+          about: resourceId,
+          pubInfo: {
+            creator: {
+              id: 'http://example.com/person1',
+              name: 'Person 1',
+            },
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+            dateCreated: expect.any(Date),
+          },
+        },
+        {
+          id: expect.stringContaining('https://'),
+          type: ProvenanceEventType.TransferOfCustody,
+          about: resourceId,
+          pubInfo: {
+            creator: {
+              id: 'http://example.com/person2',
+              name: 'Person 2',
+            },
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+            dateCreated: expect.any(Date),
+          },
+        },
+      ])
+    );
+  });
+});
+
+describe('getById - full enrichments, with all properties', () => {
+  const resourceId = `http://example.org/${Date.now()}`;
+
+  // Create some enrichments
+  beforeAll(async () => {
+    const nanopubClient = new NanopubClient({
+      endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
+      proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
+    });
+
+    const creator = new EnrichmentCreator({
+      knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+      nanopubClient,
+    });
+
+    await creator.addProvenanceEvent({
+      type: ProvenanceEventType.Acquisition,
+      additionalType: {
+        id: 'http://vocab.getty.edu/aat/300417642',
+        name: 'Purchase',
+      },
+      transferredFrom: {
+        id: 'http://www.wikidata.org/entity/Q517',
+        name: 'Napoleon',
+      },
+      transferredTo: {
+        id: 'http://www.wikidata.org/entity/Q171480',
+        name: 'Joséphine de Beauharnais',
+      },
+      location: {
+        id: 'https://sws.geonames.org/2988507/',
+        name: 'Paris',
+      },
+      date: {
+        startDate: '1805',
+        endDate: '1806',
+      },
+      description: 'A comment',
+      citation:
+        'A citation or reference to a work that supports the information',
+      inLanguage: 'en',
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+          isPartOf: {
+            id: 'http://example.com/group1',
+            name: 'Group 1',
+          },
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    await creator.addProvenanceEvent({
+      type: ProvenanceEventType.TransferOfCustody,
+      additionalType: {
+        id: 'http://vocab.getty.edu/aat/300445014',
+        name: 'Returning',
+      },
+      transferredFrom: {
+        id: 'http://www.wikidata.org/entity/Q131691',
+        name: 'Arthur Wellesley',
+      },
+      transferredTo: {
+        id: 'http://www.wikidata.org/entity/Q9439',
+        name: 'Victoria',
+      },
+      location: {
+        id: 'https://sws.geonames.org/2643743/',
+        name: 'London',
+      },
+      date: {
+        startDate: '1850-02',
+        endDate: '1850-07-13',
+      },
+      description: 'Returned to the owner',
+      citation:
+        'A citation or reference to a work that supports the information',
+      inLanguage: 'en',
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person2',
+          name: 'Person 2',
+          isPartOf: {
+            id: 'http://example.com/group2',
+            name: 'Group 2',
+          },
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    // Wait a bit: storing the nanopubs takes some time
+    await setTimeout(2000);
   });
 
   it('gets the enrichments of a resource', async () => {

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -213,103 +213,105 @@ describe('getById - full enrichments, with all properties', () => {
   it('gets the enrichments of a resource', async () => {
     const enrichments = await fetcher.getById(resourceId);
 
-    expect(enrichments).toStrictEqual([
-      {
-        id: expect.stringContaining('https://'),
-        type: 'acquisition',
-        additionalTypes: [
-          {
-            id: 'http://vocab.getty.edu/aat/300417642',
-            name: 'Purchase',
-          },
-        ],
-        about: resourceId,
-        citation:
-          'A citation or reference to a work that supports the information',
-        description: 'A comment',
-        inLanguage: 'en',
-        qualifier: {
-          id: 'http://vocab.getty.edu/aat/300435722',
-          name: 'Possibly',
-        },
-        date: {
+    expect(enrichments).toEqual(
+      expect.arrayContaining([
+        {
           id: expect.stringContaining('https://'),
-          startDate: new Date('1805-01-01T00:00:00.000Z'),
-          endDate: new Date('1806-12-31T23:59:59.999Z'),
-        },
-        location: {
-          id: 'https://sws.geonames.org/2988507/',
-          name: 'Paris',
-        },
-        transferredFrom: {
-          id: 'http://www.wikidata.org/entity/Q517',
-          name: 'Napoleon',
-        },
-        transferredTo: {
-          id: 'http://www.wikidata.org/entity/Q171480',
-          name: 'Josephine de Beauharnais',
-        },
-        pubInfo: {
-          creator: {
-            id: 'http://example.com/person1',
-            name: 'Person 1',
-            isPartOf: {
-              id: 'http://example.com/group1',
-              name: 'Group 1',
+          type: 'acquisition',
+          additionalTypes: [
+            {
+              id: 'http://vocab.getty.edu/aat/300417642',
+              name: 'Purchase',
             },
+          ],
+          about: resourceId,
+          citation:
+            'A citation or reference to a work that supports the information',
+          description: 'A comment',
+          inLanguage: 'en',
+          qualifier: {
+            id: 'http://vocab.getty.edu/aat/300435722',
+            name: 'Possibly',
           },
-          license: 'https://creativecommons.org/licenses/by/4.0/',
-          dateCreated: expect.any(Date),
-        },
-      },
-      {
-        id: expect.stringContaining('https://'),
-        type: 'transferOfCustody',
-        additionalTypes: [
-          {
-            id: 'http://vocab.getty.edu/aat/300445014',
-            name: 'Returning',
+          date: {
+            id: expect.stringContaining('https://'),
+            startDate: new Date('1805-01-01T00:00:00.000Z'),
+            endDate: new Date('1806-12-31T23:59:59.999Z'),
           },
-        ],
-        about: resourceId,
-        citation:
-          'A citation or reference to a work that supports the information',
-        description: 'Returned to the owner',
-        inLanguage: 'en',
-        qualifier: {
-          id: 'http://vocab.getty.edu/aat/300435722',
-          name: 'Possibly',
+          location: {
+            id: 'https://sws.geonames.org/2988507/',
+            name: 'Paris',
+          },
+          transferredFrom: {
+            id: 'http://www.wikidata.org/entity/Q517',
+            name: 'Napoleon',
+          },
+          transferredTo: {
+            id: 'http://www.wikidata.org/entity/Q171480',
+            name: 'Josephine de Beauharnais',
+          },
+          pubInfo: {
+            creator: {
+              id: 'http://example.com/person1',
+              name: 'Person 1',
+              isPartOf: {
+                id: 'http://example.com/group1',
+                name: 'Group 1',
+              },
+            },
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+            dateCreated: expect.any(Date),
+          },
         },
-        date: {
+        {
           id: expect.stringContaining('https://'),
-          startDate: new Date('1850-02-01T00:00:00.000Z'),
-          endDate: new Date('1850-07-13T23:59:59.999Z'),
-        },
-        location: {
-          id: 'https://sws.geonames.org/2643743/',
-          name: 'London',
-        },
-        transferredFrom: {
-          id: 'http://www.wikidata.org/entity/Q131691',
-          name: 'Arthur Wellesley',
-        },
-        transferredTo: {
-          id: 'http://www.wikidata.org/entity/Q9439',
-          name: 'Victoria',
-        },
-        pubInfo: {
-          creator: {
-            id: 'http://example.com/person2',
-            name: 'Person 2',
-            isPartOf: {
-              id: 'http://example.com/group2',
-              name: 'Group 2',
+          type: 'transferOfCustody',
+          additionalTypes: [
+            {
+              id: 'http://vocab.getty.edu/aat/300445014',
+              name: 'Returning',
             },
+          ],
+          about: resourceId,
+          citation:
+            'A citation or reference to a work that supports the information',
+          description: 'Returned to the owner',
+          inLanguage: 'en',
+          qualifier: {
+            id: 'http://vocab.getty.edu/aat/300435722',
+            name: 'Possibly',
           },
-          license: 'https://creativecommons.org/licenses/by/4.0/',
-          dateCreated: expect.any(Date),
+          date: {
+            id: expect.stringContaining('https://'),
+            startDate: new Date('1850-02-01T00:00:00.000Z'),
+            endDate: new Date('1850-07-13T23:59:59.999Z'),
+          },
+          location: {
+            id: 'https://sws.geonames.org/2643743/',
+            name: 'London',
+          },
+          transferredFrom: {
+            id: 'http://www.wikidata.org/entity/Q131691',
+            name: 'Arthur Wellesley',
+          },
+          transferredTo: {
+            id: 'http://www.wikidata.org/entity/Q9439',
+            name: 'Victoria',
+          },
+          pubInfo: {
+            creator: {
+              id: 'http://example.com/person2',
+              name: 'Person 2',
+              isPartOf: {
+                id: 'http://example.com/group2',
+                name: 'Group 2',
+              },
+            },
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+            dateCreated: expect.any(Date),
+          },
         },
-      },
-    ]);
+      ])
+    );
   });
 });

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -12,7 +12,27 @@ const nanopubClient = new NanopubClient({
 const storer = new ProvenanceEventEnrichmentStorer({nanopubClient});
 
 describe('add', () => {
-  it('adds an acquisition event', async () => {
+  it('adds a basic acquisition event, with only required properties', async () => {
+    const enrichment = await storer.add({
+      type: ProvenanceEventType.Acquisition,
+      about: {
+        id: 'http://example.org/object1',
+      },
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds a full acquisition event, with all properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
       additionalType: {
@@ -60,7 +80,27 @@ describe('add', () => {
     });
   });
 
-  it('adds a transfer of custody event', async () => {
+  it('adds a basic transfer of custody event, with only required properties', async () => {
+    const enrichment = await storer.add({
+      type: ProvenanceEventType.TransferOfCustody,
+      about: {
+        id: 'http://example.org/object1',
+      },
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds a full transfer of custody event, with all properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.TransferOfCustody,
       additionalType: {


### PR DESCRIPTION
This PR updates the tests of the `enricher` a bit, by verifying whether it's possible to add provenance events with only minimal/required properties and with full/also non-required properties.