### PR TITLE
Overlay the list with a transparent div when loading

### DIFF
--- a/.github/workflows/end-to-end-testing-researcher.yml
+++ b/.github/workflows/end-to-end-testing-researcher.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-end-to-end-tests:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
@@ -20,11 +20,12 @@ export default function HeritageObjectList({
   const t = useTranslations('ObjectSearchResults');
   const view = useListStore(s => s.view);
   const imageFetchMode = useListStore(s => s.imageFetchMode);
+  const loading = useListStore(s => s.newDataNeeded);
 
   if (totalCount > 0) {
     if (view === 'grid') {
       return (
-        <div className="columns-2 gap-6 lg:columns-3 xl:columns-4 2xl:columns-5 mt-6 *:break-inside-avoid">
+        <div className="columns-2 gap-6 lg:columns-3 xl:columns-4 2xl:columns-5 mt-6 *:break-inside-avoid relative">
           {heritageObjects.map(heritageObject => (
             <HeritageObjectCard
               key={heritageObject.id}
@@ -32,11 +33,12 @@ export default function HeritageObjectList({
               imageFetchMode={imageFetchMode!}
             />
           ))}
+          <LoadingOverlay loading={loading} />
         </div>
       );
     } else {
       return (
-        <div className="flex-col flex">
+        <div className="flex-col flex relative">
           <div className="flex flex-col mt-6 w-full">
             {heritageObjects.map(heritageObject => (
               <HeritageObjectListItem
@@ -46,10 +48,17 @@ export default function HeritageObjectList({
               />
             ))}
           </div>
+          <LoadingOverlay loading={loading} />
         </div>
       );
     }
   }
 
   return <div data-testid="no-results">{t('noResults')}</div>;
+}
+
+function LoadingOverlay({loading}: {loading: boolean}) {
+  return loading ? (
+    <div className="absolute inset-0 bg-white opacity-70 z-50"></div>
+  ) : null;
 }

--- a/packages/list-store/src/use-list-helpers.tsx
+++ b/packages/list-store/src/use-list-helpers.tsx
@@ -72,16 +72,14 @@ export function useSearchParamsUpdate<SortBy>(
   const href = useListHref();
 
   const newDataNeeded = useListStore(s => s.newDataNeeded);
-  const transitionStarted = useListStore(s => s.transitionStarted);
 
   useEffect(() => {
     if (newDataNeeded && !isPending) {
       startTransition(() => {
-        transitionStarted();
-        routerReplace(href, {scroll: false});
+        routerReplace(href);
       });
     }
-  }, [href, isPending, newDataNeeded, routerReplace, transitionStarted]);
+  }, [href, isPending, newDataNeeded, routerReplace]);
 }
 
 export function useUpdateListStore<SortBy>({

--- a/packages/list-store/src/use-list-store.tsx
+++ b/packages/list-store/src/use-list-store.tsx
@@ -36,7 +36,6 @@ export interface ListState<SortBy> extends ListProps<SortBy> {
   pageChange: (direction: 1 | -1) => void;
   viewChange: (view: ListView) => void;
   imageFetchModeChange: (imageFetchMode: ImageFetchMode) => void;
-  transitionStarted: () => void;
   setNewData: ({
     totalCount,
     offset,
@@ -97,9 +96,6 @@ export function createListStore<SortBy>(initProps: ListProps<SortBy>) {
 
       set({offset: newOffset, newDataNeeded: true});
     },
-    transitionStarted: () => {
-      set({newDataNeeded: false});
-    },
     setNewData: ({
       totalCount,
       offset,
@@ -110,6 +106,9 @@ export function createListStore<SortBy>(initProps: ListProps<SortBy>) {
       view,
       imageFetchMode,
     }) => {
+      set({
+        newDataNeeded: false,
+      });
       if (!get().isInitialized) {
         set({
           totalCount,


### PR DESCRIPTION
When collecting new list data (prop `newDataNeeded`), a transparent overlay appears, making it visible that the list is loading.

Small improvements:

- I have removed `{scroll: false}` in the `routerReplace()`. Now, the user is navigated back up after clicking on the next button at the bottom of the page.
- I'm now setting `newDataNeeded` to false after loading the new data. Initially, I did this when the transition started, but I realized that was too early for the loading state. This adjustment ensures a smoother loading process.

![loading](https://github.com/colonial-heritage/colonial-collections/assets/1481602/34930a4b-e296-4a39-b8df-ec82729e84be)
