### PR TITLE
Translate provenance options

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/actions.ts
@@ -4,7 +4,8 @@ import {revalidatePath} from 'next/cache';
 import {creator} from '@/lib/enricher-instances';
 import {encodeRouteSegment} from '@/lib/clerk-route-segment-transformer';
 import {enrichmentLicence} from '@/lib/enrichment-licence';
-import {UserTypeOption, typeMapping} from './type-mapping';
+import {UserTypeOption, typeMapping} from '@/lib/provenance-options';
+import {getTranslations} from 'next-intl/server';
 
 interface AddProvenanceEnrichmentProps {
   citation: string;
@@ -16,7 +17,7 @@ interface AddProvenanceEnrichmentProps {
   };
   type: {
     id: string;
-    name: string;
+    translationKey: string;
   };
   date: {
     startDate: string;
@@ -40,7 +41,7 @@ interface AddProvenanceEnrichmentProps {
   };
   qualifier: {
     id: string;
-    name: string;
+    translationKey: string;
   };
 }
 
@@ -57,6 +58,16 @@ export async function addProvenanceEnrichment({
   community,
   qualifier,
 }: AddProvenanceEnrichmentProps) {
+  const tEnQualifier = await getTranslations({
+    locale: 'en',
+    namespace: 'QualifierSelector',
+  });
+
+  const tEnType = await getTranslations({
+    locale: 'en',
+    namespace: 'ProvenanceEventType',
+  });
+
   const enrichment = await creator.addProvenanceEvent({
     citation,
     inLanguage,
@@ -72,13 +83,18 @@ export async function addProvenanceEnrichment({
     type: typeMapping[type.id as UserTypeOption].type,
     additionalType: {
       id: typeMapping[type.id as UserTypeOption].additionalType,
-      name: type.name,
+      name: tEnType(type.translationKey),
     },
     date,
     transferredFrom: transferredFrom.id ? transferredFrom : undefined,
     transferredTo: transferredTo.id ? transferredTo : undefined,
     location: location.id ? location : undefined,
-    qualifier: qualifier.id ? qualifier : undefined,
+    qualifier: qualifier.id
+      ? {
+          id: qualifier.id,
+          name: tEnQualifier(qualifier.translationKey),
+        }
+      : undefined,
   });
 
   revalidatePath(`/[locale]/objects/${encodeRouteSegment(objectId)}`, 'page');

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/add-form.tsx
@@ -40,7 +40,7 @@ import {DefaultButton, PrimaryButton} from '@/components/buttons';
 import {ExclamationTriangleIcon} from '@heroicons/react/24/outline';
 import {CheckboxWithLabel} from '@/components/form/checkbox-with-label';
 import {addProvenanceEnrichment} from './actions';
-import {UserTypeOption, typeMapping} from './type-mapping';
+import {UserTypeOption, typeMapping} from '@/lib/provenance-options';
 
 interface FormValues {
   attributionId: string;
@@ -49,9 +49,9 @@ interface FormValues {
   transferredFrom: {id: string; name: string};
   transferredTo: {id: string; name: string};
   location: {id: string; name: string};
-  type: {id: string; name: string};
+  type: {id: string; translationKey: string};
   community: {id: string; name: string};
-  qualifier: {id: string; name: string};
+  qualifier: {id: string; translationKey: string};
   date: {
     startDate: string;
     endDate: string;
@@ -94,7 +94,7 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
       id: z.nativeEnum(UserTypeOption, {
         errorMap: () => ({message: t('typeRequired')}),
       }),
-      name: z.string(),
+      translationKey: z.string(),
     }),
     date: z
       .object({
@@ -137,7 +137,7 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
     }),
     qualifier: z.object({
       id: z.string(),
-      name: z.string(),
+      translationKey: z.string(),
     }),
   });
 
@@ -151,12 +151,12 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
       citation: '',
       inLanguage: locale,
       agreedToLicense: false,
-      type: {id: '', name: ''},
+      type: {id: '', translationKey: ''},
       transferredFrom: {id: '', name: ''},
       transferredTo: {id: '', name: ''},
       location: {id: '', name: ''},
       community: {id: '', name: ''},
-      qualifier: {id: '', name: ''},
+      qualifier: {id: '', translationKey: ''},
       date: {startDate: '', endDate: ''},
     },
   });
