### PR TITLE
fix: allow empty start date or empty end date

### DIFF
--- a/packages/enricher/src/provenance-events/definitions.ts
+++ b/packages/enricher/src/provenance-events/definitions.ts
@@ -25,10 +25,11 @@ export const provenanceEventEnrichmentBeingCreatedSchema =
         .optional(),
       date: z
         .object({
-          startDate: z.string(),
-          endDate: z.string(),
+          startDate: z.string().optional(),
+          endDate: z.string().optional(),
         })
-        .optional(),
+        .optional()
+        .refine(date => date === undefined || date.startDate || date.endDate), // `startDate` or `endDate` or both must be provided
       transferredFrom: z
         .object({
           id: z.string().url(),

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -11,8 +11,56 @@ const nanopubClient = new NanopubClient({
 
 const storer = new ProvenanceEventEnrichmentStorer({nanopubClient});
 
-describe('add', () => {
-  it('adds a basic acquisition event, with only required properties', async () => {
+describe('add event', () => {
+  it('adds an event with only a start date', async () => {
+    const enrichment = await storer.add({
+      type: ProvenanceEventType.Acquisition,
+      about: {
+        id: 'http://example.org/object1',
+      },
+      date: {
+        startDate: '1805',
+      },
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds an event with only an end date', async () => {
+    const enrichment = await storer.add({
+      type: ProvenanceEventType.Acquisition,
+      about: {
+        id: 'http://example.org/object1',
+      },
+      date: {
+        endDate: '1806',
+      },
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+});
+
+describe('add acquisition event', () => {
+  it('adds a basic event, with only required properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
       about: {
@@ -32,7 +80,7 @@ describe('add', () => {
     });
   });
 
-  it('adds a full acquisition event, with all properties', async () => {
+  it('adds a full event, with all properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
       additionalType: {
@@ -83,8 +131,10 @@ describe('add', () => {
       id: expect.stringContaining('https://'),
     });
   });
+});
 
-  it('adds a basic transfer of custody event, with only required properties', async () => {
+describe('add transfer of custody event', () => {
+  it('adds a basic event, with only required properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.TransferOfCustody,
       about: {
@@ -104,7 +154,7 @@ describe('add', () => {
     });
   });
 
-  it('adds a full transfer of custody event, with all properties', async () => {
+  it('adds a full event, with all properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.TransferOfCustody,
       additionalType: {

--- a/packages/enricher/src/provenance-events/storer.ts
+++ b/packages/enricher/src/provenance-events/storer.ts
@@ -348,29 +348,33 @@ export class ProvenanceEventEnrichmentStorer {
         )
       );
 
-      const startDate = getDateAsXsd(opts.date.startDate, DateType.StartDate);
+      if (opts.date.startDate !== undefined) {
+        const startDate = getDateAsXsd(opts.date.startDate, DateType.StartDate);
 
-      assertionStore.addQuad(
-        DF.quad(
-          timeSpanId,
-          DF.namedNode(
-            'http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin'
-          ),
-          DF.literal(startDate, dateId)
-        )
-      );
+        assertionStore.addQuad(
+          DF.quad(
+            timeSpanId,
+            DF.namedNode(
+              'http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin'
+            ),
+            DF.literal(startDate, dateId)
+          )
+        );
+      }
 
-      const endDate = getDateAsXsd(opts.date.endDate, DateType.EndDate);
+      if (opts.date.endDate !== undefined) {
+        const endDate = getDateAsXsd(opts.date.endDate, DateType.EndDate);
 
-      assertionStore.addQuad(
-        DF.quad(
-          timeSpanId,
-          DF.namedNode(
-            'http://www.cidoc-crm.org/cidoc-crm/P82b_end_of_the_end'
-          ),
-          DF.literal(endDate, dateId)
-        )
-      );
+        assertionStore.addQuad(
+          DF.quad(
+            timeSpanId,
+            DF.namedNode(
+              'http://www.cidoc-crm.org/cidoc-crm/P82b_end_of_the_end'
+            ),
+            DF.literal(endDate, dateId)
+          )
+        );
+      }
 
       assertionStore.addQuad(
         DF.quad(


### PR DESCRIPTION
This PR updates the business rules of the `enricher` package: when adding a provenance event...

1. The event may have a `date`
2. If the event has a `date` then it must have a `startDate`, an `endDate` or both.