### PR TITLE
Minor bugs and changes to provenance form

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
@@ -347,7 +347,7 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
                   />
                   <EdtfInput name="date.endDate" />
                   <FieldValidationMessage field="date.endDate" />
-                  <FieldValidationMessage field="date" />
+                  <FieldValidationMessage field="date.root" />
                 </FormColumn>
               </FormRow>
               <ButtonGroup>
@@ -377,9 +377,9 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
                     required
                   />
                   <Textarea name="citation" />
+                  <FieldValidationMessage field="citation" />
                 </FormColumn>
                 <FormColumn>
-                  <FieldValidationMessage field="citation" />
                   <InputLabel
                     title={t('attributionId')}
                     description={t('attributionIdDescription')}

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -196,14 +196,14 @@
     "communityDescription": "Select the community you speak on behalf of.",
     "typePlaceholder": "Select what happened",
     "license": "I agree that all added information in the application is published with a <link>CC-BY-4.0 license</link>",
-    "attributionId": "Persoonlijke URL",
-    "attributionIdDescription": "Door uw verhaal toe te voegen, wordt uw persoonlijke URL opgeslagen bij het verhaal. Dit kan een link zijn naar uw persoonlijke LinkedIn-, Facebook- of ORCID-profiel. Het is mogelijk niet zichtbaar voor andere bezoekers, maar de URL wordt wel opgeslagen in de cloud.",
+    "attributionId": "Personal profile URL",
+    "attributionIdDescription": "By adding your provenance event, your personal URL will be stored with the provenance event. This can be a link to your personal LinkedIn, Facebook or ORCID profile. It may not be visible to other visitors but the data is being stored in the cloud.",
     "qualifier": "Level of certainty",
     "qualifierDescription": "If you are uncertain about this information select one of the two options. If you are certain, leave them unchecked.",
     "typeRequired": "Type is required",
     "citationRequired": "Resource is required",
     "invalidAttributionId": "Invalid personal profile URL",
-    "agreedToLicenseUnchecked": "You need to agree to the license before you can add a narrative",
+    "agreedToLicenseUnchecked": "You need to agree to the license before you can add a provenance event",
     "invalidStartDate": "Invalid start date",
     "invalidEndDate": "Invalid end date",
     "invalidDateRange": "Invalid date range, start date should be before end date",
@@ -443,7 +443,7 @@
     "confiscatedDescription": "The status or condition of property having been taken or forfeited by a governmental or other entity in power or having authority."
   },
   "SignedOutSlideOut": {
-    "needAccountToAddNarrativeDescription": "With this account you can unlock more functionality of this platform. Creating an account free of charge. <link>See what else you can do with an account</link>.",
+    "description": "With this account you can unlock more functionality of this platform. Creating an account free of charge. <link>See what else you can do with an account</link>.",
     "login": "Login",
     "createAccount": "Create an account",
     "cancel": "Cancel"

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -197,13 +197,13 @@
     "typePlaceholder": "Selecteer wat er is gebeurd",
     "license": "Ik ga ermee akkoord dat alle toegevoegde informatie in de applicatie wordt gepubliceerd met een <link>CC-BY-4.0 licentie</link>",
     "attributionId": "Persoonlijke URL",
-    "attributionIdDescription": "Door uw verhaal toe te voegen, wordt uw persoonlijke URL opgeslagen bij het verhaal. Dit kan een link zijn naar uw persoonlijke LinkedIn-, Facebook- of ORCID-profiel. Het is mogelijk niet zichtbaar voor andere bezoekers, maar de URL wordt wel opgeslagen in de cloud.",
+    "attributionIdDescription": "Door uw herkomstgebeurtenis toe te voegen, wordt uw persoonlijke URL opgeslagen bij het herkomstgebeurtenis. Dit kan een link zijn naar uw persoonlijke LinkedIn-, Facebook- of ORCID-profiel. Het is mogelijk niet zichtbaar voor andere bezoekers, maar de URL wordt wel opgeslagen in de cloud.",
     "qualifier": "Zekerheidsniveau",
     "qualifierDescription": "Als u niet zeker bent over deze informatie, selecteer dan een van de twee opties. Als u zeker bent, laat ze dan onaangevinkt.",
     "typeRequired": "Type is vereist",
     "citationRequired": "Bron is vereist",
     "invalidAttributionId": "Ongeldige persoonlijke profiel-URL",
-    "agreedToLicenseUnchecked": "U moet akkoord gaan met de licentie voordat u een verhaal kunt toevoegen",
+    "agreedToLicenseUnchecked": "U moet akkoord gaan met de licentie voordat u een herkomstgebeurtenis kunt toevoegen",
     "invalidStartDate": "Ongeldige startdatum",
     "invalidEndDate": "Ongeldige einddatum",
     "invalidDateRange": "Ongeldig datumbereik, de startdatum moet vóór de einddatum zijn",
@@ -443,9 +443,9 @@
       "confiscatedDescription": "De status of toestand van eigendom dat is ingenomen of verbeurd verklaard door een regeringsinstantie of andere machthebbende entiteit."
     },
     "SignedOutSlideOut": {
+      "description": "Met dit account kun je meer functionaliteit van deze platform ontgrendelen. Een account aanmaken is gratis. <link>Zie wat je nog meer kunt doen met een account</link>.",
       "login": "Inloggen",
       "createAccount": "Maak een account aan",
-      "cancel": "Annuleren",
-      "description": "Met dit account kun je meer functionaliteit van deze platform ontgrendelen. Een account aanmaken is gratis. <link>Zie wat je nog meer kunt doen met een account</link>."
+      "cancel": "Annuleren"
     }
 }


### PR DESCRIPTION
- The date range validation message was not visible. It's because its places at `date.root`
- The citation validation message was at the wrong spot
- Translation "SignedOutSlideOut.description" was missing
- Some English translations needed to be translated