@@ -170,6 +170,7 @@ export default function AddProvenanceForm({objectId, slideOutId}: Props) {
   const typeOptions = useMemo(() => {
     return Object.values(UserTypeOption).map(value => ({
       id: value,
+      translationKey: typeMapping[value].translationKey,
       name: tType(typeMapping[value].translationKey),
       description: tType(`${typeMapping[value].translationKey}Description`),
     }));

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/data-table.tsx
@@ -5,8 +5,9 @@ import type {LabeledProvenanceEvent} from './definitions';
 import {useTranslations} from 'next-intl';
 import {useProvenance} from './provenance-store';
 import {SelectEventsButton} from './buttons';
-import {XMarkIcon} from '@heroicons/react/24/outline';
+import {ExclamationTriangleIcon, XMarkIcon} from '@heroicons/react/24/outline';
 import {ProvidedBy} from './provided-by';
+import {qualifierOptions, typeMapping} from '@/lib/provenance-options';
 
 interface Props {
   organizationName?: string;
@@ -71,6 +72,8 @@ function ProvenanceEventRow({
   organizationName,
 }: ProvenanceEventRowProps) {
   const t = useTranslations('Provenance');
+  const tQualifier = useTranslations('QualifierSelector');
+  const tType = useTranslations('ProvenanceEventType');
 
   return (
     <div className="flex flex-col md:flex-row gap-4 border-t">
@@ -99,9 +102,48 @@ function ProvenanceEventRow({
                   <strong>{event.transferredFrom?.name}</strong>
                 </div>
               )}
+              {event.type && (
+                <div>
+                  {t('type')}{' '}
+                  <strong>
+                    {event.additionalTypes
+                      ?.map(type => {
+                        const translationKey = Object.values(typeMapping).find(
+                          mapping =>
+                            mapping.type === event.type &&
+                            mapping.additionalType === type.id
+                        )?.translationKey;
+
+                        const name = translationKey
+                          ? tType(translationKey)
+                          : type.name;
+                        return name;
+                      })
+                      .join(', ')}
+                  </strong>
+                </div>
+              )}
               {event.location && (
                 <div>
                   {t('location')} <strong>{event.location.name}</strong>
+                </div>
+              )}
+              {'qualifier' in event && event.qualifier && (
+                <div className="text-sm text-neutral-600 flex items-center gap-1 italic mt-1">
+                  <ExclamationTriangleIcon className="w-4 h-4 stroke-neutral-600" />
+                  {t.rich('qualifier', {
+                    qualifier: () => {
+                      const translationKey = qualifierOptions.find(
+                        qualifier => qualifier.id === event.qualifier!.id
+                      )?.translationKey;
+
+                      const name = translationKey
+                        ? tQualifier(translationKey)
+                        : event.qualifier!.name;
+
+                      return <strong>{name}</strong>;
+                    },
+                  })}
                 </div>
               )}
               {event.description && (

--- a/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/definitions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/(provenance)/definitions.ts
@@ -13,8 +13,3 @@ export type TimelineEvent = {
   selectIds: string[];
   labels: string[];
 };
-
-export enum ProvenanceEventType {
-  Acquisition = 'acquisition',
-  TransferOfCustody = 'transferOfCustody',
-}

--- a/apps/researcher/src/components/form/qualifier-selector.tsx
+++ b/apps/researcher/src/components/form/qualifier-selector.tsx
@@ -2,11 +2,7 @@
 
 import {useController, useFormContext} from 'react-hook-form';
 import {useTranslations} from 'next-intl';
-
-const options = [
-  {translationKey: 'possibly', id: 'http://vocab.getty.edu/aat/300435722'},
-  {translationKey: 'probably', id: 'http://vocab.getty.edu/aat/300435721'},
-];
+import {qualifierOptions} from '@/lib/provenance-options';
 
 interface Props extends React.HTMLProps<HTMLInputElement> {
   name: string;
@@ -21,15 +17,16 @@ export function QualifierSelector({name}: Props) {
 
   return (
     <>
-      {options.map(option => (
+      {qualifierOptions.map(option => (
         <div key={option.id} className="flex gap-2">
           <input
+            id={option.translationKey}
             type="checkbox"
             checked={controller.field.value.id === option.id}
             onChange={event =>
               event.target.checked
                 ? controller.field.onChange(option)
-                : controller.field.onChange({id: '', name: ''})
+                : controller.field.onChange({id: '', translationKey: ''})
             }
             onBlur={controller.field.onBlur}
           />

--- a/apps/researcher/src/lib/provenance-options.ts
+++ b/apps/researcher/src/lib/provenance-options.ts
@@ -74,3 +74,8 @@ export const typeMapping = {
     translationKey: 'confiscated',
   },
 };
+
+export const qualifierOptions = [
+  {translationKey: 'possibly', id: 'http://vocab.getty.edu/aat/300435722'},
+  {translationKey: 'probably', id: 'http://vocab.getty.edu/aat/300435721'},
+];

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -148,6 +148,7 @@
     "transferredFrom": "Transferred from",
     "transferredTo": "Transferred to",
     "location": "Location",
+    "qualifier": "The provider qualified this information as <qualifier></qualifier>",
     "readMore": "Read more",
     "descriptionTitle": "Description",
     "noData": "No provenance events provided for this object.",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -149,6 +149,7 @@
     "transferredTo": "Overgedragen aan",
     "location": "Locatie",
     "descriptionTitle": "Beschrijving",
+    "qualifier": "De verstrekker heeft deze informatie gekwalificeerd als <qualifier></qualifier>",
     "readMore": "Lees meer",
     "noData": "Geen herkomstgegevens aangeleverd.",
     "dataTableTitle": "Herkomst data tabel",


### PR DESCRIPTION
Translate the options to English on save. This can only be done in the server action, the frontend components cannot get translations in a different locale then the selected language.

Translate it back to the selected language in the data table. If the id is unknown use the saved name. This could happen if nanopubs are saved outside our application.