### PR TITLE
fix: localization of facet values

### DIFF
--- a/apps/dataset-browser/src/app/[locale]/datasets/[id]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/datasets/[id]/page.tsx
@@ -1,4 +1,4 @@
-import {getTranslations, getFormatter} from 'next-intl/server';
+import {getTranslations, getFormatter, getLocale} from 'next-intl/server';
 import {
   PageHeader,
   PageTitle,
@@ -18,6 +18,7 @@ import {Fragment} from 'react';
 import BooleanMeasurement from '@/components/boolean-measurement';
 import metricIds from '@/lib/transparency-metrics';
 import BackButton from './back-button';
+import {LocaleEnum} from '@/definitions';
 
 interface Props {
   params: {id: string};
@@ -28,7 +29,8 @@ export const revalidate = 0;
 
 export default async function Details({params}: Props) {
   const id = decodeURIComponent(params.id);
-  const dataset = await datasets.getById({id});
+  const locale = (await getLocale()) as LocaleEnum;
+  const dataset = await datasets.getById({id, locale});
   const t = await getTranslations('Details');
   const tMetrics = await getTranslations('TransparencyMetrics');
   const formatter = await getFormatter();

--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -7,7 +7,7 @@ import {
   SortOrderEnum,
 } from '@colonial-collections/api';
 import {useTranslations} from 'next-intl';
-import {getTranslations} from 'next-intl/server';
+import {getTranslations, getLocale} from 'next-intl/server';
 import DatasetList from './dataset-list';
 import {sortMapping} from './sort-mapping';
 import {
@@ -32,6 +32,7 @@ import {
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
 import {ElementType} from 'react';
 import {ListStoreUpdater} from './list-store-updater';
+import {LocaleEnum} from '@/definitions';
 
 // Revalidate the page every n seconds
 export const revalidate = 60;
@@ -86,6 +87,8 @@ interface Props {
 }
 
 export default async function Home({searchParams = {}}: Props) {
+  const locale = (await getLocale()) as LocaleEnum;
+
   const searchOptions = fromSearchParamsToSearchOptions({
     sortOptions: {
       SortOrderEnum,
@@ -111,7 +114,7 @@ export default async function Home({searchParams = {}}: Props) {
   let hasError;
   let searchResult: DatasetSearchResult | undefined;
   try {
-    searchResult = await datasets.search(searchOptions);
+    searchResult = await datasets.search({...searchOptions, locale});
   } catch (err) {
     hasError = true;
     console.error(err);

--- a/packages/api/src/datasets/fetcher.integration.test.ts
+++ b/packages/api/src/datasets/fetcher.integration.test.ts
@@ -231,3 +231,37 @@ describe('getById', () => {
     });
   });
 });
+
+describe('get with localized names', () => {
+  it('returns a dataset with English names', async () => {
+    const dataset = await datasetFetcher.getById({
+      locale: 'en',
+      id: 'https://example.org/datasets/1',
+    });
+
+    // Currently the only localized parts
+    expect(dataset).toMatchObject({
+      id: 'https://example.org/datasets/1',
+      publisher: {
+        id: 'https://museum.example.org/',
+        name: 'The Museum',
+      },
+    });
+  });
+
+  it('returns a dataset with Dutch names', async () => {
+    const dataset = await datasetFetcher.getById({
+      locale: 'nl',
+      id: 'https://example.org/datasets/1',
+    });
+
+    // Currently the only localized parts
+    expect(dataset).toMatchObject({
+      id: 'https://example.org/datasets/1',
+      publisher: {
+        id: 'https://museum.example.org/',
+        name: 'Het Museum',
+      },
+    });
+  });
+});

--- a/packages/api/src/datasets/fetcher.ts
+++ b/packages/api/src/datasets/fetcher.ts
@@ -90,7 +90,7 @@ export class DatasetFetcher {
 
         OPTIONAL {
           ?this schema:name ?name
-          FILTER(LANG(?name) = "" || LANGMATCHES(LANG(?name), "en"))
+          FILTER(LANG(?name) = "" || LANG(?name) = "${options.locale}")
         }
 
         ####################
@@ -99,7 +99,7 @@ export class DatasetFetcher {
 
         OPTIONAL {
           ?this schema:description ?description
-          FILTER(LANG(?description) = "" || LANGMATCHES(LANG(?description), "en"))
+          FILTER(LANG(?description) = "" || LANG(?description) = "${options.locale}")
         }
 
         ####################
@@ -109,7 +109,7 @@ export class DatasetFetcher {
         OPTIONAL {
           ?this schema:license ?license .
           ?license schema:name ?licenseName .
-          FILTER(LANG(?licenseName) = "" || LANGMATCHES(LANG(?licenseName), "en"))
+          FILTER(LANG(?licenseName) = "" || LANG(?licenseName) = "${options.locale}")
         }
 
         ####################
@@ -119,7 +119,7 @@ export class DatasetFetcher {
         OPTIONAL {
           ?this schema:publisher ?publisher .
           ?publisher schema:name ?publisherName
-          FILTER(LANG(?publisherName) = "" || LANGMATCHES(LANG(?publisherName), "en"))
+          FILTER(LANG(?publisherName) = "${options.locale}")
         }
 
         ####################
@@ -136,7 +136,7 @@ export class DatasetFetcher {
 
         OPTIONAL {
           ?this schema:keywords ?keywords
-          FILTER(LANG(?keywords) = "" || LANGMATCHES(LANG(?keywords), "en"))
+          FILTER(LANG(?keywords) = "" || LANG(?keywords) = "${options.locale}")
         }
 
         ####################

--- a/packages/api/src/datasets/searcher.integration.test.ts
+++ b/packages/api/src/datasets/searcher.integration.test.ts
@@ -105,10 +105,6 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/10',
           name: 'Dataset 10',
-          publisher: {
-            id: 'https://library.example.org/',
-            name: 'Library',
-          },
           license: {
             id: 'https://example.org/custom-license',
             name: 'Custom License',
@@ -173,10 +169,6 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/11',
           name: 'Dataset 11',
-          publisher: {
-            id: 'https://library.example.org/',
-            name: 'Library',
-          },
           license: {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
@@ -244,10 +236,6 @@ describe('search', () => {
           name: 'Dataset 12',
           description:
             'Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac.',
-          publisher: {
-            id: 'https://library.example.org/',
-            name: 'Library',
-          },
           license: {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
@@ -387,10 +375,6 @@ describe('search', () => {
           name: 'Dataset 14',
           description:
             'Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac.',
-          publisher: {
-            id: 'https://library.example.org/',
-            name: 'Library',
-          },
           license: {
             id: 'http://creativecommons.org/publicdomain/zero/1.0/deed.nl',
             name: 'CC0 1.0 Universeel (CC0 1.0) Publiek Domein Verklaring',
@@ -699,11 +683,6 @@ describe('search', () => {
             name: 'Archive',
           },
           {
-            totalCount: 5,
-            id: 'Library',
-            name: 'Library',
-          },
-          {
             totalCount: 3,
             id: 'The Museum',
             name: 'The Museum',
@@ -763,7 +742,7 @@ describe('search', () => {
   it('finds datasets if "publishers" filter matches', async () => {
     const result = await datasetSearcher.search({
       filters: {
-        publishers: ['Library'],
+        publishers: ['Archive'],
       },
     });
 
@@ -773,8 +752,8 @@ describe('search', () => {
         publishers: [
           {
             totalCount: 5,
-            id: 'Library',
-            name: 'Library',
+            id: 'Archive',
+            name: 'Archive',
           },
         ],
       },
@@ -796,6 +775,54 @@ describe('search', () => {
             totalCount: 2,
             id: 'Attribution 4.0 International (CC BY 4.0)',
             name: 'Attribution 4.0 International (CC BY 4.0)',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('search with localized names', () => {
+  it('finds datasets with English names', async () => {
+    // Currently the only localized parts
+    const result = await datasetSearcher.search({
+      locale: 'en',
+      filters: {
+        publishers: ['The Museum'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 3,
+      filters: {
+        publishers: [
+          {
+            totalCount: 3,
+            id: 'The Museum',
+            name: 'The Museum',
+          },
+        ],
+      },
+    });
+  });
+
+  it('finds datasets with Dutch names', async () => {
+    // Currently the only localized parts
+    const result = await datasetSearcher.search({
+      locale: 'nl',
+      filters: {
+        publishers: ['Het Museum'],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 3,
+      filters: {
+        publishers: [
+          {
+            totalCount: 3,
+            id: 'Het Museum',
+            name: 'Het Museum',
           },
         ],
       },

--- a/packages/api/src/datasets/searcher.ts
+++ b/packages/api/src/datasets/searcher.ts
@@ -107,8 +107,10 @@ export class DatasetSearcher {
   }
 
   private buildRequest(options: SearchOptions) {
+    const publisherKey = `${RawKeys.Publisher}_${options.locale}.keyword`;
+
     const aggregations = {
-      publishers: this.buildAggregation(`${RawKeys.Publisher}.keyword`),
+      publishers: this.buildAggregation(publisherKey),
       licenses: this.buildAggregation(`${RawKeys.License}.keyword`),
     };
 
@@ -152,8 +154,8 @@ export class DatasetSearcher {
     };
 
     const queryFilters: Map<string, string[] | undefined> = new Map([
-      [RawKeys.Publisher, options.filters?.publishers],
-      [RawKeys.License, options.filters?.licenses],
+      [publisherKey, options.filters?.publishers],
+      [`${RawKeys.License}.keyword`, options.filters?.licenses],
     ]);
 
     for (const [rawDatasetKey, filters] of queryFilters) {
@@ -161,7 +163,7 @@ export class DatasetSearcher {
         const andFilters = filters.map(filter => {
           return {
             terms: {
-              [`${rawDatasetKey}.keyword`]: [filter],
+              [rawDatasetKey]: [filter],
             },
           };
         });


### PR DESCRIPTION
This PR fixes an issue in the Dataset Browser: the facet values do not respond to the requested locale. See for example https://datasets.colonialcollections.nl/nl: facet 'Eigenaren' contains both Dutch and English names, whereas only the Dutch names should be visible.