### PR TITLE
fix: broaden search results

### DIFF
--- a/apps/researcher/src/app/[locale]/api/geonames/route.ts
+++ b/apps/researcher/src/app/[locale]/api/geonames/route.ts
@@ -5,7 +5,6 @@ import {NextRequest} from 'next/server';
 import {env} from 'node:process';
 
 const geoNamesLocationSearcher = new GeoNamesLocationSearcher({
-  endpointUrl: 'http://api.geonames.org',
   username: env.GEONAMES_USERNAME as string,
 });
 

--- a/packages/api/src/enrichments/searcher-locations-geonames.integration.test.ts
+++ b/packages/api/src/enrichments/searcher-locations-geonames.integration.test.ts
@@ -6,7 +6,6 @@ let locationSearcher: GeoNamesLocationSearcher;
 
 beforeEach(() => {
   locationSearcher = new GeoNamesLocationSearcher({
-    endpointUrl: 'http://api.geonames.org',
     username: env.GEONAMES_USERNAME as string,
   });
 });
@@ -22,14 +21,14 @@ describe('search', () => {
     expect(result).toStrictEqual({
       things: [
         {
-          id: 'https://sws.geonames.org/5028921/',
+          id: 'https://sws.geonames.org/2755251/',
           name: 'Groningen',
-          description: 'Minnesota, VS',
+          description: 'Groningen, Nederland',
         },
         {
-          id: 'https://sws.geonames.org/2904901/',
-          name: 'Heynburg',
-          description: 'Saksen-Anhalt, Duitsland',
+          id: 'https://sws.geonames.org/6296685/',
+          name: 'Groningen Airport Eelde',
+          description: 'Drenthe, Nederland',
         },
         {
           id: 'https://sws.geonames.org/2755249/',
@@ -50,14 +49,14 @@ describe('search', () => {
     expect(result).toStrictEqual({
       things: [
         {
-          id: 'https://sws.geonames.org/5028921/',
+          id: 'https://sws.geonames.org/2755251/',
           name: 'Groningen',
-          description: 'Minnesota, United States',
+          description: 'Groningen, The Netherlands',
         },
         {
-          id: 'https://sws.geonames.org/2904901/',
-          name: 'Heynburg',
-          description: 'Saxony-Anhalt, Germany',
+          id: 'https://sws.geonames.org/6296685/',
+          name: 'Groningen Airport Eelde',
+          description: 'Drenthe, The Netherlands',
         },
         {
           id: 'https://sws.geonames.org/2755249/',

--- a/packages/api/src/enrichments/searcher-locations-geonames.ts
+++ b/packages/api/src/enrichments/searcher-locations-geonames.ts
@@ -3,11 +3,11 @@ import {Thing} from '../definitions';
 import {z} from 'zod';
 
 const constructorOptionsSchema = z.object({
-  endpointUrl: z.string(),
+  endpointUrl: z.string().optional().default('http://api.geonames.org'),
   username: z.string(),
 });
 
-export type GeoNamesLocationSearcherConstructorOptions = z.infer<
+export type GeoNamesLocationSearcherConstructorOptions = z.input<
   typeof constructorOptionsSchema
 >;
 
@@ -24,6 +24,7 @@ const rawSearchResponseSchema = z.object({
 
 type RawSearchResponse = z.infer<typeof rawSearchResponseSchema>;
 
+// Docs: http://www.geonames.org/export/geonames-search.html
 export class GeoNamesLocationSearcher {
   private readonly endpointUrl: string;
   private readonly username: string;
@@ -36,16 +37,15 @@ export class GeoNamesLocationSearcher {
   }
 
   private buildRequest(options: SearchOptions) {
+    // If the precision of the results is too low, we could limit the
+    // results to specific feature codes: https://www.geonames.org/export/codes.html
     const searchParams: [string, string][] = [
       ['username', this.username],
       ['name_startsWith', options.query],
       ['maxRows', options.limit!.toString()],
       ['lang', options.locale!],
-      ['featureCode', 'CONT'], // Continent
-      ['featureCode', 'RGN'], // Region
-      ['featureCode', 'ADM1'], // First-order administrative division, e.g. country, state
-      ['featureCode', 'PPL'], // Populated place
       ['type', 'json'],
+      ['orderby', 'relevance'],
     ];
 
     const urlSearchParams = new URLSearchParams(searchParams);


### PR DESCRIPTION
This PR changes the way that we search in GeoNames: rather than limiting the results to specific feature codes (e.g. places, countries, administrative divisions), we now search for all types of geographical entities. This could result in a low precision, though. If that's the case we can revisit the use of feature codes.