### PR TITLE
fix: query for fetching the citation

### DIFF
--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -106,16 +106,15 @@ export class HeritageObjectEnrichmentFetcher {
              oa:hasSource ?source .
 
           OPTIONAL {
-            ?annotation rdfs:comment ?comment
-          }
-
-          OPTIONAL {
             ?annotation oa:hasBody ?body .
             ?body rdf:value ?value .
             OPTIONAL {
               ?body dc:language ?language .
             }
-         }
+            OPTIONAL {
+              ?body rdfs:comment ?comment
+            }
+          }
         }
       }
     `;


### PR DESCRIPTION
This PR updates the SPARQL query for fetching the citations from an enrichment, due to a recent change to the way that we store nanopublications.