### PR TITLE
fix: data model for storing and retrieving the community of a user

### DIFF
--- a/packages/enricher/src/client.integration.test.ts
+++ b/packages/enricher/src/client.integration.test.ts
@@ -34,7 +34,14 @@ describe('add', () => {
     const nanopub = await nanopubClient.add({
       assertionStore,
       publicationStore,
-      creator: 'http://example.com/person',
+      creator: {
+        id: 'http://example.com/person',
+        name: 'Name of person',
+        isPartOf: {
+          id: 'http://example.com/community',
+          name: 'Name of community',
+        },
+      },
     });
 
     expect(nanopub).toEqual({

--- a/packages/enricher/src/client.ts
+++ b/packages/enricher/src/client.ts
@@ -7,13 +7,13 @@ import {z} from 'zod';
 
 const DF = new DataFactory();
 
-export const nanopubIri = 'http://purl.org/nanopub/temp/temp-nanopub-id/';
-export const nanopubId = DF.namedNode(nanopubIri);
+export const nanopubTempIri = 'http://purl.org/nanopub/temp/temp-nanopub-id/';
+export const nanopubId = DF.namedNode(nanopubTempIri);
 
-const headGraph = DF.namedNode(`${nanopubIri}Head`);
-const publicationGraph = DF.namedNode(`${nanopubIri}pubinfo`);
-const assertionGraph = DF.namedNode(`${nanopubIri}assertion`);
-const provenanceGraph = DF.namedNode(`${nanopubIri}provenance`);
+const headGraph = DF.namedNode(`${nanopubTempIri}Head`);
+const publicationGraph = DF.namedNode(`${nanopubTempIri}pubinfo`);
+const assertionGraph = DF.namedNode(`${nanopubTempIri}assertion`);
+const provenanceGraph = DF.namedNode(`${nanopubTempIri}provenance`);
 
 const constructorOptionsSchema = z.object({
   endpointUrl: z.string(),
@@ -27,7 +27,14 @@ export type NanopubClientConstructorOptions = z.infer<
 const addOptionsSchema = z.object({
   assertionStore: z.instanceof(RdfStore<number>),
   publicationStore: z.instanceof(RdfStore<number>),
-  creator: z.string().url(),
+  creator: z.object({
+    id: z.string().url(),
+    name: z.string(),
+    isPartOf: z.object({
+      id: z.string().url(),
+      name: z.string(),
+    }),
+  }),
 });
 
 export type AddOptions = z.infer<typeof addOptionsSchema>;
@@ -138,11 +145,90 @@ export class NanopubClient {
     );
 
     // Provenance graph
+    const assertingActivityNode = DF.namedNode(
+      `${nanopubTempIri}asserting-activity`
+    );
+    const qualifiedDelegationNode = DF.namedNode(`${nanopubTempIri}delegation`);
+    const userNode = DF.namedNode(opts.creator.id);
+    const communityNode = DF.namedNode(opts.creator.isPartOf.id);
+
+    primaryStore.addQuad(
+      DF.quad(
+        assertingActivityNode,
+        DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        DF.namedNode('http://www.w3.org/ns/prov#Activity'),
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        assertionGraph,
+        DF.namedNode('http://www.w3.org/ns/prov#wasGeneratedBy'),
+        assertingActivityNode,
+        provenanceGraph
+      )
+    );
     primaryStore.addQuad(
       DF.quad(
         assertionGraph,
         DF.namedNode('http://www.w3.org/ns/prov#wasAttributedTo'),
-        DF.namedNode(opts.creator),
+        userNode,
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        userNode,
+        DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+        DF.literal(opts.creator.name),
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        userNode,
+        DF.namedNode('http://www.w3.org/ns/prov#actedOnBehalfOf'),
+        communityNode,
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        userNode,
+        DF.namedNode('http://www.w3.org/ns/prov#qualifiedDelegation'),
+        qualifiedDelegationNode,
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        qualifiedDelegationNode,
+        DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        DF.namedNode('http://www.w3.org/ns/prov#Delegation'),
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        qualifiedDelegationNode,
+        DF.namedNode('http://www.w3.org/ns/prov#agent'),
+        communityNode,
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        qualifiedDelegationNode,
+        DF.namedNode('http://www.w3.org/ns/prov#hadActivity'),
+        assertingActivityNode,
+        provenanceGraph
+      )
+    );
+    primaryStore.addQuad(
+      DF.quad(
+        communityNode,
+        DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+        DF.literal(opts.creator.isPartOf.name),
         provenanceGraph
       )
     );
@@ -164,7 +250,7 @@ export class NanopubClient {
     });
 
     const nanopubIri = await this.save({
-      creator: opts.creator,
+      creator: opts.creator.id,
       store: primaryStore,
     });
 

--- a/packages/enricher/src/creator.integration.test.ts
+++ b/packages/enricher/src/creator.integration.test.ts
@@ -18,7 +18,25 @@ const creator = new EnrichmentCreator({
 });
 
 describe('addText', () => {
-  it('adds a textual enrichment', async () => {
+  it('adds a basic textual enrichment, with only required properties', async () => {
+    const enrichment = await creator.addText({
+      type: HeritageObjectEnrichmentType.Name,
+      about: 'http://example.org/object',
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds a full textual enrichment, with all properties', async () => {
     const enrichment = await creator.addText({
       type: HeritageObjectEnrichmentType.Name,
       description: 'A comment about the name of an object',
@@ -45,7 +63,25 @@ describe('addText', () => {
 });
 
 describe('addProvenanceEvent', () => {
-  it('adds a provenance event enrichment', async () => {
+  it('adds a basic provenance event enrichment, with only required properties', async () => {
+    const enrichment = await creator.addProvenanceEvent({
+      type: ProvenanceEventType.Acquisition,
+      about: 'http://example.org/object',
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds a full provenance event enrichment, with all properties', async () => {
     const enrichment = await creator.addProvenanceEvent({
       type: ProvenanceEventType.Acquisition,
       additionalType: {

--- a/packages/enricher/src/definitions.ts
+++ b/packages/enricher/src/definitions.ts
@@ -7,6 +7,18 @@ export const ontologyUrl =
 // We currently have just one version of our ontology
 export const ontologyVersionIdentifier = 'Version1';
 
+export const creatorSchema = z.object({
+  id: z.string().url(),
+  name: z.string(),
+  // The group the creator speaks on behalf of
+  isPartOf: z
+    .object({
+      id: z.string().url(),
+      name: z.string(),
+    })
+    .optional(),
+});
+
 export type BasicEnrichment = {
   id: string;
 };
@@ -17,15 +29,7 @@ export const basicEnrichmentBeingCreatedSchema = z.object({
   inLanguage: z.string().optional(), // E.g. 'en', 'nl-nl'
   about: z.string().url(),
   pubInfo: z.object({
-    creator: z.object({
-      id: z.string().url(),
-      name: z.string(),
-      // The community the creator speaks on behalf of
-      isPartOf: z.object({
-        id: z.string().url(),
-        name: z.string(),
-      }),
-    }),
+    creator: creatorSchema,
     license: z.string().url(),
   }),
 });

--- a/packages/enricher/src/definitions.ts
+++ b/packages/enricher/src/definitions.ts
@@ -20,12 +20,11 @@ export const basicEnrichmentBeingCreatedSchema = z.object({
     creator: z.object({
       id: z.string().url(),
       name: z.string(),
-      isPartOf: z
-        .object({
-          id: z.string().url(),
-          name: z.string(),
-        })
-        .optional(),
+      // The community the creator speaks on behalf of
+      isPartOf: z.object({
+        id: z.string().url(),
+        name: z.string(),
+      }),
     }),
     license: z.string().url(),
   }),

--- a/packages/enricher/src/objects/fetcher.integration.test.ts
+++ b/packages/enricher/src/objects/fetcher.integration.test.ts
@@ -50,8 +50,8 @@ beforeAll(async () => {
     about: resourceId,
     pubInfo: {
       creator: {
-        id: 'http://example.com/person2',
-        name: 'Person 2',
+        id: 'http://example.com/person1',
+        name: 'Person 1',
         isPartOf: {
           id: 'http://example.com/group2',
           name: 'Group 2',
@@ -110,8 +110,8 @@ describe('getById', () => {
         about: resourceId,
         pubInfo: {
           creator: {
-            id: 'http://example.com/person2',
-            name: 'Person 2',
+            id: 'http://example.com/person1',
+            name: 'Person 1',
             isPartOf: {
               id: 'http://example.com/group2',
               name: 'Group 2',

--- a/packages/enricher/src/objects/fetcher.integration.test.ts
+++ b/packages/enricher/src/objects/fetcher.integration.test.ts
@@ -3,66 +3,22 @@ import {EnrichmentCreator} from '../creator';
 import {HeritageObjectEnrichmentType} from './definitions';
 import {HeritageObjectEnrichmentFetcher} from './fetcher';
 import {beforeAll, describe, expect, it} from '@jest/globals';
+import {randomUUID} from 'node:crypto';
 import {env} from 'node:process';
 import {setTimeout} from 'node:timers/promises';
 
-const fetcher = new HeritageObjectEnrichmentFetcher({
-  endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,
+const nanopubClient = new NanopubClient({
+  endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
+  proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
 });
 
-const resourceId = `http://example.org/${Date.now()}`;
+const creator = new EnrichmentCreator({
+  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+  nanopubClient,
+});
 
-// Create some enrichments
-beforeAll(async () => {
-  const nanopubClient = new NanopubClient({
-    endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
-    proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
-  });
-
-  const creator = new EnrichmentCreator({
-    knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-    nanopubClient,
-  });
-
-  await creator.addText({
-    type: HeritageObjectEnrichmentType.Name,
-    description: 'Comment about the name of the resource',
-    citation: 'A citation or reference to a work that supports the comment',
-    inLanguage: 'en-gb',
-    about: resourceId,
-    pubInfo: {
-      creator: {
-        id: 'http://example.com/person1',
-        name: 'Person 1',
-        isPartOf: {
-          id: 'http://example.com/group1',
-          name: 'Group 1',
-        },
-      },
-      license: 'https://creativecommons.org/licenses/by/4.0/',
-    },
-  });
-
-  await creator.addText({
-    type: HeritageObjectEnrichmentType.Description,
-    description: 'Comment about the description of the resource',
-    citation: 'A citation or reference to a work that supports the comment',
-    about: resourceId,
-    pubInfo: {
-      creator: {
-        id: 'http://example.com/person1',
-        name: 'Person 1',
-        isPartOf: {
-          id: 'http://example.com/group2',
-          name: 'Group 2',
-        },
-      },
-      license: 'https://creativecommons.org/licenses/by/4.0/',
-    },
-  });
-
-  // Wait a bit: storing the nanopubs takes some time
-  await setTimeout(2000);
+const fetcher = new HeritageObjectEnrichmentFetcher({
+  endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,
 });
 
 describe('getById', () => {
@@ -76,6 +32,120 @@ describe('getById', () => {
     const enrichments = await fetcher.getById('http://example.org/unknown');
 
     expect(enrichments).toEqual([]);
+  });
+});
+
+describe('getById - basic enrichments, with only required properties', () => {
+  const resourceId = `http://example.org/${randomUUID()}`;
+
+  // Create some enrichments
+  beforeAll(async () => {
+    await creator.addText({
+      type: HeritageObjectEnrichmentType.Name,
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    await creator.addText({
+      type: HeritageObjectEnrichmentType.Description,
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    // Wait a bit: storing the nanopubs takes some time
+    await setTimeout(2000);
+  });
+
+  it('gets the enrichments of a resource', async () => {
+    const enrichments = await fetcher.getById(resourceId);
+
+    expect(enrichments).toStrictEqual([
+      {
+        id: expect.stringContaining('https://'),
+        type: HeritageObjectEnrichmentType.Name,
+        about: resourceId,
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person1',
+            name: 'Person 1',
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+          dateCreated: expect.any(Date),
+        },
+      },
+      {
+        id: expect.stringContaining('https://'),
+        type: HeritageObjectEnrichmentType.Description,
+        about: resourceId,
+        pubInfo: {
+          creator: {
+            id: 'http://example.com/person1',
+            name: 'Person 1',
+          },
+          license: 'https://creativecommons.org/licenses/by/4.0/',
+          dateCreated: expect.any(Date),
+        },
+      },
+    ]);
+  });
+});
+
+describe('getById - full enrichments, with all properties', () => {
+  const resourceId = `http://example.org/${randomUUID()}`;
+
+  // Create some enrichments
+  beforeAll(async () => {
+    await creator.addText({
+      type: HeritageObjectEnrichmentType.Name,
+      description: 'Comment about the name of the resource',
+      citation: 'A citation or reference to a work that supports the comment',
+      inLanguage: 'en-gb',
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+          isPartOf: {
+            id: 'http://example.com/group1',
+            name: 'Group 1',
+          },
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    await creator.addText({
+      type: HeritageObjectEnrichmentType.Description,
+      description: 'Comment about the description of the resource',
+      citation: 'A citation or reference to a work that supports the comment',
+      about: resourceId,
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+          isPartOf: {
+            id: 'http://example.com/group2',
+            name: 'Group 2',
+          },
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    // Wait a bit: storing the nanopubs takes some time
+    await setTimeout(2000);
   });
 
   it('gets the enrichments of a resource', async () => {

--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -88,26 +88,34 @@ export class HeritageObjectEnrichmentFetcher {
 
         graph ?provenance {
           ?assertion prov:wasAttributedTo ?creator .
+          ?creator rdfs:label ?creatorName .
 
-          ?creator rdfs:label ?creatorName ;
-            prov:qualifiedDelegation [ prov:agent ?group ] .
-
-          ?group rdfs:label ?groupName .
+          OPTIONAL {
+            ?creator prov:qualifiedDelegation [
+              prov:agent ?group
+            ] .
+            ?group rdfs:label ?groupName
+          }
         }
 
         graph ?assertion {
           ?annotation a oa:Annotation ;
-            rdfs:comment ?comment ;
-            oa:hasBody ?body ;
-            oa:hasTarget ?target .
-
-          ?body rdf:value ?value .
-          OPTIONAL {
-            ?body dc:language ?language .
-          }
+             oa:hasTarget ?target .
 
           ?target a oa:SpecificResource ;
-            oa:hasSource ?source .
+             oa:hasSource ?source .
+
+          OPTIONAL {
+            ?annotation rdfs:comment ?comment
+          }
+
+          OPTIONAL {
+            ?annotation oa:hasBody ?body .
+            ?body rdf:value ?value .
+            OPTIONAL {
+              ?body dc:language ?language .
+            }
+         }
         }
       }
     `;

--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -54,11 +54,11 @@ export class HeritageObjectEnrichmentFetcher {
           ex:inLanguage ?language ;
           ex:license ?license ;
           ex:creator ?creator ;
+          ex:createdOnBehalfOf ?group ;
           ex:dateCreated ?dateCreated .
 
         ?creator a ex:Actor ;
-          ex:name ?creatorName ;
-          ex:isPartOf ?group .
+          ex:name ?creatorName .
 
         ?group a ex:Actor ;
           ex:name ?groupName .

--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -67,30 +67,32 @@ export class HeritageObjectEnrichmentFetcher {
         BIND(<${iri}> AS ?source)
 
         graph npa:graph {
-          ?np npa:hasHeadGraph ?head .
-          ?np dcterms:created ?dateCreated .
+          ?np npa:hasHeadGraph ?head ;
+            dcterms:created ?dateCreated .
         }
 
         graph ?head {
-          ?np np:hasProvenance ?provenance .
-          ?np np:hasPublicationInfo ?pubInfo .
+          ?np np:hasProvenance ?provenance ;
+            np:hasPublicationInfo ?pubInfo ;
+            np:hasAssertion ?assertion .
         }
 
         graph ?pubInfo {
           ?np a cc:Nanopub ;
             npx:introduces ?annotation ;
-            dcterms:creator ?creator ;
             dcterms:license ?license .
-
-          ?creator rdfs:label ?creatorName .
-
-          OPTIONAL {
-            ?creator dcterms:isPartOf ?group .
-            ?group rdfs:label ?groupName
-          }
 
           ?np a ?additionalType
           FILTER(?additionalType != cc:Nanopub)
+        }
+
+        graph ?provenance {
+          ?assertion prov:wasAttributedTo ?creator .
+
+          ?creator rdfs:label ?creatorName ;
+            prov:qualifiedDelegation [ prov:agent ?group ] .
+
+          ?group rdfs:label ?groupName .
         }
 
         graph ?assertion {

--- a/packages/enricher/src/objects/rdf-helpers.ts
+++ b/packages/enricher/src/objects/rdf-helpers.ts
@@ -13,11 +13,15 @@ export function toHeritageObjectEnrichment(rawEnrichment: Resource) {
   const additionalType = getPropertyValue(rawEnrichment, 'ex:additionalType');
   const about = getPropertyValue(rawEnrichment, 'ex:isPartOf')!;
   const creator = onlyOne(createActors(rawEnrichment, 'ex:creator'))!;
+  const group = onlyOne(createActors(rawEnrichment, 'ex:createdOnBehalfOf'));
   const license = getPropertyValue(rawEnrichment, 'ex:license')!;
   const dateCreated = onlyOne(createDates(rawEnrichment, 'ex:dateCreated'))!;
   const citation = getPropertyValue(rawEnrichment, 'ex:citation');
   const description = getPropertyValue(rawEnrichment, 'ex:description');
   const inLanguage = getPropertyValue(rawEnrichment, 'ex:inLanguage');
+
+  const creatorWithGroup =
+    group !== undefined ? {...creator, ...{isPartOf: group}} : creator;
 
   const enrichment: HeritageObjectEnrichment = {
     id: rawEnrichment.value,
@@ -27,7 +31,7 @@ export function toHeritageObjectEnrichment(rawEnrichment: Resource) {
     description,
     inLanguage,
     pubInfo: {
-      creator,
+      creator: creatorWithGroup,
       license,
       dateCreated,
     },

--- a/packages/enricher/src/objects/storer.integration.test.ts
+++ b/packages/enricher/src/objects/storer.integration.test.ts
@@ -29,8 +29,8 @@ describe('add', () => {
           id: 'http://example.com/person',
           name: 'Person',
           isPartOf: {
-            id: 'http://example.com/community',
-            name: 'Community',
+            id: 'http://example.com/group',
+            name: 'Group',
           },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',

--- a/packages/enricher/src/objects/storer.integration.test.ts
+++ b/packages/enricher/src/objects/storer.integration.test.ts
@@ -12,7 +12,30 @@ const nanopubClient = new NanopubClient({
 const storer = new HeritageObjectEnrichmentStorer({nanopubClient});
 
 describe('add', () => {
-  it('adds a textual enrichment', async () => {
+  it('adds a basic textual enrichment, with only required properties', async () => {
+    const enrichment = await storer.addText({
+      type: HeritageObjectEnrichmentType.Name,
+      about: {
+        id: 'http://example.org/object#name',
+        isPartOf: {
+          id: 'http://example.org/object',
+        },
+      },
+      pubInfo: {
+        creator: {
+          id: 'http://example.com/person',
+          name: 'Person',
+        },
+        license: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+    });
+
+    expect(enrichment).toEqual({
+      id: expect.stringContaining('https://'),
+    });
+  });
+
+  it('adds a full textual enrichment, with all properties', async () => {
     const enrichment = await storer.addText({
       type: HeritageObjectEnrichmentType.Name,
       description: 'A comment about the name of an object',

--- a/packages/enricher/src/objects/storer.ts
+++ b/packages/enricher/src/objects/storer.ts
@@ -107,39 +107,6 @@ export class HeritageObjectEnrichmentStorer {
       )
     );
 
-    // The server automatically adds 'dcterms:creator'.
-    // A creator can change his or her name later on, but the name at the time of
-    // creation is preserved.
-    const creatorId = DF.namedNode(opts.pubInfo.creator.id);
-
-    publicationStore.addQuad(
-      DF.quad(
-        creatorId,
-        DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
-        DF.literal(opts.pubInfo.creator.name)
-      )
-    );
-
-    if (opts.pubInfo.creator.isPartOf !== undefined) {
-      const groupId = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
-
-      publicationStore.addQuad(
-        DF.quad(
-          creatorId,
-          DF.namedNode('http://purl.org/dc/terms/isPartOf'),
-          groupId
-        )
-      );
-
-      publicationStore.addQuad(
-        DF.quad(
-          groupId,
-          DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
-          DF.literal(opts.pubInfo.creator.isPartOf.name)
-        )
-      );
-    }
-
     assertionStore.addQuad(
       DF.quad(
         enrichmentId,
@@ -238,7 +205,7 @@ export class HeritageObjectEnrichmentStorer {
     const nanopub = await this.nanopubClient.add({
       assertionStore,
       publicationStore,
-      creator: opts.pubInfo.creator.id,
+      creator: opts.pubInfo.creator,
     });
 
     const basicEnrichment: BasicEnrichment = {

--- a/packages/enricher/src/objects/storer.ts
+++ b/packages/enricher/src/objects/storer.ts
@@ -167,7 +167,7 @@ export class HeritageObjectEnrichmentStorer {
     if (opts.citation !== undefined) {
       assertionStore.addQuad(
         DF.quad(
-          enrichmentId,
+          bodyId,
           DF.namedNode('http://www.w3.org/2000/01/rdf-schema#comment'),
           DF.literal(opts.citation, languageCode)
         )

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -46,6 +46,10 @@ describe('getById - basic enrichments, with only required properties', () => {
         creator: {
           id: 'http://example.com/person1',
           name: 'Person 1',
+          isPartOf: {
+            id: 'http://example.com/group1',
+            name: 'Group 1',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -56,8 +60,12 @@ describe('getById - basic enrichments, with only required properties', () => {
       about: resourceId,
       pubInfo: {
         creator: {
-          id: 'http://example.com/person2',
-          name: 'Person 2',
+          id: 'http://example.com/person1',
+          name: 'Person 1',
+          isPartOf: {
+            id: 'http://example.com/group2',
+            name: 'Group 2',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -80,6 +88,10 @@ describe('getById - basic enrichments, with only required properties', () => {
             creator: {
               id: 'http://example.com/person1',
               name: 'Person 1',
+              isPartOf: {
+                id: 'http://example.com/group1',
+                name: 'Group 1',
+              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),
@@ -91,8 +103,12 @@ describe('getById - basic enrichments, with only required properties', () => {
           about: resourceId,
           pubInfo: {
             creator: {
-              id: 'http://example.com/person2',
-              name: 'Person 2',
+              id: 'http://example.com/person1',
+              name: 'Person 1',
+              isPartOf: {
+                id: 'http://example.com/group2',
+                name: 'Group 2',
+              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -211,8 +211,8 @@ describe('getById - full enrichments, with all properties', () => {
       about: resourceId,
       pubInfo: {
         creator: {
-          id: 'http://example.com/person2',
-          name: 'Person 2',
+          id: 'http://example.com/person1',
+          name: 'Person 1',
           isPartOf: {
             id: 'http://example.com/group2',
             name: 'Group 2',
@@ -316,8 +316,8 @@ describe('getById - full enrichments, with all properties', () => {
           },
           pubInfo: {
             creator: {
-              id: 'http://example.com/person2',
-              name: 'Person 2',
+              id: 'http://example.com/person1',
+              name: 'Person 1',
               isPartOf: {
                 id: 'http://example.com/group2',
                 name: 'Group 2',

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -3,8 +3,19 @@ import {EnrichmentCreator} from '../creator';
 import {ProvenanceEventType} from './definitions';
 import {ProvenanceEventEnrichmentFetcher} from './fetcher';
 import {beforeAll, describe, expect, it} from '@jest/globals';
+import {randomUUID} from 'node:crypto';
 import {env} from 'node:process';
 import {setTimeout} from 'node:timers/promises';
+
+const nanopubClient = new NanopubClient({
+  endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
+  proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
+});
+
+const creator = new EnrichmentCreator({
+  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+  nanopubClient,
+});
 
 const fetcher = new ProvenanceEventEnrichmentFetcher({
   endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,
@@ -25,20 +36,10 @@ describe('getById', () => {
 });
 
 describe('getById - basic enrichments, with only required properties', () => {
-  const resourceId = `http://example.org/${Date.now()}`;
+  const resourceId = `http://example.org/${randomUUID()}`;
 
   // Create some enrichments
   beforeAll(async () => {
-    const nanopubClient = new NanopubClient({
-      endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
-      proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
-    });
-
-    const creator = new EnrichmentCreator({
-      knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-      nanopubClient,
-    });
-
     await creator.addProvenanceEvent({
       type: ProvenanceEventType.Acquisition,
       about: resourceId,
@@ -46,10 +47,6 @@ describe('getById - basic enrichments, with only required properties', () => {
         creator: {
           id: 'http://example.com/person1',
           name: 'Person 1',
-          isPartOf: {
-            id: 'http://example.com/group1',
-            name: 'Group 1',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -62,10 +59,6 @@ describe('getById - basic enrichments, with only required properties', () => {
         creator: {
           id: 'http://example.com/person1',
           name: 'Person 1',
-          isPartOf: {
-            id: 'http://example.com/group2',
-            name: 'Group 2',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -88,10 +81,6 @@ describe('getById - basic enrichments, with only required properties', () => {
             creator: {
               id: 'http://example.com/person1',
               name: 'Person 1',
-              isPartOf: {
-                id: 'http://example.com/group1',
-                name: 'Group 1',
-              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),
@@ -105,10 +94,6 @@ describe('getById - basic enrichments, with only required properties', () => {
             creator: {
               id: 'http://example.com/person1',
               name: 'Person 1',
-              isPartOf: {
-                id: 'http://example.com/group2',
-                name: 'Group 2',
-              },
             },
             license: 'https://creativecommons.org/licenses/by/4.0/',
             dateCreated: expect.any(Date),
@@ -120,20 +105,10 @@ describe('getById - basic enrichments, with only required properties', () => {
 });
 
 describe('getById - full enrichments, with all properties', () => {
-  const resourceId = `http://example.org/${Date.now()}`;
+  const resourceId = `http://example.org/${randomUUID()}`;
 
   // Create some enrichments
   beforeAll(async () => {
-    const nanopubClient = new NanopubClient({
-      endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
-      proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
-    });
-
-    const creator = new EnrichmentCreator({
-      knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-      nanopubClient,
-    });
-
     await creator.addProvenanceEvent({
       type: ProvenanceEventType.Acquisition,
       additionalType: {

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -106,11 +106,14 @@ export class ProvenanceEventEnrichmentFetcher {
 
         graph ?provenance {
           ?assertion prov:wasAttributedTo ?creator .
+          ?creator rdfs:label ?creatorName .
 
-          ?creator rdfs:label ?creatorName ;
-            prov:qualifiedDelegation [ prov:agent ?group ] .
-
-          ?group rdfs:label ?groupName .
+          OPTIONAL {
+            ?creator prov:qualifiedDelegation [
+              prov:agent ?group
+            ] .
+            ?group rdfs:label ?groupName
+          }
         }
 
         graph ?assertion {

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -56,6 +56,7 @@ export class ProvenanceEventEnrichmentFetcher {
           ex:about ?source ;
           ex:license ?license ;
           ex:creator ?creator ;
+          ex:createdOnBehalfOf ?group ;
           ex:dateCreated ?dateCreated .
 
         ?additionalType a ex:DefinedTerm ;
@@ -78,8 +79,7 @@ export class ProvenanceEventEnrichmentFetcher {
           ex:name ?qualifierName .
 
         ?creator a ex:Actor ;
-          ex:name ?creatorName ;
-          ex:isPartOf ?group .
+          ex:name ?creatorName .
 
         ?group a ex:Actor ;
           ex:name ?groupName .
@@ -101,31 +101,26 @@ export class ProvenanceEventEnrichmentFetcher {
         graph ?pubInfo {
           ?np a cc:Nanopub ;
             npx:introduces ?attributeAssignment ;
-            dcterms:creator ?creator ;
             dcterms:license ?license .
         }
 
         graph ?provenance {
-          ?assertion prov:wasAttributedTo ?creator ;
-            prov:wasGeneratedBy ?assertingActivity .
+          ?assertion prov:wasAttributedTo ?creator .
 
           ?creator rdfs:label ?creatorName ;
-            prov:qualifiedDelegation ?delegation .
-
-          ?delegation prov:agent ?group ;
-            prov:hadActivity ?assertingActivity .
+            prov:qualifiedDelegation [ prov:agent ?group ] .
 
           ?group rdfs:label ?groupName .
         }
 
-        OPTIONAL {
-          ?attributeAssignment crm:P2_has_type ?qualifier .
-          ?qualifier rdfs:label ?qualifierName .
-        }
-
-        ?attributeAssignment crm:P141_assigned ?provenanceEvent .
-
         graph ?assertion {
+          ?attributeAssignment crm:P141_assigned ?provenanceEvent .
+
+          OPTIONAL {
+            ?attributeAssignment crm:P2_has_type ?qualifier .
+            ?qualifier rdfs:label ?qualifierName .
+          }
+
           {
             ?provenanceEvent a crm:E8_Acquisition ;
               crm:P24_transferred_title_of ?source .

--- a/packages/enricher/src/provenance-events/fetcher.ts
+++ b/packages/enricher/src/provenance-events/fetcher.ts
@@ -36,6 +36,7 @@ export class ProvenanceEventEnrichmentFetcher {
       PREFIX np: <http://www.nanopub.org/nschema#>
       PREFIX npa: <http://purl.org/nanopub/admin/>
       PREFIX npx: <http://purl.org/nanopub/x/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
       CONSTRUCT {
@@ -87,13 +88,14 @@ export class ProvenanceEventEnrichmentFetcher {
         BIND(<${iri}> AS ?source)
 
         graph npa:graph {
-          ?np npa:hasHeadGraph ?head .
-          ?np dcterms:created ?dateCreated .
+          ?np npa:hasHeadGraph ?head ;
+            dcterms:created ?dateCreated .
         }
 
         graph ?head {
-          ?np np:hasProvenance ?provenance .
-          ?np np:hasPublicationInfo ?pubInfo .
+          ?np np:hasProvenance ?provenance ;
+            np:hasPublicationInfo ?pubInfo ;
+            np:hasAssertion ?assertion .
         }
 
         graph ?pubInfo {
@@ -101,13 +103,19 @@ export class ProvenanceEventEnrichmentFetcher {
             npx:introduces ?attributeAssignment ;
             dcterms:creator ?creator ;
             dcterms:license ?license .
+        }
 
-          ?creator rdfs:label ?creatorName .
+        graph ?provenance {
+          ?assertion prov:wasAttributedTo ?creator ;
+            prov:wasGeneratedBy ?assertingActivity .
 
-          OPTIONAL {
-            ?creator dcterms:isPartOf ?group .
-            ?group rdfs:label ?groupName
-          }
+          ?creator rdfs:label ?creatorName ;
+            prov:qualifiedDelegation ?delegation .
+
+          ?delegation prov:agent ?group ;
+            prov:hadActivity ?assertingActivity .
+
+          ?group rdfs:label ?groupName .
         }
 
         OPTIONAL {

--- a/packages/enricher/src/provenance-events/rdf-helpers.ts
+++ b/packages/enricher/src/provenance-events/rdf-helpers.ts
@@ -21,6 +21,7 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
 
   const about = getPropertyValue(rawEnrichment, 'ex:about')!;
   const creator = onlyOne(createActors(rawEnrichment, 'ex:creator'))!;
+  const group = onlyOne(createActors(rawEnrichment, 'ex:createdOnBehalfOf'));
   const license = getPropertyValue(rawEnrichment, 'ex:license')!;
   const dateCreated = onlyOne(createDates(rawEnrichment, 'ex:dateCreated'))!;
   const citation = getPropertyValue(rawEnrichment, 'ex:citation');
@@ -40,6 +41,9 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
   );
   const qualifier = onlyOne(createThings<Term>(rawEnrichment, 'ex:qualifier'));
 
+  const creatorWithGroup =
+    group !== undefined ? {...creator, ...{isPartOf: group}} : creator;
+
   const enrichment: ProvenanceEventEnrichment = {
     id,
     type,
@@ -54,7 +58,7 @@ export function toProvenanceEventEnrichment(rawEnrichment: Resource) {
     transferredTo,
     date,
     pubInfo: {
-      creator,
+      creator: creatorWithGroup,
       license,
       dateCreated,
     },

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -25,10 +25,6 @@ describe('add event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
-          isPartOf: {
-            id: 'http://example.com/group',
-            name: 'Group',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -52,10 +48,6 @@ describe('add event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
-          isPartOf: {
-            id: 'http://example.com/group',
-            name: 'Group',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -78,10 +70,6 @@ describe('add acquisition event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
-          isPartOf: {
-            id: 'http://example.com/group',
-            name: 'Group',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -156,10 +144,6 @@ describe('add transfer of custody event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
-          isPartOf: {
-            id: 'http://example.com/group',
-            name: 'Group',
-          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -25,6 +25,10 @@ describe('add event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/group',
+            name: 'Group',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -48,6 +52,10 @@ describe('add event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/group',
+            name: 'Group',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -70,6 +78,10 @@ describe('add acquisition event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/group',
+            name: 'Group',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -119,8 +131,8 @@ describe('add acquisition event', () => {
           id: 'http://example.com/person',
           name: 'Person',
           isPartOf: {
-            id: 'http://example.com/community',
-            name: 'Community',
+            id: 'http://example.com/group',
+            name: 'Group',
           },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
@@ -144,6 +156,10 @@ describe('add transfer of custody event', () => {
         creator: {
           id: 'http://example.com/person',
           name: 'Person',
+          isPartOf: {
+            id: 'http://example.com/group',
+            name: 'Group',
+          },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',
       },
@@ -193,8 +209,8 @@ describe('add transfer of custody event', () => {
           id: 'http://example.com/person',
           name: 'Person',
           isPartOf: {
-            id: 'http://example.com/community',
-            name: 'Community',
+            id: 'http://example.com/group',
+            name: 'Group',
           },
         },
         license: 'https://creativecommons.org/licenses/by/4.0/',

--- a/packages/enricher/src/provenance-events/storer.ts
+++ b/packages/enricher/src/provenance-events/storer.ts
@@ -114,39 +114,6 @@ export class ProvenanceEventEnrichmentStorer {
       )
     );
 
-    // The server automatically adds 'dcterms:creator'.
-    // A creator can change his or her name later on, but the name at the time of
-    // creation is preserved.
-    const creatorId = DF.namedNode(opts.pubInfo.creator.id);
-
-    publicationStore.addQuad(
-      DF.quad(
-        creatorId,
-        DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
-        DF.literal(opts.pubInfo.creator.name)
-      )
-    );
-
-    if (opts.pubInfo.creator.isPartOf !== undefined) {
-      const groupId = DF.namedNode(opts.pubInfo.creator.isPartOf.id);
-
-      publicationStore.addQuad(
-        DF.quad(
-          creatorId,
-          DF.namedNode('http://purl.org/dc/terms/isPartOf'),
-          groupId
-        )
-      );
-
-      publicationStore.addQuad(
-        DF.quad(
-          groupId,
-          DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
-          DF.literal(opts.pubInfo.creator.isPartOf.name)
-        )
-      );
-    }
-
     assertionStore.addQuad(
       DF.quad(
         enrichmentId,
@@ -474,7 +441,7 @@ export class ProvenanceEventEnrichmentStorer {
     const nanopub = await this.nanopubClient.add({
       assertionStore,
       publicationStore,
-      creator: opts.pubInfo.creator.id,
+      creator: opts.pubInfo.creator,
     });
 
     const basicEnrichment: BasicEnrichment = {


### PR DESCRIPTION
This (backward-compatible) PR fixes two issues in the `enricher` package:

1. The data model for storing and retrieving the community (that a user speaks of behalf of) has been updated, per the feedback from Tobias/Knowledge Pixels.
2. The queries for retrieving the community have been updated, to resolve an issue where it wasn't clear on which particular community a user speaks on behalf of for a particular enrichment.

The PR, in its slipstream, also refactors the tests quite a bit.

See also https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=62071832