### PR TITLE
Set list defaults correctly

### DIFF
--- a/apps/dataset-browser/src/app/[locale]/layout.tsx
+++ b/apps/dataset-browser/src/app/[locale]/layout.tsx
@@ -3,7 +3,11 @@ import {ReactNode} from 'react';
 import Navigation from './navigation';
 import {NextIntlClientProvider, useMessages, useTranslations} from 'next-intl';
 import {WipMessage} from '@colonial-collections/ui';
-import {ListProvider, defaultSortBy} from '@colonial-collections/list-store';
+import {
+  ListProvider,
+  defaultSortBy,
+  defaultLimit,
+} from '@colonial-collections/list-store';
 import {Link} from '@/navigation';
 
 interface Props {
@@ -39,7 +43,11 @@ export default function RootLayout({children, params: {locale}}: Props) {
           </header>
           <main className="bg-white pb-32">
             <div className="max-w-7xl container mx-auto p-8">
-              <ListProvider baseUrl="/" defaultSortBy={defaultSortBy}>
+              <ListProvider
+                baseUrl="/"
+                defaultSortBy={defaultSortBy}
+                defaultLimit={defaultLimit}
+              >
                 {children}
               </ListProvider>
             </div>

--- a/apps/dataset-browser/src/app/[locale]/page.tsx
+++ b/apps/dataset-browser/src/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ import {getTranslations, getLocale} from 'next-intl/server';
 import DatasetList from './dataset-list';
 import {sortMapping} from './sort-mapping';
 import {
+  defaultLimit,
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   Type as SearchParamType,
@@ -102,6 +103,7 @@ export default async function Home({searchParams = {}}: Props) {
       type: searchParamType,
     })),
     searchParams,
+    defaultLimit,
   });
   const sortBy = getClientSortBy({
     sortMapping,

--- a/apps/researcher/src/app/[locale]/(home)/layout.tsx
+++ b/apps/researcher/src/app/[locale]/(home)/layout.tsx
@@ -1,10 +1,14 @@
-import {ListProvider} from '@colonial-collections/list-store';
+import {ListProvider, defaultLimit} from '@colonial-collections/list-store';
 import {defaultSortByUserOption} from '../objects/sort-mapping';
 import {ReactNode} from 'react';
 
 export default function ObjectLayout({children}: {children: ReactNode}) {
   return (
-    <ListProvider baseUrl="/objects" defaultSortBy={defaultSortByUserOption}>
+    <ListProvider
+      baseUrl="/objects"
+      defaultSortBy={defaultSortByUserOption}
+      defaultLimit={defaultLimit}
+    >
       {children}
     </ListProvider>
   );

--- a/apps/researcher/src/app/[locale]/communities/layout.tsx
+++ b/apps/researcher/src/app/[locale]/communities/layout.tsx
@@ -1,10 +1,15 @@
 import {ListProvider} from '@colonial-collections/list-store';
 import {defaultSortBy} from '@/lib/community/actions';
 import {ReactNode} from 'react';
+import {limit} from './settings';
 
 export default function Layout({children}: {children: ReactNode}) {
   return (
-    <ListProvider baseUrl="/communities" defaultSortBy={defaultSortBy}>
+    <ListProvider
+      baseUrl="/communities"
+      defaultSortBy={defaultSortBy}
+      defaultLimit={limit}
+    >
       <div>{children}</div>
     </ListProvider>
   );

--- a/apps/researcher/src/app/[locale]/communities/layout.tsx
+++ b/apps/researcher/src/app/[locale]/communities/layout.tsx
@@ -1,14 +1,14 @@
 import {ListProvider} from '@colonial-collections/list-store';
 import {defaultSortBy} from '@/lib/community/actions';
 import {ReactNode} from 'react';
-import {limit} from './settings';
+import {itemsPerPageLimit} from './settings';
 
 export default function Layout({children}: {children: ReactNode}) {
   return (
     <ListProvider
       baseUrl="/communities"
       defaultSortBy={defaultSortBy}
-      defaultLimit={limit}
+      defaultLimit={itemsPerPageLimit}
     >
       <div>{children}</div>
     </ListProvider>

--- a/apps/researcher/src/app/[locale]/communities/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/page.tsx
@@ -13,7 +13,7 @@ import {AddCommunityButton} from './buttons';
 import {MyCommunityToggle} from './my-community-toggle';
 import SignedIn from '@/lib/community/signed-in';
 import {SignedOut} from '@clerk/nextjs';
-import {limit} from './settings';
+import {itemsPerPageLimit} from './settings';
 
 // 1 day = 60*60*24 = 86400
 export const revalidate = 86400;
@@ -38,7 +38,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
       communities = await getMyCommunities({
         sortBy,
         offset,
-        limit,
+        limit: itemsPerPageLimit,
         includeMembersCount: true,
       });
     } else {
@@ -46,7 +46,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         query,
         sortBy,
         offset,
-        limit,
+        limit: itemsPerPageLimit,
         includeMembersCount: true,
       });
     }
@@ -60,7 +60,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         {...{
           totalCount: communities.length,
           offset: offset ?? 0,
-          limit,
+          limit: itemsPerPageLimit,
           query: query ?? '',
           sortBy,
           selectedFilters: {onlyMyCommunities},

--- a/apps/researcher/src/app/[locale]/communities/page.tsx
+++ b/apps/researcher/src/app/[locale]/communities/page.tsx
@@ -13,6 +13,7 @@ import {AddCommunityButton} from './buttons';
 import {MyCommunityToggle} from './my-community-toggle';
 import SignedIn from '@/lib/community/signed-in';
 import {SignedOut} from '@clerk/nextjs';
+import {limit} from './settings';
 
 // 1 day = 60*60*24 = 86400
 export const revalidate = 86400;
@@ -37,7 +38,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
       communities = await getMyCommunities({
         sortBy,
         offset,
-        limit: 24,
+        limit,
         includeMembersCount: true,
       });
     } else {
@@ -45,7 +46,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         query,
         sortBy,
         offset,
-        limit: 24,
+        limit,
         includeMembersCount: true,
       });
     }
@@ -59,7 +60,7 @@ export default async function CommunitiesPage({searchParams = {}}: Props) {
         {...{
           totalCount: communities.length,
           offset: offset ?? 0,
-          limit: 12,
+          limit,
           query: query ?? '',
           sortBy,
           selectedFilters: {onlyMyCommunities},

--- a/apps/researcher/src/app/[locale]/communities/settings.ts
+++ b/apps/researcher/src/app/[locale]/communities/settings.ts
@@ -1,0 +1,1 @@
+export const limit = 12;

--- a/apps/researcher/src/app/[locale]/communities/settings.ts
+++ b/apps/researcher/src/app/[locale]/communities/settings.ts
@@ -1,1 +1,1 @@
-export const limit = 12;
+export const itemsPerPageLimit = 12;

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
@@ -9,13 +9,13 @@ import {ImageFetchMode} from '@colonial-collections/list-store';
 interface Props {
   heritageObject: HeritageObject;
   imageFetchMode: ImageFetchMode;
-  isInitialized: boolean;
+  listSettingsLoaded: boolean;
 }
 
 export function HeritageObjectCard({
   heritageObject,
   imageFetchMode,
-  isInitialized,
+  listSettingsLoaded,
 }: Props) {
   const t = useTranslations('HeritageObjectCard');
   const imageUrl =
@@ -42,22 +42,24 @@ export function HeritageObjectCard({
         {heritageObject.isPartOf?.publisher?.name}
       </div>
 
-      {imageUrl && isInitialized && imageFetchMode !== ImageFetchMode.None && (
-        <div>
-          <ImageWithFallback
-            src={imageUrl}
-            alt={heritageObject.name || ''}
-            width="0"
-            height="0"
-            sizes={imageFetchMode === ImageFetchMode.Large ? '270px' : '90px'}
-            quality={40}
-            className={classNames('max-h-72 object-cover object-center', {
-              'w-full max-h-72': imageFetchMode === ImageFetchMode.Large,
-              'w-1/3': imageFetchMode === ImageFetchMode.Small,
-            })}
-          />
-        </div>
-      )}
+      {imageUrl &&
+        listSettingsLoaded &&
+        imageFetchMode !== ImageFetchMode.None && (
+          <div>
+            <ImageWithFallback
+              src={imageUrl}
+              alt={heritageObject.name || ''}
+              width="0"
+              height="0"
+              sizes={imageFetchMode === ImageFetchMode.Large ? '270px' : '90px'}
+              quality={40}
+              className={classNames('max-h-72 object-cover object-center', {
+                'w-full max-h-72': imageFetchMode === ImageFetchMode.Large,
+                'w-1/3': imageFetchMode === ImageFetchMode.Small,
+              })}
+            />
+          </div>
+        )}
     </Link>
   );
 }
@@ -65,7 +67,7 @@ export function HeritageObjectCard({
 export function HeritageObjectListItem({
   heritageObject,
   imageFetchMode,
-  isInitialized,
+  listSettingsLoaded,
 }: Props) {
   const t = useTranslations('HeritageObjectCard');
   const imageUrl =
@@ -81,7 +83,7 @@ export function HeritageObjectListItem({
     >
       <div className="w-30">
         {imageUrl &&
-          isInitialized &&
+          listSettingsLoaded &&
           imageFetchMode !== ImageFetchMode.None && (
             <div>
               <ImageWithFallback

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-card.tsx
@@ -9,9 +9,14 @@ import {ImageFetchMode} from '@colonial-collections/list-store';
 interface Props {
   heritageObject: HeritageObject;
   imageFetchMode: ImageFetchMode;
+  isInitialized: boolean;
 }
 
-export function HeritageObjectCard({heritageObject, imageFetchMode}: Props) {
+export function HeritageObjectCard({
+  heritageObject,
+  imageFetchMode,
+  isInitialized,
+}: Props) {
   const t = useTranslations('HeritageObjectCard');
   const imageUrl =
     heritageObject.images && heritageObject.images.length > 0
@@ -37,7 +42,7 @@ export function HeritageObjectCard({heritageObject, imageFetchMode}: Props) {
         {heritageObject.isPartOf?.publisher?.name}
       </div>
 
-      {imageUrl && imageFetchMode !== ImageFetchMode.None && (
+      {imageUrl && isInitialized && imageFetchMode !== ImageFetchMode.None && (
         <div>
           <ImageWithFallback
             src={imageUrl}
@@ -60,6 +65,7 @@ export function HeritageObjectCard({heritageObject, imageFetchMode}: Props) {
 export function HeritageObjectListItem({
   heritageObject,
   imageFetchMode,
+  isInitialized,
 }: Props) {
   const t = useTranslations('HeritageObjectCard');
   const imageUrl =
@@ -74,19 +80,23 @@ export function HeritageObjectListItem({
       aria-label={t('heritageObject')}
     >
       <div className="w-30">
-        {imageUrl && imageFetchMode !== ImageFetchMode.None && (
-          <div>
-            <ImageWithFallback
-              src={imageUrl}
-              alt={heritageObject.name || ''}
-              width="0"
-              height="0"
-              sizes={imageFetchMode === ImageFetchMode.Large ? '270px' : '90px'}
-              quality={40}
-              className="w-20 -my-3"
-            />
-          </div>
-        )}
+        {imageUrl &&
+          isInitialized &&
+          imageFetchMode !== ImageFetchMode.None && (
+            <div>
+              <ImageWithFallback
+                src={imageUrl}
+                alt={heritageObject.name || ''}
+                width="0"
+                height="0"
+                sizes={
+                  imageFetchMode === ImageFetchMode.Large ? '270px' : '90px'
+                }
+                quality={40}
+                className="w-20 -my-3"
+              />
+            </div>
+          )}
 
         {!imageUrl && imageFetchMode !== ImageFetchMode.None && (
           <div className="w-20 flex flex-col justify-center items-center text-xs text-neutral-400">

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
@@ -32,7 +32,7 @@ export default function HeritageObjectList({
               key={heritageObject.id}
               heritageObject={heritageObject}
               imageFetchMode={imageFetchMode!}
-              isInitialized={isInitialized}
+              listSettingsLoaded={isInitialized}
             />
           ))}
           <LoadingOverlay loading={loading} />
@@ -47,7 +47,7 @@ export default function HeritageObjectList({
                 key={heritageObject.id}
                 heritageObject={heritageObject}
                 imageFetchMode={imageFetchMode!}
-                isInitialized={isInitialized}
+                listSettingsLoaded={isInitialized}
               />
             ))}
           </div>

--- a/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
+++ b/apps/researcher/src/app/[locale]/objects/heritage-object-list.tsx
@@ -21,6 +21,7 @@ export default function HeritageObjectList({
   const view = useListStore(s => s.view);
   const imageFetchMode = useListStore(s => s.imageFetchMode);
   const loading = useListStore(s => s.newDataNeeded);
+  const isInitialized = useListStore(s => s.isInitialized);
 
   if (totalCount > 0) {
     if (view === 'grid') {
@@ -31,6 +32,7 @@ export default function HeritageObjectList({
               key={heritageObject.id}
               heritageObject={heritageObject}
               imageFetchMode={imageFetchMode!}
+              isInitialized={isInitialized}
             />
           ))}
           <LoadingOverlay loading={loading} />
@@ -45,6 +47,7 @@ export default function HeritageObjectList({
                 key={heritageObject.id}
                 heritageObject={heritageObject}
                 imageFetchMode={imageFetchMode!}
+                isInitialized={isInitialized}
               />
             ))}
           </div>

--- a/apps/researcher/src/app/[locale]/objects/layout.tsx
+++ b/apps/researcher/src/app/[locale]/objects/layout.tsx
@@ -2,6 +2,7 @@ import {
   ListProvider,
   ListView,
   defaultImageFetchMode,
+  defaultLimit,
 } from '@colonial-collections/list-store';
 import {defaultSortByUserOption} from './sort-mapping';
 import {ReactNode} from 'react';
@@ -13,6 +14,7 @@ export default function ObjectLayout({children}: {children: ReactNode}) {
       defaultSortBy={defaultSortByUserOption}
       defaultImageFetchMode={defaultImageFetchMode}
       defaultView={ListView.Grid}
+      defaultLimit={defaultLimit}
     >
       {children}
     </ListProvider>

--- a/apps/researcher/src/app/[locale]/objects/search-results.tsx
+++ b/apps/researcher/src/app/[locale]/objects/search-results.tsx
@@ -7,6 +7,7 @@ import {
   sortMapping,
 } from './sort-mapping';
 import {
+  defaultLimit,
   fromSearchParamsToSearchOptions,
   getClientSortBy,
   ImageFetchMode,
@@ -137,6 +138,7 @@ export default async function SearchResults({searchParams = {}}: Props) {
       type: searchParamType,
     })),
     searchParams,
+    defaultLimit,
   });
 
   const sortBy = getClientSortBy({

--- a/apps/researcher/src/components/list-store-updater.tsx
+++ b/apps/researcher/src/components/list-store-updater.tsx
@@ -41,6 +41,7 @@ export function ListStoreUpdater<SortBy>({
   const defaultSortBy = useListStore<SortBy, SortBy>(s => s.defaultSortBy);
   const defaultView = useListStore(s => s.defaultView);
   const defaultImageFetchMode = useListStore(s => s.defaultImageFetchMode);
+  const defaultLimit = useListStore(s => s.defaultLimit);
 
   useUpdateListStore({
     totalCount,
@@ -67,6 +68,7 @@ export function ListStoreUpdater<SortBy>({
     imageFetchMode,
     defaultView,
     defaultImageFetchMode,
+    defaultLimit,
   });
 
   saveLastSearch(baseUrl, url);

--- a/packages/list-store/src/definitions.ts
+++ b/packages/list-store/src/definitions.ts
@@ -4,7 +4,7 @@ export enum SortBy {
   NameDesc = 'nameDesc',
 }
 
-export const defaultSortBy = SortBy.RelevanceDesc;
+export const defaultSortBy = SortBy.NameAsc;
 
 export enum ListView {
   Grid = 'grid',
@@ -18,3 +18,5 @@ export enum ImageFetchMode {
 }
 
 export const defaultImageFetchMode = ImageFetchMode.Large;
+
+export const defaultLimit = 25;

--- a/packages/list-store/src/search-params.test.ts
+++ b/packages/list-store/src/search-params.test.ts
@@ -4,7 +4,7 @@ import {
   getClientSortBy,
   FromSearchParamsToSearchOptionsProps,
 } from './search-params';
-import {SortBy, defaultSortBy} from './definitions';
+import {SortBy, defaultLimit, defaultSortBy} from './definitions';
 import {describe, expect, it} from '@jest/globals';
 import {z} from 'zod';
 
@@ -54,7 +54,7 @@ const sortOptions = {
 
 describe('getUrlWithSearchParams', () => {
   it('returns "/" if there are no filter options', () => {
-    expect(getUrlWithSearchParams({defaultSortBy})).toBe('/');
+    expect(getUrlWithSearchParams({defaultSortBy, defaultLimit})).toBe('/');
   });
 
   it('returns "/" with only default values', () => {
@@ -62,6 +62,7 @@ describe('getUrlWithSearchParams', () => {
       offset: 0,
       sortBy: defaultSortBy,
       defaultSortBy,
+      defaultLimit,
     };
 
     expect(getUrlWithSearchParams(options)).toBe('/');
@@ -71,6 +72,7 @@ describe('getUrlWithSearchParams', () => {
     const options = {
       query: '',
       defaultSortBy,
+      defaultLimit,
     };
 
     expect(getUrlWithSearchParams(options)).toBe('/');
@@ -80,6 +82,7 @@ describe('getUrlWithSearchParams', () => {
     const options = {
       query: '',
       defaultSortBy,
+      defaultLimit,
       filters: {
         types: [],
         locations: [],
@@ -94,6 +97,7 @@ describe('getUrlWithSearchParams', () => {
     const options = {
       query: 'my query',
       defaultSortBy,
+      defaultLimit,
     };
 
     expect(getUrlWithSearchParams(options)).toBe('/?query=my+query');
@@ -103,6 +107,7 @@ describe('getUrlWithSearchParams', () => {
     const options = {
       offset: 12,
       defaultSortBy,
+      defaultLimit,
     };
 
     expect(getUrlWithSearchParams(options)).toBe('/?offset=12');
@@ -110,16 +115,18 @@ describe('getUrlWithSearchParams', () => {
 
   it('adds "sortBy" to the search params if `sortBy` is not the default', () => {
     const options = {
-      sortBy: SortBy.NameAsc,
+      sortBy: SortBy.NameDesc,
       defaultSortBy,
+      defaultLimit,
     };
 
-    expect(getUrlWithSearchParams(options)).toBe('/?sortBy=nameAsc');
+    expect(getUrlWithSearchParams(options)).toBe('/?sortBy=nameDesc');
   });
 
   it('adds "filters" to the search params if the filter arrays are not empty', () => {
     const options = {
       defaultSortBy,
+      defaultLimit,
       filters: {
         types: ['filter1'],
         locations: ['filter2', 'filter3'],
@@ -139,6 +146,7 @@ describe('getUrlWithSearchParams', () => {
       offset: 20,
       sortBy: SortBy.NameDesc,
       defaultSortBy,
+      defaultLimit,
       filters: {
         types: ['filter1'],
         locations: ['filter2', 'filter3'],
@@ -160,6 +168,7 @@ describe('fromSearchParamsToSearchOptions', () => {
         sortOptions,
         searchParams: {},
         filterKeys: [],
+        defaultLimit,
       })
     ).toStrictEqual({
       filters: {},
@@ -182,12 +191,13 @@ describe('fromSearchParamsToSearchOptions', () => {
         sortOptions,
         searchParams,
         filterKeys: [],
+        defaultLimit,
       })
     ).toStrictEqual({
       filters: {},
       offset: 0,
-      sortBy: 'relevance',
-      sortOrder: 'desc',
+      sortBy: 'name',
+      sortOrder: 'asc',
       limit: 25,
       query: undefined,
     });
@@ -204,6 +214,7 @@ describe('fromSearchParamsToSearchOptions', () => {
         sortOptions,
         searchParams,
         filterKeys: [],
+        defaultLimit,
       })
     ).toStrictEqual({
       filters: {},
@@ -231,6 +242,7 @@ describe('fromSearchParamsToSearchOptions', () => {
         sortOptions,
         searchParams,
         filterKeys,
+        defaultLimit,
       })
     ).toStrictEqual({
       query: 'My query',

--- a/packages/list-store/src/search-params.ts
+++ b/packages/list-store/src/search-params.ts
@@ -3,8 +3,6 @@ import {ImageFetchMode, ListView} from './definitions';
 
 export type Type = 'string' | 'array' | 'number';
 
-const defaultLimit = 25;
-
 // Only strings are allowed in the search params.
 const searchParamFilterSchema = z
   .array(z.coerce.string())
@@ -15,6 +13,7 @@ interface GetSearchParamsSchemaProps<SortBy> {
   defaultSortBy: SortBy;
   defaultView?: ListView;
   defaultImageFetchMode?: ImageFetchMode;
+  defaultLimit: number;
 }
 
 function transformToStringAndRemoveDefaultSchema(defaultValue?: string) {
@@ -28,6 +27,7 @@ function getSearchParamsSchema<SortBy>({
   defaultSortBy,
   defaultView,
   defaultImageFetchMode,
+  defaultLimit,
 }: GetSearchParamsSchemaProps<SortBy>) {
   return z.object({
     query: z.string().default(''),
@@ -55,6 +55,7 @@ interface ClientSearchOptions<SortBy> {
   defaultSortBy: SortBy;
   defaultView?: ListView;
   defaultImageFetchMode?: ImageFetchMode;
+  defaultLimit: number;
 }
 
 export function getUrlWithSearchParams<SortBy>({
@@ -69,12 +70,14 @@ export function getUrlWithSearchParams<SortBy>({
   defaultSortBy,
   defaultImageFetchMode,
   defaultView,
+  defaultLimit,
 }: ClientSearchOptions<SortBy>): string {
   const searchParams: {[key: string]: string | string[]} =
     getSearchParamsSchema({
       defaultSortBy,
       defaultImageFetchMode,
       defaultView,
+      defaultLimit,
     }).parse({
       query,
       offset,
@@ -148,6 +151,7 @@ export interface FromSearchParamsToSearchOptionsProps {
     name: string;
     type: Type;
   }[];
+  defaultLimit: number;
 }
 
 // This function translates the search params to valid search options.
@@ -161,6 +165,7 @@ export function fromSearchParamsToSearchOptions({
     sortMapping,
   },
   filterKeys,
+  defaultLimit,
 }: FromSearchParamsToSearchOptionsProps) {
   // Always return a valid SearchOptions object, even if the search params aren't correct,
   // so the application doesn't fail on invalid search params.

--- a/packages/list-store/src/use-list-helpers.tsx
+++ b/packages/list-store/src/use-list-helpers.tsx
@@ -31,6 +31,7 @@ export const useListHref = () => {
   const view = useListStore(s => s.view);
   const imageFetchMode = useListStore(s => s.imageFetchMode);
   const limit = useListStore(s => s.limit);
+  const defaultLimit = useListStore(s => s.defaultLimit);
 
   const href = useMemo(
     () =>
@@ -46,10 +47,12 @@ export const useListHref = () => {
         view,
         imageFetchMode,
         limit,
+        defaultLimit,
       }),
     [
       baseUrl,
       defaultImageFetchMode,
+      defaultLimit,
       defaultSortBy,
       defaultView,
       imageFetchMode,

--- a/packages/list-store/src/use-list-store.test.tsx
+++ b/packages/list-store/src/use-list-store.test.tsx
@@ -8,7 +8,7 @@ import {
   initialList,
   ListProvider,
 } from './use-list-store';
-import {SortBy, defaultSortBy} from './definitions';
+import {SortBy, defaultSortBy, defaultLimit} from './definitions';
 import {renderHook} from '@testing-library/react';
 
 const initialState = {
@@ -16,13 +16,19 @@ const initialState = {
   defaultSortBy,
   sortBy: defaultSortBy,
   baseUrl: '/',
+  defaultLimit,
+  limit: defaultLimit,
 };
 
 describe('useListStore', () => {
   it('returns the selected state from the store', () => {
     const {result} = renderHook(() => useListStore(s => s.defaultSortBy), {
       wrapper: ({children}) => (
-        <ListProvider baseUrl="/" defaultSortBy={SortBy.NameAsc}>
+        <ListProvider
+          baseUrl="/"
+          defaultSortBy={SortBy.NameAsc}
+          defaultLimit={defaultLimit}
+        >
           {children}
         </ListProvider>
       ),

--- a/packages/list-store/src/use-list-store.tsx
+++ b/packages/list-store/src/use-list-store.tsx
@@ -19,6 +19,7 @@ interface ListProps<SortBy> {
   defaultSortBy: SortBy;
   defaultView?: ListView;
   defaultImageFetchMode?: ImageFetchMode;
+  defaultLimit: number;
   baseUrl: string;
   selectedFilters: {
     [filterKey: string]: (string | number)[] | number | string | undefined;
@@ -139,7 +140,6 @@ export const initialList = {
   query: '',
   totalCount: 0,
   offset: 0,
-  limit: 25,
   sortBy: undefined,
   defaultSortBy: undefined,
   defaultView: undefined,
@@ -155,6 +155,7 @@ export type ListProviderProps<SortBy> = PropsWithChildren<{
   defaultSortBy: SortBy;
   defaultView?: ListView;
   defaultImageFetchMode?: ImageFetchMode;
+  defaultLimit: number;
   baseUrl: string;
 }>;
 
@@ -162,7 +163,8 @@ export function ListProvider<SortBy>({
   children,
   defaultSortBy,
   defaultView,
-  defaultImageFetchMode,
+  defaultImageFetchMode = ImageFetchMode.None,
+  defaultLimit,
   baseUrl,
 }: ListProviderProps<SortBy>) {
   const storeRef = useRef<ListStore<SortBy>>();
@@ -174,10 +176,10 @@ export function ListProvider<SortBy>({
       defaultImageFetchMode,
       sortBy: defaultSortBy,
       view: defaultView,
-      // Set the default `imageFetchMode` to none so images won't load by default.
-      // As soon as the search results are loaded this will be overridden by the user setting.
-      imageFetchMode: ImageFetchMode.None,
+      imageFetchMode: defaultImageFetchMode,
       baseUrl,
+      limit: defaultLimit,
+      defaultLimit,
     });
   }
 


### PR DESCRIPTION
The defaults for `sortBy`, `limit`, `view`, and `imageFetchMode` were not always set correctly, and there were some differences. Without changing the logic too much, I tried to set the defaults all the same way and use the same default variable for each list to prevent different values being used within the same list.

Details of the implementation

- `imageFetchMode` is not set to `ImageFetchMode.None` to prevent loading of images. Instead, in the object card, I wait for `isInitialized` before trying to load the images.
- There was no default limit; this was a problem because the communities list used a different value. The wrong limit was added to the URL search parameters when navigating back, causing unexpected behavior. To address this, I added a default for limit, which ensures a consistent and predictable user experience.
- The default sortBy was `RelevanceDesc`, but we don't use relevance for most lists, so I changed this to `NameAsc`.