### PR TITLE
feat: enricher - add qualifier to prov events

### DIFF
--- a/packages/enricher/src/objects/storer.ts
+++ b/packages/enricher/src/objects/storer.ts
@@ -39,16 +39,16 @@ export class HeritageObjectEnrichmentStorer {
 
     const publicationStore = RdfStore.createDefault();
     const assertionStore = RdfStore.createDefault();
-    const annotationId = DF.blankNode();
+    const enrichmentId = DF.blankNode();
     const bodyId = DF.blankNode();
     const languageCode = opts.inLanguage;
 
     // Make clear what application has published this nanopub
-    const softwareTool = DF.namedNode('https://app.colonialcollections.nl/');
+    const softwareToolId = DF.namedNode('https://app.colonialcollections.nl/');
 
     publicationStore.addQuad(
       DF.quad(
-        softwareTool,
+        softwareToolId,
         DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
         DF.namedNode('http://purl.org/nanopub/x/SoftwareTool')
       )
@@ -56,7 +56,7 @@ export class HeritageObjectEnrichmentStorer {
 
     publicationStore.addQuad(
       DF.quad(
-        softwareTool,
+        softwareToolId,
         DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
         DF.literal('Colonial Collections')
       )
@@ -94,7 +94,7 @@ export class HeritageObjectEnrichmentStorer {
       DF.quad(
         nanopubId,
         DF.namedNode('http://purl.org/nanopub/x/wasCreatedWith'),
-        softwareTool
+        softwareToolId
       )
     );
 
@@ -103,37 +103,37 @@ export class HeritageObjectEnrichmentStorer {
       DF.quad(
         nanopubId,
         DF.namedNode('http://purl.org/nanopub/x/introduces'),
-        annotationId
+        enrichmentId
       )
     );
 
     // The server automatically adds 'dcterms:creator'.
     // A creator can change his or her name later on, but the name at the time of
     // creation is preserved.
-    const creatorNode = DF.namedNode(opts.pubInfo.creator.id);
+    const creatorId = DF.namedNode(opts.pubInfo.creator.id);
 
     publicationStore.addQuad(
       DF.quad(
-        creatorNode,
+        creatorId,
         DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
         DF.literal(opts.pubInfo.creator.name)
       )
     );
 
     if (opts.pubInfo.creator.isPartOf !== undefined) {
-      const groupNode = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
+      const groupId = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
 
       publicationStore.addQuad(
         DF.quad(
-          creatorNode,
+          creatorId,
           DF.namedNode('http://purl.org/dc/terms/isPartOf'),
-          groupNode
+          groupId
         )
       );
 
       publicationStore.addQuad(
         DF.quad(
-          groupNode,
+          groupId,
           DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
           DF.literal(opts.pubInfo.creator.isPartOf.name)
         )
@@ -142,7 +142,7 @@ export class HeritageObjectEnrichmentStorer {
 
     assertionStore.addQuad(
       DF.quad(
-        annotationId,
+        enrichmentId,
         DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
         DF.namedNode('http://www.w3.org/ns/oa#Annotation')
       )
@@ -150,7 +150,7 @@ export class HeritageObjectEnrichmentStorer {
 
     assertionStore.addQuad(
       DF.quad(
-        annotationId,
+        enrichmentId,
         DF.namedNode('http://www.w3.org/ns/oa#hasBody'),
         bodyId
       )
@@ -200,7 +200,7 @@ export class HeritageObjectEnrichmentStorer {
     if (opts.citation !== undefined) {
       assertionStore.addQuad(
         DF.quad(
-          annotationId,
+          enrichmentId,
           DF.namedNode('http://www.w3.org/2000/01/rdf-schema#comment'),
           DF.literal(opts.citation, languageCode)
         )
@@ -208,17 +208,19 @@ export class HeritageObjectEnrichmentStorer {
     }
 
     // The part of an object that the enrichment is about
+    const objectId = DF.namedNode(opts.about.id);
+
     assertionStore.addQuad(
       DF.quad(
-        annotationId,
+        enrichmentId,
         DF.namedNode('http://www.w3.org/ns/oa#hasTarget'),
-        DF.namedNode(opts.about.id)
+        objectId
       )
     );
 
     assertionStore.addQuad(
       DF.quad(
-        DF.namedNode(opts.about.id),
+        objectId,
         DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
         DF.namedNode('http://www.w3.org/ns/oa#SpecificResource')
       )
@@ -227,7 +229,7 @@ export class HeritageObjectEnrichmentStorer {
     // The object that the enrichment is about
     assertionStore.addQuad(
       DF.quad(
-        DF.namedNode(opts.about.id),
+        objectId,
         DF.namedNode('http://www.w3.org/ns/oa#hasSource'),
         DF.namedNode(opts.about.isPartOf.id)
       )

--- a/packages/enricher/src/provenance-events/definitions.ts
+++ b/packages/enricher/src/provenance-events/definitions.ts
@@ -47,6 +47,12 @@ export const provenanceEventEnrichmentBeingCreatedSchema =
           name: z.string(),
         })
         .optional(),
+      qualifier: z
+        .object({
+          id: z.string().url(),
+          name: z.string(),
+        })
+        .optional(),
     })
   );
 
@@ -78,6 +84,7 @@ export type ProvenanceEventEnrichment = {
   description?: string;
   citation?: string;
   inLanguage?: string;
+  qualifier?: Term;
   about: string;
   pubInfo: PubInfo;
 };

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -130,55 +130,7 @@ describe('getById', () => {
   it('gets the enrichments of a resource', async () => {
     const enrichments = await fetcher.getById(resourceId);
 
-    expect(enrichments).toMatchObject([
-      {
-        id: expect.stringContaining('https://'),
-        type: 'transferOfCustody',
-        additionalTypes: [
-          {
-            id: 'http://vocab.getty.edu/aat/300445014',
-            name: 'Returning',
-          },
-        ],
-        about: resourceId,
-        citation:
-          'A citation or reference to a work that supports the information',
-        description: 'Returned to the owner',
-        inLanguage: 'en',
-        qualifier: {
-          id: 'http://vocab.getty.edu/aat/300435722',
-          name: 'Possibly',
-        },
-        date: {
-          id: expect.stringContaining('https://'),
-          startDate: new Date('1850-02-01T00:00:00.000Z'),
-          endDate: new Date('1850-07-13T23:59:59.999Z'),
-        },
-        location: {
-          id: 'https://sws.geonames.org/2643743/',
-          name: 'London',
-        },
-        transferredFrom: {
-          id: 'http://www.wikidata.org/entity/Q131691',
-          name: 'Arthur Wellesley',
-        },
-        transferredTo: {
-          id: 'http://www.wikidata.org/entity/Q9439',
-          name: 'Victoria',
-        },
-        pubInfo: {
-          creator: {
-            id: 'http://example.com/person2',
-            name: 'Person 2',
-            isPartOf: {
-              id: 'http://example.com/group2',
-              name: 'Group 2',
-            },
-          },
-          license: 'https://creativecommons.org/licenses/by/4.0/',
-          dateCreated: expect.any(Date),
-        },
-      },
+    expect(enrichments).toStrictEqual([
       {
         id: expect.stringContaining('https://'),
         type: 'acquisition',
@@ -221,6 +173,54 @@ describe('getById', () => {
             isPartOf: {
               id: 'http://example.com/group1',
               name: 'Group 1',
+            },
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+          dateCreated: expect.any(Date),
+        },
+      },
+      {
+        id: expect.stringContaining('https://'),
+        type: 'transferOfCustody',
+        additionalTypes: [
+          {
+            id: 'http://vocab.getty.edu/aat/300445014',
+            name: 'Returning',
+          },
+        ],
+        about: resourceId,
+        citation:
+          'A citation or reference to a work that supports the information',
+        description: 'Returned to the owner',
+        inLanguage: 'en',
+        qualifier: {
+          id: 'http://vocab.getty.edu/aat/300435722',
+          name: 'Possibly',
+        },
+        date: {
+          id: expect.stringContaining('https://'),
+          startDate: new Date('1850-02-01T00:00:00.000Z'),
+          endDate: new Date('1850-07-13T23:59:59.999Z'),
+        },
+        location: {
+          id: 'https://sws.geonames.org/2643743/',
+          name: 'London',
+        },
+        transferredFrom: {
+          id: 'http://www.wikidata.org/entity/Q131691',
+          name: 'Arthur Wellesley',
+        },
+        transferredTo: {
+          id: 'http://www.wikidata.org/entity/Q9439',
+          name: 'Victoria',
+        },
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person2',
+            name: 'Person 2',
+            isPartOf: {
+              id: 'http://example.com/group2',
+              name: 'Group 2',
             },
           },
           license: 'https://creativecommons.org/licenses/by/4.0/',

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -36,7 +36,7 @@ beforeAll(async () => {
     },
     transferredTo: {
       id: 'http://www.wikidata.org/entity/Q171480',
-      name: 'Joséphine de Beauharnais',
+      name: 'Josephine de Beauharnais',
     },
     location: {
       id: 'https://sws.geonames.org/2988507/',
@@ -49,6 +49,10 @@ beforeAll(async () => {
     description: 'A comment',
     citation: 'A citation or reference to a work that supports the information',
     inLanguage: 'en',
+    qualifier: {
+      id: 'http://vocab.getty.edu/aat/300435722',
+      name: 'Possibly',
+    },
     about: resourceId,
     pubInfo: {
       creator: {
@@ -88,6 +92,10 @@ beforeAll(async () => {
     description: 'Returned to the owner',
     citation: 'A citation or reference to a work that supports the information',
     inLanguage: 'en',
+    qualifier: {
+      id: 'http://vocab.getty.edu/aat/300435722',
+      name: 'Possibly',
+    },
     about: resourceId,
     pubInfo: {
       creator: {
@@ -122,97 +130,101 @@ describe('getById', () => {
   it('gets the enrichments of a resource', async () => {
     const enrichments = await fetcher.getById(resourceId);
 
-    expect(enrichments).toEqual(
-      expect.arrayContaining([
-        {
-          id: expect.stringContaining('https://'),
-          type: ProvenanceEventType.Acquisition,
-          about: resourceId,
-          pubInfo: {
-            creator: {
-              id: 'http://example.com/person1',
-              name: 'Person 1',
-              isPartOf: {
-                id: 'http://example.com/group1',
-                name: 'Group 1',
-              },
-            },
-            license: 'https://creativecommons.org/licenses/by/4.0/',
-            dateCreated: expect.any(Date),
+    expect(enrichments).toMatchObject([
+      {
+        id: expect.stringContaining('https://'),
+        type: 'acquisition',
+        additionalTypes: [
+          {
+            id: 'http://vocab.getty.edu/aat/300417642',
+            name: 'Purchase',
           },
-          additionalTypes: [
-            {
-              id: 'http://vocab.getty.edu/aat/300417642',
-              name: 'Purchase',
-            },
-          ],
-          citation:
-            'A citation or reference to a work that supports the information',
-          description: 'A comment',
-          inLanguage: 'en',
-          date: {
-            id: expect.stringContaining('https://'),
-            startDate: new Date('1805-01-01T00:00:00.000Z'),
-            endDate: new Date('1806-12-31T23:59:59.999Z'),
-          },
-          transferredFrom: {
-            id: 'http://www.wikidata.org/entity/Q517',
-            name: 'Napoleon',
-          },
-          transferredTo: {
-            id: 'http://www.wikidata.org/entity/Q171480',
-            name: 'Joséphine de Beauharnais',
-          },
-          location: {
-            id: 'https://sws.geonames.org/2988507/',
-            name: 'Paris',
-          },
+        ],
+        about: resourceId,
+        citation:
+          'A citation or reference to a work that supports the information',
+        description: 'A comment',
+        inLanguage: 'en',
+        qualifier: {
+          id: 'http://vocab.getty.edu/aat/300435722',
+          name: 'Possibly',
         },
-        {
+        date: {
           id: expect.stringContaining('https://'),
-          type: ProvenanceEventType.TransferOfCustody,
-          about: resourceId,
-          pubInfo: {
-            creator: {
-              id: 'http://example.com/person2',
-              name: 'Person 2',
-              isPartOf: {
-                id: 'http://example.com/group2',
-                name: 'Group 2',
-              },
-            },
-            license: 'https://creativecommons.org/licenses/by/4.0/',
-            dateCreated: expect.any(Date),
-          },
-          additionalTypes: [
-            {
-              id: 'http://vocab.getty.edu/aat/300445014',
-              name: 'Returning',
-            },
-          ],
-          citation:
-            'A citation or reference to a work that supports the information',
-          description: 'Returned to the owner',
-          inLanguage: 'en',
-          date: {
-            id: expect.stringContaining('https://'),
-            startDate: new Date('1850-02-01T00:00:00.000Z'),
-            endDate: new Date('1850-07-13T23:59:59.999Z'),
-          },
-          transferredFrom: {
-            id: 'http://www.wikidata.org/entity/Q131691',
-            name: 'Arthur Wellesley',
-          },
-          transferredTo: {
-            id: 'http://www.wikidata.org/entity/Q9439',
-            name: 'Victoria',
-          },
-          location: {
-            id: 'https://sws.geonames.org/2643743/',
-            name: 'London',
-          },
+          startDate: new Date('1805-01-01T00:00:00.000Z'),
+          endDate: new Date('1806-12-31T23:59:59.999Z'),
         },
-      ])
-    );
+        location: {
+          id: 'https://sws.geonames.org/2988507/',
+          name: 'Paris',
+        },
+        transferredFrom: {
+          id: 'http://www.wikidata.org/entity/Q517',
+          name: 'Napoleon',
+        },
+        transferredTo: {
+          id: 'http://www.wikidata.org/entity/Q171480',
+          name: 'Josephine de Beauharnais',
+        },
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person1',
+            name: 'Person 1',
+            isPartOf: {
+              id: 'http://example.com/group1',
+              name: 'Group 1',
+            },
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+        },
+      },
+      {
+        id: expect.stringContaining('https://'),
+        type: 'transferOfCustody',
+        additionalTypes: [
+          {
+            id: 'http://vocab.getty.edu/aat/300445014',
+            name: 'Returning',
+          },
+        ],
+        about: resourceId,
+        citation:
+          'A citation or reference to a work that supports the information',
+        description: 'Returned to the owner',
+        inLanguage: 'en',
+        qualifier: {
+          id: 'http://vocab.getty.edu/aat/300435722',
+          name: 'Possibly',
+        },
+        date: {
+          id: expect.stringContaining('https://'),
+          startDate: new Date('1850-02-01T00:00:00.000Z'),
+          endDate: new Date('1850-07-13T23:59:59.999Z'),
+        },
+        location: {
+          id: 'https://sws.geonames.org/2643743/',
+          name: 'London',
+        },
+        transferredFrom: {
+          id: 'http://www.wikidata.org/entity/Q131691',
+          name: 'Arthur Wellesley',
+        },
+        transferredTo: {
+          id: 'http://www.wikidata.org/entity/Q9439',
+          name: 'Victoria',
+        },
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person2',
+            name: 'Person 2',
+            isPartOf: {
+              id: 'http://example.com/group2',
+              name: 'Group 2',
+            },
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+        },
+      },
+    ]);
   });
 });

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -133,53 +133,6 @@ describe('getById', () => {
     expect(enrichments).toMatchObject([
       {
         id: expect.stringContaining('https://'),
-        type: 'acquisition',
-        additionalTypes: [
-          {
-            id: 'http://vocab.getty.edu/aat/300417642',
-            name: 'Purchase',
-          },
-        ],
-        about: resourceId,
-        citation:
-          'A citation or reference to a work that supports the information',
-        description: 'A comment',
-        inLanguage: 'en',
-        qualifier: {
-          id: 'http://vocab.getty.edu/aat/300435722',
-          name: 'Possibly',
-        },
-        date: {
-          id: expect.stringContaining('https://'),
-          startDate: new Date('1805-01-01T00:00:00.000Z'),
-          endDate: new Date('1806-12-31T23:59:59.999Z'),
-        },
-        location: {
-          id: 'https://sws.geonames.org/2988507/',
-          name: 'Paris',
-        },
-        transferredFrom: {
-          id: 'http://www.wikidata.org/entity/Q517',
-          name: 'Napoleon',
-        },
-        transferredTo: {
-          id: 'http://www.wikidata.org/entity/Q171480',
-          name: 'Josephine de Beauharnais',
-        },
-        pubInfo: {
-          creator: {
-            id: 'http://example.com/person1',
-            name: 'Person 1',
-            isPartOf: {
-              id: 'http://example.com/group1',
-              name: 'Group 1',
-            },
-          },
-          license: 'https://creativecommons.org/licenses/by/4.0/',
-        },
-      },
-      {
-        id: expect.stringContaining('https://'),
         type: 'transferOfCustody',
         additionalTypes: [
           {
@@ -223,6 +176,55 @@ describe('getById', () => {
             },
           },
           license: 'https://creativecommons.org/licenses/by/4.0/',
+          dateCreated: expect.any(Date),
+        },
+      },
+      {
+        id: expect.stringContaining('https://'),
+        type: 'acquisition',
+        additionalTypes: [
+          {
+            id: 'http://vocab.getty.edu/aat/300417642',
+            name: 'Purchase',
+          },
+        ],
+        about: resourceId,
+        citation:
+          'A citation or reference to a work that supports the information',
+        description: 'A comment',
+        inLanguage: 'en',
+        qualifier: {
+          id: 'http://vocab.getty.edu/aat/300435722',
+          name: 'Possibly',
+        },
+        date: {
+          id: expect.stringContaining('https://'),
+          startDate: new Date('1805-01-01T00:00:00.000Z'),
+          endDate: new Date('1806-12-31T23:59:59.999Z'),
+        },
+        location: {
+          id: 'https://sws.geonames.org/2988507/',
+          name: 'Paris',
+        },
+        transferredFrom: {
+          id: 'http://www.wikidata.org/entity/Q517',
+          name: 'Napoleon',
+        },
+        transferredTo: {
+          id: 'http://www.wikidata.org/entity/Q171480',
+          name: 'Josephine de Beauharnais',
+        },
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person1',
+            name: 'Person 1',
+            isPartOf: {
+              id: 'http://example.com/group1',
+              name: 'Group 1',
+            },
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+          dateCreated: expect.any(Date),
         },
       },
     ]);

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -214,6 +214,14 @@ export class ProvenanceEventEnrichmentFetcher {
       toProvenanceEventEnrichment(rawEnrichment)
     );
 
+    // Sort the enrichments by date of creation, from old to new
+    enrichments.sort((enrichmentA, enrichmentB) => {
+      const dateCreatedA = enrichmentA.pubInfo.dateCreated.getTime();
+      const dateCreatedB = enrichmentB.pubInfo.dateCreated.getTime();
+
+      return dateCreatedA - dateCreatedB;
+    });
+
     return enrichments;
   }
 

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -51,6 +51,7 @@ export class ProvenanceEventEnrichmentFetcher {
           ex:description ?description ;
           ex:citation ?citation ;
           ex:inLanguage ?language ;
+          ex:qualifier ?qualifier ;
           ex:about ?source ;
           ex:license ?license ;
           ex:creator ?creator ;
@@ -71,6 +72,9 @@ export class ProvenanceEventEnrichmentFetcher {
         ?timeSpan a ex:TimeSpan ;
           ex:startDate ?beginOfTheBegin ;
           ex:endDate ?endOfTheEnd .
+
+        ?qualifier a ex:DefinedTerm ;
+          ex:name ?qualifierName .
 
         ?creator a ex:Actor ;
           ex:name ?creatorName ;
@@ -94,7 +98,7 @@ export class ProvenanceEventEnrichmentFetcher {
 
         graph ?pubInfo {
           ?np a cc:Nanopub ;
-            npx:introduces ?provenanceEvent ;
+            npx:introduces ?attributeAssignment ;
             dcterms:creator ?creator ;
             dcterms:license ?license .
 
@@ -105,6 +109,13 @@ export class ProvenanceEventEnrichmentFetcher {
             ?group rdfs:label ?groupName
           }
         }
+
+        OPTIONAL {
+          ?attributeAssignment crm:P2_has_type ?qualifier .
+          ?qualifier rdfs:label ?qualifierName .
+        }
+
+        ?attributeAssignment crm:P141_assigned ?provenanceEvent .
 
         graph ?assertion {
           {

--- a/packages/enricher/src/provenance-events/rdf-helpers.test.ts
+++ b/packages/enricher/src/provenance-events/rdf-helpers.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
       ex:citation "Citation" ;
       ex:description "Description" ;
       ex:inLanguage "en" ;
+      ex:qualifier ex:myQualifier ;
       ex:date ex:myTimeSpan ;
       ex:transferredFrom ex:myTransferredFrom ;
       ex:transferredTo ex:myTransferredTo ;
@@ -49,6 +50,9 @@ beforeAll(async () => {
 
     ex:myAdditionalType a ex:DefinedTerm ;
       ex:name "Term" .
+
+    ex:myQualifier a ex:DefinedTerm ;
+      ex:name "Possibly" .
 
     ex:myTimeSpan a ex:TimeSpan ;
       ex:startDate "1889"^^xsd:gYear ;
@@ -126,6 +130,10 @@ describe('toProvenanceEventEnrichment', () => {
       citation: 'Citation',
       description: 'Description',
       inLanguage: 'en',
+      qualifier: {
+        id: 'https://example.org/myQualifier',
+        name: 'Possibly',
+      },
       date: {
         id: 'https://example.org/myTimeSpan',
         startDate: new Date('1889-01-01T00:00:00.000Z'),

--- a/packages/enricher/src/provenance-events/rdf-helpers.ts
+++ b/packages/enricher/src/provenance-events/rdf-helpers.ts
@@ -38,6 +38,7 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
     rawEnrichment,
     'ex:additionalType'
   );
+  const qualifier = onlyOne(createThings<Term>(rawEnrichment, 'ex:qualifier'));
 
   const enrichment: ProvenanceEventEnrichment = {
     id,
@@ -47,6 +48,7 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
     citation,
     description,
     inLanguage,
+    qualifier,
     location,
     transferredFrom,
     transferredTo,

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -39,6 +39,10 @@ describe('add', () => {
       citation:
         'A citation or reference to a work that supports the information',
       inLanguage: 'en',
+      qualifier: {
+        id: 'http://vocab.getty.edu/aat/300435722',
+        name: 'Possibly',
+      },
       about: {
         id: 'http://example.org/object1',
       },
@@ -87,6 +91,10 @@ describe('add', () => {
       citation:
         'A citation or reference to a work that supports the information',
       inLanguage: 'en',
+      qualifier: {
+        id: 'http://vocab.getty.edu/aat/300435722',
+        name: 'Possibly',
+      },
       about: {
         id: 'http://example.org/object1',
       },


### PR DESCRIPTION
This PR expands the `enricher` package and adds support for storing and retrieving the 'qualifier' of a provenance event. The qualifier gives context information about an event and can be used for storing the level of certainty.