### PR TITLE
Minor changes

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/traditional-knowledge-labels.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/traditional-knowledge-labels.tsx
@@ -1,6 +1,5 @@
 import {useTranslations} from 'next-intl';
 import Image from 'next/image';
-import useObject from './use-object';
 
 export default function TraditionalKnowledgeLabels() {
   const t = useTranslations('TraditionalKnowledgeLabels');

--- a/apps/researcher/src/app/[locale]/objects/[id]/traditional-knowledge-labels.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/traditional-knowledge-labels.tsx
@@ -4,7 +4,6 @@ import useObject from './use-object';
 
 export default function TraditionalKnowledgeLabels() {
   const t = useTranslations('TraditionalKnowledgeLabels');
-  const {organization} = useObject.getState();
 
   return (
     <div className="my-16">
@@ -47,7 +46,7 @@ export default function TraditionalKnowledgeLabels() {
               <div className="p-2 py-3 text-xs  my-1 self-start w-full lg:w-1/3 ">
                 <div>
                   {t.rich('providedBy', {
-                    name: () => <strong>{organization?.name}</strong>,
+                    strong: name => <strong>{name}</strong>,
                   })}
                 </div>
                 <div className="flex flex-col justify-between">

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
@@ -67,7 +67,12 @@ export function HeritageObjectListItem({
       ? heritageObject.images[0].contentUrl
       : undefined;
   return (
-    <div className="flex flex-row justify-start items-center gap-4 border-t border-neutral-200 py-3 w-full">
+    <Link
+      href={`/objects/${encodeRouteSegment(heritageObject.id)}`}
+      data-testid="object-card"
+      className="flex flex-row justify-start items-center gap-4 border-t border-neutral-200 py-3 w-full no-underline"
+      aria-label={t('heritageObject')}
+    >
       <div className="w-30">
         {imageUrl && imageFetchMode !== ImageFetchMode.None && (
           <div>
@@ -100,6 +105,6 @@ export function HeritageObjectListItem({
         </div>
       </div>
       <div className="md:py-2 grow flex justify-end"></div>
-    </div>
+    </Link>
   );
 }

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -219,7 +219,7 @@ export default async function SearchResults({searchParams = {}}: Props) {
                 {t('title', {totalDatasets: searchResult.totalCount})}
               </h2>
               <div className="flex flex-col sm:flex-row justify-end gap-4 relative flex-wrap">
-                <SettingsButton>{t('addObjectsToList')}</SettingsButton>
+                {/* <SettingsButton>{t('addObjectsToList')}</SettingsButton> */}
                 <SettingsMenu />
                 <OrderSelector
                   values={[

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -38,7 +38,6 @@ import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import {ElementType} from 'react';
 import {ListStoreUpdater} from '@/components/list-store-updater';
 import {LocaleEnum} from '@/definitions';
-import {SettingsButton} from '@/components/buttons';
 import SettingsMenu from './settings-menu';
 
 // Revalidate the page every n seconds

--- a/apps/researcher/src/app/[locale]/objects/settings-menu.tsx
+++ b/apps/researcher/src/app/[locale]/objects/settings-menu.tsx
@@ -48,7 +48,6 @@ export default function SettingsMenu() {
             <option value="10">10</option>
             <option value="25">25</option>
             <option value="50">50</option>
-            <option value="100">100</option>
           </select>
         </div>
         <div className="p-4 border-b flex gap-2 flex-col text-sm">

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -150,7 +150,7 @@
     "description": "The TK Labels support the inclusion of local protocols for access and use to cultural heritage that is digitally circulating outside community contexts. <link> Learn more about the Traditional Knowledge Labels </link>.",
     "attributionIncomplete": "Notice: Attribution Incomplete",
     "attributionIncompleteDescription": "Collections and items in our institution have incomplete, inaccurate, and/or missing attribution. We are using this notice to clearly identify this material so that it can be updated, or corrected by communities of origin. Our institution is committed to collaboration and partnerships to address this problem of incorrect or missing attribution.",
-    "providedBy": "Provided by <name></name>",
+    "providedBy": "Provided by <strong>Colonial Collections Consortium</strong>",
     "defaultLabel": "This is a default notice if no other labels or notices are asigned."
   },
   "Provenance": {

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -150,7 +150,7 @@
     "description": "De TK Labels ondersteunen de opname van lokale protocollen voor toegang en gebruik van cultureel erfgoed dat digitaal buiten de gemeenschapscontexten circuleert. <link> Meer leren over de Labels voor Traditionele Kennis </link>.",
     "attributionIncomplete": "Opmerking: Attributie Onvolledig",
     "attributionIncompleteDescription": "Collecties en items in onze instelling hebben onvolledige, onnauwkeurige en/of ontbrekende attributie. We gebruiken deze kennisgeving om dit materiaal duidelijk te identificeren zodat het kan worden bijgewerkt of gecorrigeerd door de gemeenschappen van herkomst. Onze instelling zet zich in voor samenwerking en partnerschappen om dit probleem van onjuiste of ontbrekende attributie aan te pakken.",
-    "providedBy": "Aangeboden door <name></name>",
+    "providedBy": "Aangeboden door <strong>Colonial Collections Consortium</strong>",
     "defaultLabel": "Dit is een standaardmelding als er geen andere labels of kennisgevingen zijn toegewezen."
   },
   "Provenance": {


### PR DESCRIPTION
Minor changes mentioned during the sprint planning:

- Hide the settings button "Add objects to list" for now (not implemented)
- Default Traditional Knowledge Label is provided by "Colonial Collections Consortium"
- Remove the 100 option in limit setting

Not mentioned during the sprint planning:

- Bugfix: Objects are not clickable in list view