### PR TITLE
Add iri to users after signup

### DIFF
--- a/apps/researcher/src/app/[locale]/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/researcher/src/app/[locale]/sign-up/[[...sign-up]]/page.tsx
@@ -1,10 +1,12 @@
 import {SignUp} from '@clerk/nextjs';
+import {createPersistentIri} from '@colonial-collections/iris';
 import {getLocale, getTranslations} from 'next-intl/server';
 import {env} from 'node:process';
 
 export default async function Page() {
   const t = await getTranslations('SignUp');
   const locale = await getLocale();
+  const iri = createPersistentIri();
 
   return (
     <div>
@@ -45,6 +47,7 @@ export default async function Page() {
             <div className="w-full p-4 md:sticky top-0 {{> styles/style_form }} rounded-lg min-h-[300px]">
               <div className="-translate-x-5 md:-translate-x-10">
                 <SignUp
+                  unsafeMetadata={{iri}}
                   redirectUrl="/"
                   path={`/${locale}${env.NEXT_PUBLIC_CLERK_SIGN_UP_URL}`}
                 />


### PR DESCRIPTION
Add `iri` to users after sign up.

It is possible to add the `iri` directly to the user with the `SignUp` component using `unsafeMetadata`. This is nicer implementation than using the public metadata like the communities.

 - Docs about metadata: https://clerk.com/docs/users/metadata

If we want to use `publicMetadata` we need to implement the same workflow as for communities. After sign-up navigate the user to a page with the logic for adding the `iri`, then navigate to the homepage. The problem with this workflow is the user can prevent this action by closing the browser/navigation away/broken internet.

The advantage of using `unsafeMetadata` is that we don't need to relay on the redirect workflow. Clerk has named this type of metadata "unsafe" since it can be set and accessed by both the Frontend API and the Backend API. But I don't think this is a huge problem.

Do you prefer this implementation? Or do you want the `publicMetadata` workflow? I can also safe the community `iri` as `unsafeMetadata`, so the data structure is similar, however, unfortunately the `openCreateOrganization` function we use does not have a `unsafeMetadata` property, so we need to keep the redirect workflow for community.
