### PR TITLE
feat: research guides api

### DIFF
--- a/apps/researcher/src/lib/research-guides-instance.ts
+++ b/apps/researcher/src/lib/research-guides-instance.ts
@@ -1,0 +1,8 @@
+import {ResearchGuides} from '@colonial-collections/api';
+import {env} from 'node:process';
+
+const researchGuides = new ResearchGuides({
+  sparqlEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+});
+
+export default researchGuides;

--- a/packages/api/src/definitions.ts
+++ b/packages/api/src/definitions.ts
@@ -8,6 +8,7 @@ export type Thing = {
   id: string;
   name?: string; // Name may not exist (e.g. in a specific locale)
   description?: string;
+  sameAs?: string; // An identifier
 };
 
 export type Term = Thing;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,3 +5,4 @@ export * from './enrichments';
 export * from './objects';
 export * from './organizations';
 export * from './provenance-events';
+export * from './research-guides';

--- a/packages/api/src/rdf-helpers.test.ts
+++ b/packages/api/src/rdf-helpers.test.ts
@@ -42,7 +42,8 @@ beforeAll(async () => {
       ex:isPartOf ex:dataset1, ex:dataset2, ex:dataset3 .
 
     ex:subject1 a ex:DefinedTerm ;
-      ex:name "Term" .
+      ex:name "Term" ;
+      ex:sameAs "ID" .
 
     ex:subject2 a ex:DefinedTerm .
 
@@ -77,7 +78,8 @@ beforeAll(async () => {
 
     ex:location2 a ex:Place ;
       ex:name "City 2" ;
-      ex:isPartOf ex:location3 .
+      ex:isPartOf ex:location3 ;
+      ex:sameAs "ID" .
 
     ex:location3 a ex:Place ;
       ex:name "Country" .
@@ -223,8 +225,8 @@ describe('createThings', () => {
     const things = createThings(objectResource, 'ex:subject');
 
     expect(things).toStrictEqual([
-      {id: 'https://example.org/subject1', name: 'Term'},
-      {id: 'https://example.org/subject2', name: undefined},
+      {id: 'https://example.org/subject1', name: 'Term', sameAs: 'ID'},
+      {id: 'https://example.org/subject2', name: undefined, sameAs: undefined},
     ]);
   });
 });
@@ -243,13 +245,16 @@ describe('createPlaces', () => {
       {
         id: 'https://example.org/location1',
         name: 'City 1',
+        sameAs: undefined,
       },
       {
         id: 'https://example.org/location2',
         name: 'City 2',
+        sameAs: 'ID',
         isPartOf: {
           id: 'https://example.org/location3',
           name: 'Country',
+          sameAs: undefined,
         },
       },
     ]);

--- a/packages/api/src/rdf-helpers.ts
+++ b/packages/api/src/rdf-helpers.ts
@@ -43,10 +43,12 @@ export function removeNullish<T>(objectWithNullishValues: object) {
 
 function createPlace(placeResource: Resource) {
   const name = getPropertyValue(placeResource, 'ex:name');
+  const sameAs = getPropertyValue(placeResource, 'ex:sameAs');
 
   const place: Place = {
     id: placeResource.value,
     name,
+    sameAs,
   };
 
   // Recursively get the parent place(s), if any
@@ -58,12 +60,14 @@ function createPlace(placeResource: Resource) {
   return place;
 }
 
-function createThingFromProperty<T>(thingResource: Resource) {
+function createThing<T>(thingResource: Resource) {
   const name = getPropertyValue(thingResource, 'ex:name');
+  const sameAs = getPropertyValue(thingResource, 'ex:sameAs');
 
   const thing = {
     id: thingResource.value,
     name,
+    sameAs,
   };
 
   return thing as T;
@@ -71,9 +75,7 @@ function createThingFromProperty<T>(thingResource: Resource) {
 
 export function createThings<T>(resource: Resource, propertyName: string) {
   const properties = resource.properties[propertyName];
-  const things = properties.map(property =>
-    createThingFromProperty<T>(property)
-  );
+  const things = properties.map(property => createThing<T>(property));
 
   return things.length > 0 ? things : undefined;
 }

--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -1,0 +1,14 @@
+import {Place, Term, Thing} from '../definitions';
+
+export type Citation = Thing & {url?: string};
+
+export type ResearchGuide = Thing & {
+  abstract?: string;
+  text?: string;
+  encodingFormat?: string;
+  contentLocations?: Place[];
+  keywords?: Term[];
+  citations?: Citation[];
+  isPartOf?: ResearchGuide[];
+  hasParts?: ResearchGuide[];
+};

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -1,0 +1,205 @@
+import {ResearchGuideFetcher} from './fetcher';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {env} from 'node:process';
+
+let researchGuideFetcher: ResearchGuideFetcher;
+
+beforeEach(() => {
+  researchGuideFetcher = new ResearchGuideFetcher({
+    endpointUrl: env.SPARQL_ENDPOINT_URL as string,
+  });
+});
+
+describe('getByIds', () => {
+  it('returns empty list if no IDs were provided', async () => {
+    const researchGuides = await researchGuideFetcher.getByIds({ids: []});
+
+    expect(researchGuides).toEqual([]);
+  });
+
+  it('returns empty list if no research guides match the IDs', async () => {
+    const researchGuides = await researchGuideFetcher.getByIds({
+      ids: ['https://unknown.org/'],
+    });
+
+    expect(researchGuides).toEqual([]);
+  });
+
+  it('returns the research guides that match the IDs', async () => {
+    const researchGuides = await researchGuideFetcher.getByIds({
+      ids: [
+        'https://guides.example.org/level-2a',
+        'https://guides.example.org/level-2c',
+      ],
+    });
+
+    expect(researchGuides).toMatchObject([
+      {
+        id: 'https://guides.example.org/level-2a',
+      },
+      {
+        id: 'https://guides.example.org/level-2c',
+      },
+    ]);
+  });
+});
+
+describe('getById', () => {
+  it('returns undefined if a malformed ID is used', async () => {
+    const researchGuide = await researchGuideFetcher.getById({
+      id: 'malformedID',
+    });
+
+    expect(researchGuide).toBeUndefined();
+  });
+
+  it('returns undefined if no research guide matches the ID', async () => {
+    const researchGuide = await researchGuideFetcher.getById({
+      id: 'https://unknown.org/',
+    });
+
+    expect(researchGuide).toBeUndefined();
+  });
+
+  it('returns the research guide that matches the ID', async () => {
+    const researchGuide = await researchGuideFetcher.getById({
+      id: 'https://guides.example.org/level-2a',
+    });
+
+    expect(researchGuide).toStrictEqual({
+      id: 'https://guides.example.org/level-2a',
+      name: 'Military and navy',
+      abstract:
+        'Army and Navy personnel who operated in colonized territories collected objects in various ways during the colonial era.',
+      text: 'Dutch authority in the [Dutch East Indies](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) and on the [Caribbean Islands](https://www.geonames.org/8505032/netherlands-antilles.html) relied heavily on the use of the military...',
+      encodingFormat: 'text/markdown',
+      hasParts: [
+        {
+          id: 'https://guides.example.org/level-3a',
+          name: 'Royal Cabinet of Curiosities',
+        },
+      ],
+      isPartOf: [
+        {
+          id: 'https://guides.example.org/level-1a',
+          name: 'Doing research',
+        },
+      ],
+      contentLocations: [
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Netherlands Antilles',
+          sameAs: 'https://www.geonames.org/8505032/netherlands-antilles.html',
+        },
+      ],
+      keywords: [
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Midshipman',
+          sameAs: 'https://www.wikidata.org/wiki/Q11141137',
+        },
+      ],
+      citations: [
+        {
+          id: expect.stringContaining(
+            'https://data.colonialcollections.nl/.well-known/genid/'
+          ),
+          name: 'Regeeringsalmanak voor Nederlandsch-Indië',
+          description:
+            'Via Delpher, the editions can be found by selecting the title',
+          url: 'https://www.delpher.nl/',
+        },
+      ],
+    });
+  });
+});
+
+describe('get with localized names', () => {
+  it('returns a research guide with English names', async () => {
+    const researchGuide = await researchGuideFetcher.getById({
+      id: 'https://guides.example.org/level-2a',
+      locale: 'en',
+    });
+
+    expect(researchGuide).toMatchObject({
+      id: 'https://guides.example.org/level-2a',
+      name: 'Military and navy',
+      abstract:
+        'Army and Navy personnel who operated in colonized territories collected objects in various ways during the colonial era.',
+      text: 'Dutch authority in the [Dutch East Indies](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) and on the [Caribbean Islands](https://www.geonames.org/8505032/netherlands-antilles.html) relied heavily on the use of the military...',
+      hasParts: [
+        {
+          name: 'Royal Cabinet of Curiosities',
+        },
+      ],
+      isPartOf: [
+        {
+          name: 'Doing research',
+        },
+      ],
+      contentLocations: [
+        {
+          name: 'Netherlands Antilles',
+        },
+      ],
+      keywords: [
+        {
+          name: 'Midshipman',
+        },
+      ],
+      citations: [
+        {
+          name: 'Regeeringsalmanak voor Nederlandsch-Indië',
+          description:
+            'Via Delpher, the editions can be found by selecting the title',
+        },
+      ],
+    });
+  });
+
+  it('returns a research guide with Dutch names', async () => {
+    const researchGuide = await researchGuideFetcher.getById({
+      id: 'https://guides.example.org/level-2a',
+      locale: 'nl',
+    });
+
+    expect(researchGuide).toMatchObject({
+      id: 'https://guides.example.org/level-2a',
+      name: 'Leger en Marine',
+      abstract:
+        'Leger- en marinepersoneel dat actief was in gekoloniseerde gebieden, verzamelde op verschillende manieren objecten tijdens het koloniale tijdperk.',
+      text: 'Het Nederlandse gezag in [Nederlands-Indië](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) en op de [Caribische eilanden](https://www.geonames.org/8505032/netherlands-antilles.html) steunde in belangrijke mate op de inzet van het leger.',
+      hasParts: [
+        {
+          name: 'Koninklijk Kabinet van Zeldzaamheden',
+        },
+      ],
+      isPartOf: [
+        {
+          name: 'Onderzoeken',
+        },
+      ],
+      contentLocations: [
+        {
+          name: 'Antillen',
+        },
+      ],
+      keywords: [
+        {
+          name: 'Adelborst',
+        },
+      ],
+      citations: [
+        {
+          name: 'Regeeringsalmanak voor Nederlandsch-Indië',
+          description:
+            'Edities van 1865 tot en met 1942 beschikbaar via Delpher en edities van 1865 tot en met 1912 beschikbaar via de digitale collecties van de Staatsbibliothek zu Berlin.',
+        },
+      ],
+    });
+  });
+});

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -10,6 +10,18 @@ beforeEach(() => {
   });
 });
 
+describe('getByTopLevel', () => {
+  it('returns the top level guides', async () => {
+    const researchGuides = await researchGuideFetcher.getByTopLevel();
+
+    expect(researchGuides).toMatchObject([
+      {
+        id: 'https://guides.example.org/top-level',
+      },
+    ]);
+  });
+});
+
 describe('getByIds', () => {
   it('returns empty list if no IDs were provided', async () => {
     const researchGuides = await researchGuideFetcher.getByIds({ids: []});

--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -1,0 +1,231 @@
+import {isIri} from '@colonial-collections/iris';
+import type {Stream} from '@rdfjs/types';
+import {SparqlEndpointFetcher} from 'fetch-sparql-endpoint';
+import {EOL} from 'node:os';
+import type {Readable} from 'node:stream';
+import {RdfObjectLoader} from 'rdf-object';
+import {z} from 'zod';
+import {localeSchema} from '../definitions';
+import {createResearchGuide} from './rdf-helpers';
+import {ResearchGuide} from './definitions';
+
+const constructorOptionsSchema = z.object({
+  endpointUrl: z.string(),
+});
+
+export type ConstructorOptions = z.infer<typeof constructorOptionsSchema>;
+
+const getByIdsOptionsSchema = z.object({
+  locale: localeSchema,
+  ids: z.array(z.string()),
+});
+
+export type GetByIdsOptions = z.input<typeof getByIdsOptionsSchema>;
+
+const getByIdOptionsSchema = z.object({
+  locale: localeSchema,
+  id: z.string(),
+});
+
+export type GetByIdOptions = z.input<typeof getByIdOptionsSchema>;
+
+export class ResearchGuideFetcher {
+  private readonly endpointUrl: string;
+  private readonly fetcher = new SparqlEndpointFetcher();
+
+  constructor(options: ConstructorOptions) {
+    const opts = constructorOptionsSchema.parse(options);
+
+    this.endpointUrl = opts.endpointUrl;
+  }
+
+  private async fetchTriples(options: GetByIdsOptions) {
+    const iris = options.ids.map(iri => `<${iri}>`).join(EOL);
+
+    const query = `
+      PREFIX ex: <https://example.org/>
+      PREFIX schema: <https://schema.org/>
+
+      CONSTRUCT {
+        ?this a ex:CreativeWork ;
+          ex:name ?name ;
+          ex:abstract ?abstract ;
+          ex:text ?text ;
+          ex:encodingFormat ?encodingFormat ;
+          ex:hasPart ?hasPart ;
+          ex:isPartOf ?isPartOf ;
+          ex:contentLocation ?contentLocation ;
+          ex:keyword ?keyword ;
+          ex:citation ?citation .
+
+        ?hasPart a ex:CreativeWork ;
+          ex:name ?hasPartName .
+
+        ?isPartOf a ex:CreativeWork ;
+          ex:name ?isPartOfName .
+
+        ?contentLocation a ex:Place ;
+          ex:name ?contentLocationName ;
+          ex:sameAs ?contentLocationSameAs .
+
+        ?keyword a ex:DefinedTerm ;
+          ex:name ?keywordName ;
+          ex:sameAs ?keywordSameAs .
+
+        ?citation a ex:CreativeWork ;
+          ex:name ?citationName ;
+          ex:description ?citationDescription ;
+          ex:url ?citationUrl .
+      }
+      WHERE {
+        VALUES ?this {
+          ${iris}
+        }
+
+        ?this a schema:TextDigitalDocument ;
+          schema:additionalType <http://vocab.getty.edu/aat/300027029> . # "Guides"
+
+        OPTIONAL {
+          ?this schema:name ?name .
+          FILTER(LANG(?name) = "${options.locale}")
+        }
+
+        OPTIONAL {
+          ?this schema:abstract ?abstract .
+          FILTER(LANG(?abstract) = "${options.locale}")
+        }
+
+        OPTIONAL {
+          ?this schema:text ?text .
+          FILTER(LANG(?text) = "${options.locale}")
+        }
+
+        OPTIONAL {
+          ?this schema:encodingFormat ?encodingFormat .
+        }
+
+        # Get a selection of information from the parts, if any
+        OPTIONAL {
+          ?this schema:hasPart ?hasPart .
+          ?hasPart schema:name ?hasPartName .
+          FILTER(LANG(?hasPartName) = "${options.locale}")
+        }
+
+        # Get a selection of information from the parent, if any
+        OPTIONAL {
+          ?this schema:isPartOf ?isPartOf .
+          ?isPartOf schema:name ?isPartOfName .
+          FILTER(LANG(?isPartOfName) = "${options.locale}")
+        }
+
+        OPTIONAL {
+          ?this schema:contentLocation ?contentLocation .
+
+          OPTIONAL {
+            ?contentLocation schema:name ?contentLocationName .
+            FILTER(LANG(?contentLocationName) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?contentLocation schema:sameAs ?contentLocationSameAs
+          }
+        }
+
+        OPTIONAL {
+          ?this schema:keywords ?keyword .
+
+          OPTIONAL {
+            ?keyword schema:name ?keywordName .
+            FILTER(LANG(?keywordName) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?keyword schema:sameAs ?keywordSameAs
+          }
+        }
+
+        OPTIONAL {
+          ?this schema:citation ?citation .
+
+          OPTIONAL {
+            ?citation schema:name ?citationName .
+            FILTER(LANG(?citationName) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?citation schema:description ?citationDescription .
+            FILTER(LANG(?citationDescription) = "${options.locale}")
+          }
+
+          OPTIONAL {
+            ?citation schema:url ?citationUrl .
+          }
+        }
+      }
+    `;
+
+    return this.fetcher.fetchTriples(this.endpointUrl, query);
+  }
+
+  private async fromTriplesToResearchGuides(
+    iris: string[],
+    triplesStream: Readable & Stream
+  ) {
+    const loader = new RdfObjectLoader({
+      context: {
+        ex: 'https://example.org/',
+      },
+    });
+
+    await loader.import(triplesStream);
+
+    const researchGuides = iris.reduce(
+      (researchGuides: ResearchGuide[], iri) => {
+        const rawResearchGuide = loader.resources[iri];
+        if (rawResearchGuide !== undefined) {
+          const researchGuide = createResearchGuide(rawResearchGuide);
+          researchGuides.push(researchGuide);
+        }
+        return researchGuides;
+      },
+      []
+    );
+
+    return researchGuides;
+  }
+
+  async getByIds(options: GetByIdsOptions) {
+    const opts = getByIdsOptionsSchema.parse(options);
+
+    if (opts.ids.length === 0) {
+      return [];
+    }
+
+    const triplesStream = await this.fetchTriples(opts);
+    const researchGuides = await this.fromTriplesToResearchGuides(
+      opts.ids,
+      triplesStream
+    );
+
+    return researchGuides;
+  }
+
+  async getById(options: GetByIdOptions) {
+    const opts = getByIdOptionsSchema.parse(options);
+
+    if (!isIri(opts.id)) {
+      return undefined;
+    }
+
+    const researchGuides = await this.getByIds({
+      locale: opts.locale,
+      ids: [opts.id],
+    });
+
+    if (researchGuides.length !== 1) {
+      return undefined;
+    }
+
+    return researchGuides[0];
+  }
+}

--- a/packages/api/src/research-guides/index.integration.test.ts
+++ b/packages/api/src/research-guides/index.integration.test.ts
@@ -1,0 +1,38 @@
+import {ResearchGuides} from '.';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {env} from 'node:process';
+
+// This file contains some straightforward tests that make
+// sure the API of 'index.ts' works. The real integration tests
+// are in the files that 'index.ts' uses, e.g. 'fetcher.integration.test.ts'.
+
+let researchGuides: ResearchGuides;
+
+beforeEach(() => {
+  researchGuides = new ResearchGuides({
+    sparqlEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
+  });
+});
+
+describe('getByIds', () => {
+  it('returns the research guides', async () => {
+    const results = await researchGuides.getByIds({
+      ids: [
+        'https://guides.example.org/level-2a',
+        'https://guides.example.org/level-2c',
+      ],
+    });
+
+    expect(results).toHaveLength(2);
+  });
+});
+
+describe('getById', () => {
+  it('returns the research guide', async () => {
+    const researchGuide = await researchGuides.getById({
+      id: 'https://guides.example.org/level-2a',
+    });
+
+    expect(researchGuide).not.toBeUndefined();
+  });
+});

--- a/packages/api/src/research-guides/index.integration.test.ts
+++ b/packages/api/src/research-guides/index.integration.test.ts
@@ -14,6 +14,14 @@ beforeEach(() => {
   });
 });
 
+describe('getByTopLevel', () => {
+  it('returns the top level research guides', async () => {
+    const results = await researchGuides.getByTopLevel();
+
+    expect(results).toHaveLength(1);
+  });
+});
+
 describe('getByIds', () => {
   it('returns the research guides', async () => {
     const results = await researchGuides.getByIds({

--- a/packages/api/src/research-guides/index.ts
+++ b/packages/api/src/research-guides/index.ts
@@ -1,0 +1,32 @@
+import {z} from 'zod';
+import {GetByIdOptions, GetByIdsOptions, ResearchGuideFetcher} from './fetcher';
+
+const constructorOptionsSchema = z.object({
+  sparqlEndpointUrl: z.string(),
+});
+
+export type ResearchGuideConstructorOptions = z.infer<
+  typeof constructorOptionsSchema
+>;
+
+// A small wrapper around 'ResearchGuideFetcher', to be in sync with
+// 'objects/index.ts' and to allow for future expansion
+export class ResearchGuides {
+  private readonly researchGuideFetcher: ResearchGuideFetcher;
+
+  constructor(options: ResearchGuideConstructorOptions) {
+    const opts = constructorOptionsSchema.parse(options);
+
+    this.researchGuideFetcher = new ResearchGuideFetcher({
+      endpointUrl: opts.sparqlEndpointUrl,
+    });
+  }
+
+  async getByIds(options: GetByIdsOptions) {
+    return this.researchGuideFetcher.getByIds(options);
+  }
+
+  async getById(options: GetByIdOptions) {
+    return this.researchGuideFetcher.getById(options);
+  }
+}

--- a/packages/api/src/research-guides/index.ts
+++ b/packages/api/src/research-guides/index.ts
@@ -1,5 +1,10 @@
 import {z} from 'zod';
-import {GetByIdOptions, GetByIdsOptions, ResearchGuideFetcher} from './fetcher';
+import {
+  GetByIdOptions,
+  GetByIdsOptions,
+  GetByTopLevelOptions,
+  ResearchGuideFetcher,
+} from './fetcher';
 
 const constructorOptionsSchema = z.object({
   sparqlEndpointUrl: z.string(),
@@ -20,6 +25,10 @@ export class ResearchGuides {
     this.researchGuideFetcher = new ResearchGuideFetcher({
       endpointUrl: opts.sparqlEndpointUrl,
     });
+  }
+
+  async getByTopLevel(options?: GetByTopLevelOptions) {
+    return this.researchGuideFetcher.getByTopLevel(options);
   }
 
   async getByIds(options: GetByIdsOptions) {

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -1,0 +1,141 @@
+import {describe, expect, it} from '@jest/globals';
+import {StreamParser} from 'n3';
+import {RdfObjectLoader, Resource} from 'rdf-object';
+import streamifyString from 'streamify-string';
+import {createCitations, createResearchGuide} from './rdf-helpers';
+
+const loader = new RdfObjectLoader({
+  context: {
+    ex: 'https://example.org/',
+    rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  },
+});
+
+beforeAll(async () => {
+  const triples = `
+    @prefix ex: <https://example.org/> .
+
+    ex:researchGuide1 a ex:CreativeWork ;
+      ex:name "Name 1" .
+
+    ex:researchGuide2 a ex:CreativeWork ;
+      ex:name "Name 2" ;
+      ex:abstract "Abstract" ;
+      ex:text "Text" ;
+      ex:encodingFormat "text/html" ;
+      ex:hasPart ex:researchGuide3 ;
+      ex:isPartOf ex:researchGuide1 ;
+      ex:contentLocation [
+        ex:name "Content Location" ;
+        ex:sameAs <https://example.org/place> ;
+      ] ;
+      ex:keyword [
+        ex:name "Keyword" ;
+        ex:sameAs <https://example.org/keyword> ;
+      ] ;
+      ex:citation [
+        ex:name "Citation" ;
+        ex:description "Citation Description" ;
+        ex:url <https://example.org/citation> ;
+      ] .
+
+    ex:researchGuide3 a ex:CreativeWork ;
+      ex:name "Name 3" .
+
+    ex:researchGuide4 a ex:CreativeWork ;
+      ex:name "Name A", "Name B" ;
+      ex:abstract "Abstract A", "Abstract B" ;
+      ex:text "Text A", "Text B" ;
+      ex:encodingFormat "text/html", "text/plain" .
+  `;
+
+  const stringStream = streamifyString(triples);
+  const streamParser = new StreamParser();
+  stringStream.pipe(streamParser);
+  await loader.import(streamParser);
+});
+
+describe('createCitations', () => {
+  let resource: Resource;
+
+  beforeEach(() => {
+    resource = loader.resources['https://example.org/researchGuide2'];
+  });
+
+  it('returns undefined if property does not exist', () => {
+    const citations = createCitations(resource, 'ex:unknown');
+
+    expect(citations).toBeUndefined();
+  });
+
+  it('returns citations if property exists', () => {
+    const citations = createCitations(resource, 'ex:citation');
+
+    expect(citations).toStrictEqual([
+      {
+        id: 'n3-2',
+        name: 'Citation',
+        description: 'Citation Description',
+        url: 'https://example.org/citation',
+      },
+    ]);
+  });
+});
+
+describe('createResearchGuide', () => {
+  it('returns a research guide with minimal properties', () => {
+    const resource = loader.resources['https://example.org/researchGuide1'];
+    const researchGuide = createResearchGuide(resource);
+
+    expect(researchGuide).toStrictEqual({
+      id: 'https://example.org/researchGuide1',
+      name: 'Name 1',
+    });
+  });
+
+  it('returns a research guide with all properties', () => {
+    const resource = loader.resources['https://example.org/researchGuide2'];
+    const researchGuide = createResearchGuide(resource);
+
+    expect(researchGuide).toStrictEqual({
+      id: 'https://example.org/researchGuide2',
+      name: 'Name 2',
+      abstract: 'Abstract',
+      text: 'Text',
+      encodingFormat: 'text/html',
+      hasParts: [{id: 'https://example.org/researchGuide3', name: 'Name 3'}],
+      isPartOf: [{id: 'https://example.org/researchGuide1', name: 'Name 1'}],
+      contentLocations: [
+        {
+          id: 'n3-0',
+          name: 'Content Location',
+          sameAs: 'https://example.org/place',
+        },
+      ],
+      keywords: [
+        {id: 'n3-1', name: 'Keyword', sameAs: 'https://example.org/keyword'},
+      ],
+      citations: [
+        {
+          id: 'n3-2',
+          name: 'Citation',
+          description: 'Citation Description',
+          url: 'https://example.org/citation',
+        },
+      ],
+    });
+  });
+
+  it('returns a research guide with just one value if it has multiple values in the source', () => {
+    const resource = loader.resources['https://example.org/researchGuide4'];
+    const researchGuide = createResearchGuide(resource);
+
+    expect(researchGuide).toStrictEqual({
+      id: 'https://example.org/researchGuide4',
+      name: 'Name A',
+      abstract: 'Abstract A',
+      text: 'Text A',
+      encodingFormat: 'text/html',
+    });
+  });
+});

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -1,0 +1,81 @@
+import {
+  createPlaces,
+  createThings,
+  getPropertyValues,
+  onlyOne,
+  removeNullish,
+} from '../rdf-helpers';
+import type {Resource} from 'rdf-object';
+import {Citation, ResearchGuide} from './definitions';
+import {Term} from '../definitions';
+
+function createCitation(citationResource: Resource) {
+  const name = onlyOne(getPropertyValues(citationResource, 'ex:name'));
+  const description = onlyOne(
+    getPropertyValues(citationResource, 'ex:description')
+  );
+  const url = onlyOne(getPropertyValues(citationResource, 'ex:url'));
+
+  const citation: Citation = {
+    id: citationResource.value,
+    name,
+    description,
+    url,
+  };
+
+  return citation;
+}
+
+export function createCitations(resource: Resource, propertyName: string) {
+  const properties = resource.properties[propertyName];
+  const citations = properties.map(property => createCitation(property));
+
+  return citations.length > 0 ? citations : undefined;
+}
+
+export function createResearchGuide(researchGuideResource: Resource) {
+  const name = onlyOne(getPropertyValues(researchGuideResource, 'ex:name'));
+  const abstract = onlyOne(
+    getPropertyValues(researchGuideResource, 'ex:abstract')
+  );
+  const text = onlyOne(getPropertyValues(researchGuideResource, 'ex:text'));
+  const encodingFormat = onlyOne(
+    getPropertyValues(researchGuideResource, 'ex:encodingFormat')
+  );
+  const hasParts = createResearchGuides(researchGuideResource, 'ex:hasPart');
+  const isPartOf = createResearchGuides(researchGuideResource, 'ex:isPartOf');
+  const contentLocations = createPlaces(
+    researchGuideResource,
+    'ex:contentLocation'
+  );
+  const keywords = createThings<Term>(researchGuideResource, 'ex:keyword');
+  const citations = createCitations(researchGuideResource, 'ex:citation');
+
+  const researchGuideWithUndefinedValues: ResearchGuide = {
+    id: researchGuideResource.value,
+    name,
+    abstract,
+    text,
+    encodingFormat,
+    hasParts,
+    isPartOf,
+    contentLocations,
+    keywords,
+    citations,
+  };
+
+  const researchGuide = removeNullish<ResearchGuide>(
+    researchGuideWithUndefinedValues
+  );
+
+  return researchGuide;
+}
+
+export function createResearchGuides(resource: Resource, propertyName: string) {
+  const properties = resource.properties[propertyName];
+  const researchGuides = properties.map(property =>
+    createResearchGuide(property)
+  );
+
+  return researchGuides.length > 0 ? researchGuides : undefined;
+}


### PR DESCRIPTION
This PR adds an initial, basic version of the 'Research Guides' API to the frontend:

1. The data model is a work in progress and will likely change, depending on the outcome of the work of Kinsuk
2. The API allows you to fetch a research guide (e.g. a 'level 1' or 'level 2' guide) or a list of research guides (e.g. 'all level 2 guides'). If a research guide points to another guide (e.g. a 'level 2' guide points to its parent, 'level 1') then only the ID and the name of that other guide will be in the API response, not the entire guide (this would complicate the implementation quite a bit, due to recursive fetching)
3. The API does not have a way to fetch a selection of research guides, based in their type [1]
4. The API does not distinguish between 'primary' and 'secondary' source [2], it just has a list of sources (named 'citations'). This can change if Kinsuk finds a way to model this
5. The API does not expose 'Related topics' [3]. This can change if Kinsuk finds a way to model this
6. The API does not expose 'Name variations' or the 'Period of activity' [4]. This can change if Kinsuk finds a way to model this

In addition to this PR I've added some research guides mock data to our development environment, for use on https://dev.app.colonialcollections.nl/en

[1] See the [design](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/), sections 'Locations' and 'Topics'. These sections are (at this moment) not in the NIOD source data
[2] See the [design](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/screen/79a31724-cf7e-45a5-98e9-a17de47cf892), 'Primair bronnenmateriaal', 'Secundair bronnenmateriaal'
[3] See the [design](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/screen/79a31724-cf7e-45a5-98e9-a17de47cf892), section 'Related topics'
[4] See the [design](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/screen/4b61f40a-3cfe-4b40-8256-80515f24553b), 'Kunstzaal Van Lier, Carel van Lier, Leendert van Lier' and 'Beginjaar', 'Eindjaar'