### PR TITLE
Fix warning LocalizedMarkdown

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
@@ -2,7 +2,7 @@
 
 import {Tab} from '@headlessui/react';
 import {useLocale, useTranslations} from 'next-intl';
-import {Fragment, Suspense, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import classNames from 'classnames';
 import {
   LocalizedMarkdown,

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
@@ -387,13 +387,11 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
                     />
                     <FieldValidationMessage field="agreedToLicense" />
                     <div className="text-sm mb-1">
-                      <Suspense>
-                        <LocalizedMarkdown
-                          name="license"
-                          contentPath="@/messages"
-                          textSize="small"
-                        />
-                      </Suspense>
+                      <LocalizedMarkdown
+                        name="license"
+                        contentPath="@/messages"
+                        textSize="small"
+                      />
                     </div>
                   </div>
                 </FormColumn>

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/provided-by.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/provided-by.tsx
@@ -14,7 +14,7 @@ interface ProvidedByProps {
   isCurrentPublisher: boolean;
 }
 
-export async function ProvidedBy({
+export function ProvidedBy({
   isCurrentPublisher,
   dateCreated,
   citation,

--- a/apps/researcher/src/app/[locale]/objects/[id]/user-enrichment-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/user-enrichment-form.tsx
@@ -23,7 +23,7 @@ import {
   ButtonGroup,
 } from '@/components/form';
 import type {HeritageObjectEnrichmentType} from '@colonial-collections/enricher';
-import {ReactNode, Suspense, useMemo} from 'react';
+import {ReactNode, useMemo} from 'react';
 import {useUser} from '@clerk/nextjs';
 import {addAttributionId} from '@/lib/user/actions';
 import {CheckboxWithLabel} from '@/components/form/checkbox-with-label';

--- a/apps/researcher/src/app/[locale]/objects/[id]/user-enrichment-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/user-enrichment-form.tsx
@@ -226,13 +226,11 @@ export function UserEnrichmentForm({
               />
               <FieldValidationMessage field="agreedToLicense" />
               <div className="text-sm mb-1">
-                <Suspense>
-                  <LocalizedMarkdown
-                    name="license"
-                    contentPath="@/messages"
-                    textSize="small"
-                  />
-                </Suspense>
+                <LocalizedMarkdown
+                  name="license"
+                  contentPath="@/messages"
+                  textSize="small"
+                />
               </div>
             </div>
           </LeftFormColumn>

--- a/packages/ui/localized-markdown.tsx
+++ b/packages/ui/localized-markdown.tsx
@@ -1,6 +1,7 @@
 import {useLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
 import classNames from 'classnames';
+import dynamic from 'next/dynamic';
 
 interface Props {
   name: string;
@@ -12,7 +13,7 @@ interface Props {
   textProps?: {[key: string]: string | number | boolean};
 }
 
-export async function LocalizedMarkdown({
+export function LocalizedMarkdown({
   name,
   contentPath,
   textSize,
@@ -33,16 +34,19 @@ export async function LocalizedMarkdown({
   let Markdown;
   try {
     if (contentPath === '@colonial-collections/content') {
-      Markdown = (
-        await import(`@colonial-collections/content/${locale}/${name}.mdx`)
-      ).default;
+      Markdown = dynamic(
+        () => import(`@colonial-collections/content/${locale}/${name}.mdx`)
+      );
     }
     if (contentPath === '@/messages') {
-      Markdown = (await import(`@/messages/${locale}/${name}.mdx`)).default;
+      Markdown = dynamic(() => import(`@/messages/${locale}/${name}.mdx`));
+    }
+    if (!Markdown) {
+      notFound();
     }
     return (
       <div className={markdownClassName} data-testid="markdown-container">
-        <Markdown name="test" {...textProps} />
+        <Markdown {...textProps} />
       </div>
     );
   } catch {


### PR DESCRIPTION
The `LocalizedMarkdown` component was created for server components. But it is also now used in client components, which warns that "async/await is not yet supported in Client Component.". I added a temporary fix by wrapping the `LocalizedMarkdown` within client components with a `<Suspense>`. With the ` <Suspense>` the component `LocalizedMarkdown` loads, but the warning was still visible.

I fix this by removing the 'async' in `LocalizedMarkdown`.