### PR TITLE
fix: improve storing and improving of enrichments

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/actions.ts
@@ -63,8 +63,6 @@ export async function addUserEnrichment({
   user,
   community,
 }: AddUserEnrichmentProps) {
-  console.log(JSON.stringify(user, null, 2));
-
   const enrichment = await creator.addText({
     type: additionalType,
     description,

--- a/apps/researcher/src/app/[locale]/objects/[id]/actions.ts
+++ b/apps/researcher/src/app/[locale]/objects/[id]/actions.ts
@@ -63,6 +63,8 @@ export async function addUserEnrichment({
   user,
   community,
 }: AddUserEnrichmentProps) {
+  console.log(JSON.stringify(user, null, 2));
+
   const enrichment = await creator.addText({
     type: additionalType,
     description,

--- a/apps/researcher/src/lib/enricher-instances.ts
+++ b/apps/researcher/src/lib/enricher-instances.ts
@@ -17,7 +17,6 @@ export const provenanceEventEnrichmentFetcher =
   });
 
 export const creator = new EnrichmentCreator({
-  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
   nanopubClient: new NanopubClient({
     endpointUrl: env.NANOPUB_WRITE_ENDPOINT_URL as string,
     proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,

--- a/packages/enricher/src/creator.integration.test.ts
+++ b/packages/enricher/src/creator.integration.test.ts
@@ -12,10 +12,7 @@ const nanopubClient = new NanopubClient({
   proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
 });
 
-const creator = new EnrichmentCreator({
-  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-  nanopubClient,
-});
+const creator = new EnrichmentCreator({nanopubClient});
 
 describe('addText', () => {
   it('adds a basic textual enrichment, with only required properties', async () => {

--- a/packages/enricher/src/creator.ts
+++ b/packages/enricher/src/creator.ts
@@ -1,20 +1,15 @@
 import {NanopubClient} from './client';
 import {
-  heritageObjectEnrichmentBeingCreatedSchema,
   HeritageObjectEnrichmentBeingCreated,
   HeritageObjectEnrichmentStorer,
-  FullHeritageObjectEnrichmentBeingCreated,
 } from './objects';
 import {
-  FullProvenanceEventEnrichmentBeingCreated,
   ProvenanceEventEnrichmentBeingCreated,
   ProvenanceEventEnrichmentStorer,
-  provenanceEventEnrichmentBeingCreatedSchema,
 } from './provenance-events';
 import {z} from 'zod';
 
 const constructorOptionsSchema = z.object({
-  knowledgeGraphEndpointUrl: z.string(),
   nanopubClient: z.instanceof(NanopubClient),
 });
 
@@ -24,14 +19,12 @@ export type EnrichmentCreatorConstructorOptions = z.infer<
 
 // High-level class for creating enrichments
 export class EnrichmentCreator {
-  private readonly knowledgeGraphEndpointUrl: string;
   private readonly heritageObjectEnrichmentStorer: HeritageObjectEnrichmentStorer;
   private readonly provenanceEventEnrichmentStorer: ProvenanceEventEnrichmentStorer;
 
   constructor(options: EnrichmentCreatorConstructorOptions) {
     const opts = constructorOptionsSchema.parse(options);
 
-    this.knowledgeGraphEndpointUrl = opts.knowledgeGraphEndpointUrl;
     this.heritageObjectEnrichmentStorer = new HeritageObjectEnrichmentStorer({
       nanopubClient: opts.nanopubClient,
     });
@@ -41,45 +34,12 @@ export class EnrichmentCreator {
   }
 
   async addText(enrichmentBeingCreated: HeritageObjectEnrichmentBeingCreated) {
-    const opts = heritageObjectEnrichmentBeingCreatedSchema.parse(
-      enrichmentBeingCreated
-    );
-
-    // TODO: fetch the resource ID (e.g. the IRI of the name of an object) from the knowledge graph.
-    // The KG currently does not have these IDs, so this is a temporary dummy implementation.
-    const resourceId = `${opts.about}#${opts.type}`;
-
-    const fullEnrichmentBeingCreated: FullHeritageObjectEnrichmentBeingCreated =
-      {
-        ...opts,
-        about: {
-          id: resourceId,
-          isPartOf: {
-            id: opts.about,
-          },
-        },
-      };
-
-    return this.heritageObjectEnrichmentStorer.addText(
-      fullEnrichmentBeingCreated
-    );
+    return this.heritageObjectEnrichmentStorer.addText(enrichmentBeingCreated);
   }
 
   async addProvenanceEvent(
     enrichmentBeingCreated: ProvenanceEventEnrichmentBeingCreated
   ) {
-    const opts = provenanceEventEnrichmentBeingCreatedSchema.parse(
-      enrichmentBeingCreated
-    );
-
-    const fullEnrichmentBeingCreated: FullProvenanceEventEnrichmentBeingCreated =
-      {
-        ...opts,
-        about: {
-          id: opts.about,
-        },
-      };
-
-    return this.provenanceEventEnrichmentStorer.add(fullEnrichmentBeingCreated);
+    return this.provenanceEventEnrichmentStorer.add(enrichmentBeingCreated);
   }
 }

--- a/packages/enricher/src/objects/definitions.ts
+++ b/packages/enricher/src/objects/definitions.ts
@@ -2,6 +2,7 @@ import {basicEnrichmentBeingCreatedSchema, PubInfo} from '../definitions';
 import {z} from 'zod';
 
 // An enrichment can be about these types
+// Beware: the values of these type matter - these are stored in the nanopublications!
 export enum HeritageObjectEnrichmentType {
   Creator = 'creator',
   DateCreated = 'dateCreated',
@@ -24,22 +25,6 @@ export const heritageObjectEnrichmentBeingCreatedSchema =
 
 export type HeritageObjectEnrichmentBeingCreated = z.infer<
   typeof heritageObjectEnrichmentBeingCreatedSchema
->;
-
-export const fullHeritageObjectEnrichmentBeingCreatedSchema =
-  heritageObjectEnrichmentBeingCreatedSchema.merge(
-    z.object({
-      about: z.object({
-        id: z.string().url(),
-        isPartOf: z.object({
-          id: z.string().url(),
-        }),
-      }),
-    })
-  );
-
-export type FullHeritageObjectEnrichmentBeingCreated = z.infer<
-  typeof fullHeritageObjectEnrichmentBeingCreatedSchema
 >;
 
 export type HeritageObjectEnrichment = {

--- a/packages/enricher/src/objects/fetcher.integration.test.ts
+++ b/packages/enricher/src/objects/fetcher.integration.test.ts
@@ -12,10 +12,7 @@ const nanopubClient = new NanopubClient({
   proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
 });
 
-const creator = new EnrichmentCreator({
-  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-  nanopubClient,
-});
+const creator = new EnrichmentCreator({nanopubClient});
 
 const fetcher = new HeritageObjectEnrichmentFetcher({
   endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,

--- a/packages/enricher/src/objects/fetcher.ts
+++ b/packages/enricher/src/objects/fetcher.ts
@@ -46,9 +46,8 @@ export class HeritageObjectEnrichmentFetcher {
         ?source ex:hasEnrichment ?annotation .
 
         ?annotation a ex:HeritageObjectEnrichment ;
-          ex:additionalType ?additionalType ;
-          ex:about ?target ;
-          ex:isPartOf ?source ;
+          ex:additionalType ?scope ;
+          ex:about ?source ;
           ex:description ?value ;
           ex:citation ?comment ;
           ex:inLanguage ?language ;
@@ -81,9 +80,6 @@ export class HeritageObjectEnrichmentFetcher {
           ?np a cc:Nanopub ;
             npx:introduces ?annotation ;
             dcterms:license ?license .
-
-          ?np a ?additionalType
-          FILTER(?additionalType != cc:Nanopub)
         }
 
         graph ?provenance {
@@ -102,8 +98,8 @@ export class HeritageObjectEnrichmentFetcher {
           ?annotation a oa:Annotation ;
              oa:hasTarget ?target .
 
-          ?target a oa:SpecificResource ;
-             oa:hasSource ?source .
+          ?target oa:hasSource ?source ;
+            oa:hasScope ?scope .
 
           OPTIONAL {
             ?annotation oa:hasBody ?body .

--- a/packages/enricher/src/objects/helpers.test.ts
+++ b/packages/enricher/src/objects/helpers.test.ts
@@ -1,19 +1,36 @@
 import {HeritageObjectEnrichmentType} from './definitions';
-import {fromClassToType, fromTypeToClass} from './helpers';
-import {ontologyUrl, ontologyVersionIdentifier} from '../definitions';
+import {
+  fromPropertyToType,
+  fromTypeToClass,
+  fromTypeToProperty,
+} from './helpers';
+import {ontologyVersionIdentifier, ontologyUrl} from '../definitions';
 import {describe, expect, it} from '@jest/globals';
 
-describe('fromClassToType', () => {
-  it('throws if the type is unknown', () => {
-    expect(() => fromClassToType('badValue')).toThrow(
-      'Unknown class: "badValue"'
+describe('fromTypeToProperty', () => {
+  it('throws if the property is unknown', () => {
+    // @ts-expect-error:TS2345
+    expect(() => fromTypeToProperty('badValue')).toThrow(
+      'Unknown type: "badValue"'
     );
   });
 
-  it('returns the type of a class', () => {
-    const type = fromClassToType(
-      `${ontologyUrl}Material${ontologyVersionIdentifier}`
+  it('returns the property of a type', () => {
+    const property = fromTypeToProperty(HeritageObjectEnrichmentType.Material);
+
+    expect(property).toEqual(`${ontologyUrl}material`);
+  });
+});
+
+describe('fromPropertyToType', () => {
+  it('throws if the type is unknown', () => {
+    expect(() => fromPropertyToType('badValue')).toThrow(
+      'Unknown property: "badValue"'
     );
+  });
+
+  it('returns the type of a property', () => {
+    const type = fromPropertyToType(`${ontologyUrl}material`);
 
     expect(type).toEqual(HeritageObjectEnrichmentType.Material);
   });

--- a/packages/enricher/src/objects/helpers.ts
+++ b/packages/enricher/src/objects/helpers.ts
@@ -1,6 +1,32 @@
 import {ontologyVersionIdentifier, ontologyUrl} from '../definitions';
 import {HeritageObjectEnrichmentType} from './definitions';
 
+// E.g. from 'material' to 'https://data.colonialcollections.nl/schemas/nanopub#material'
+export function fromTypeToProperty(type: HeritageObjectEnrichmentType) {
+  const entries = Object.entries(HeritageObjectEnrichmentType);
+  for (const entry of entries) {
+    if (type === entry[1]) {
+      return `${ontologyUrl}${type}`;
+    }
+  }
+
+  throw new TypeError(`Unknown type: "${type}"`);
+}
+
+// E.g. from 'https://data.colonialcollections.nl/schemas/nanopub#material' to 'material'
+export function fromPropertyToType(property: string | undefined) {
+  const entries = Object.entries(HeritageObjectEnrichmentType);
+  for (const entry of entries) {
+    if (property === `${ontologyUrl}${entry[1]}`) {
+      return entry[1];
+    }
+  }
+
+  // This error can be thrown if an external app has published a nanopub for
+  // inclusion into the Datahub without adhering to its data model
+  throw new TypeError(`Unknown property: "${property}"`);
+}
+
 // E.g. from 'material' to 'https://data.colonialcollections.nl/schemas/nanopub#MaterialVersion1'
 export function fromTypeToClass(type: HeritageObjectEnrichmentType) {
   const entries = Object.entries(HeritageObjectEnrichmentType);
@@ -11,18 +37,4 @@ export function fromTypeToClass(type: HeritageObjectEnrichmentType) {
   }
 
   throw new TypeError(`Unknown type: "${type}"`);
-}
-
-// E.g. from 'https://data.colonialcollections.nl/schemas/nanopub#MaterialVersion1' to 'material'
-export function fromClassToType(className: string | undefined) {
-  const entries = Object.entries(HeritageObjectEnrichmentType);
-  for (const [key, value] of entries) {
-    if (className === `${ontologyUrl}${key}${ontologyVersionIdentifier}`) {
-      return value;
-    }
-  }
-
-  // This error can be thrown if an external app has published a nanopub for
-  // inclusion into the Datahub without adhering to its data model
-  throw new TypeError(`Unknown class: "${className}"`);
 }

--- a/packages/enricher/src/objects/rdf-helpers.test.ts
+++ b/packages/enricher/src/objects/rdf-helpers.test.ts
@@ -1,4 +1,4 @@
-import {ontologyUrl, ontologyVersionIdentifier} from '../definitions';
+import {ontologyUrl} from '../definitions';
 import {HeritageObjectEnrichmentType} from './definitions';
 import {toHeritageObjectEnrichment} from './rdf-helpers';
 import {describe, expect, it} from '@jest/globals';
@@ -22,15 +22,15 @@ beforeAll(async () => {
     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
     ex:basicEnrichment a ex:HeritageObjectEnrichment ;
-      ex:additionalType <${ontologyUrl}Material${ontologyVersionIdentifier}> ;
-      ex:isPartOf <https://example.com/object> ;
+      ex:additionalType <${ontologyUrl}material> ;
+      ex:about <https://example.com/object> ;
       ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date .
 
     ex:fullEnrichment a ex:HeritageObjectEnrichment ;
-      ex:additionalType <${ontologyUrl}Material${ontologyVersionIdentifier}> ;
-      ex:isPartOf <https://example.com/object> ;
+      ex:additionalType <${ontologyUrl}material> ;
+      ex:about <https://example.com/object> ;
       ex:creator ex:myPerson ;
       ex:license <https://example.com/license> ;
       ex:dateCreated "2023-01-01"^^xsd:date ;

--- a/packages/enricher/src/objects/rdf-helpers.ts
+++ b/packages/enricher/src/objects/rdf-helpers.ts
@@ -1,4 +1,4 @@
-import {fromClassToType} from './helpers';
+import {fromPropertyToType} from './helpers';
 import {HeritageObjectEnrichment} from './definitions';
 import {
   createActors,
@@ -11,7 +11,7 @@ import type {Resource} from 'rdf-object';
 
 export function toHeritageObjectEnrichment(rawEnrichment: Resource) {
   const additionalType = getPropertyValue(rawEnrichment, 'ex:additionalType');
-  const about = getPropertyValue(rawEnrichment, 'ex:isPartOf')!;
+  const about = getPropertyValue(rawEnrichment, 'ex:about')!;
   const creator = onlyOne(createActors(rawEnrichment, 'ex:creator'))!;
   const group = onlyOne(createActors(rawEnrichment, 'ex:createdOnBehalfOf'));
   const license = getPropertyValue(rawEnrichment, 'ex:license')!;
@@ -25,7 +25,7 @@ export function toHeritageObjectEnrichment(rawEnrichment: Resource) {
 
   const enrichment: HeritageObjectEnrichment = {
     id: rawEnrichment.value,
-    type: fromClassToType(additionalType),
+    type: fromPropertyToType(additionalType),
     about,
     citation,
     description,

--- a/packages/enricher/src/objects/storer.integration.test.ts
+++ b/packages/enricher/src/objects/storer.integration.test.ts
@@ -15,12 +15,7 @@ describe('add', () => {
   it('adds a basic textual enrichment, with only required properties', async () => {
     const enrichment = await storer.addText({
       type: HeritageObjectEnrichmentType.Name,
-      about: {
-        id: 'http://example.org/object#name',
-        isPartOf: {
-          id: 'http://example.org/object',
-        },
-      },
+      about: 'http://example.org/object',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',
@@ -41,12 +36,7 @@ describe('add', () => {
       description: 'A comment about the name of an object',
       citation: 'A citation or reference to a work that supports the comment',
       inLanguage: 'en',
-      about: {
-        id: 'http://example.org/object#name',
-        isPartOf: {
-          id: 'http://example.org/object',
-        },
-      },
+      about: 'http://example.org/object',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',

--- a/packages/enricher/src/provenance-events/definitions.ts
+++ b/packages/enricher/src/provenance-events/definitions.ts
@@ -61,19 +61,6 @@ export type ProvenanceEventEnrichmentBeingCreated = z.infer<
   typeof provenanceEventEnrichmentBeingCreatedSchema
 >;
 
-export const fullProvenanceEventEnrichmentBeingCreatedSchema =
-  provenanceEventEnrichmentBeingCreatedSchema.merge(
-    z.object({
-      about: z.object({
-        id: z.string().url(),
-      }),
-    })
-  );
-
-export type FullProvenanceEventEnrichmentBeingCreated = z.infer<
-  typeof fullProvenanceEventEnrichmentBeingCreatedSchema
->;
-
 export type ProvenanceEventEnrichment = {
   id: string;
   type: ProvenanceEventType;

--- a/packages/enricher/src/provenance-events/fetcher.integration.test.ts
+++ b/packages/enricher/src/provenance-events/fetcher.integration.test.ts
@@ -12,10 +12,7 @@ const nanopubClient = new NanopubClient({
   proxyEndpointUrl: env.NANOPUB_WRITE_PROXY_ENDPOINT_URL as string,
 });
 
-const creator = new EnrichmentCreator({
-  knowledgeGraphEndpointUrl: env.SPARQL_ENDPOINT_URL as string,
-  nanopubClient,
-});
+const creator = new EnrichmentCreator({nanopubClient});
 
 const fetcher = new ProvenanceEventEnrichmentFetcher({
   endpointUrl: env.NANOPUB_SPARQL_ENDPOINT_URL as string,

--- a/packages/enricher/src/provenance-events/storer.integration.test.ts
+++ b/packages/enricher/src/provenance-events/storer.integration.test.ts
@@ -15,9 +15,7 @@ describe('add event', () => {
   it('adds an event with only a start date', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       date: {
         startDate: '1805',
       },
@@ -38,9 +36,7 @@ describe('add event', () => {
   it('adds an event with only an end date', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       date: {
         endDate: '1806',
       },
@@ -63,9 +59,7 @@ describe('add acquisition event', () => {
   it('adds a basic event, with only required properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.Acquisition,
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',
@@ -111,9 +105,7 @@ describe('add acquisition event', () => {
         id: 'http://vocab.getty.edu/aat/300435722',
         name: 'Possibly',
       },
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',
@@ -137,9 +129,7 @@ describe('add transfer of custody event', () => {
   it('adds a basic event, with only required properties', async () => {
     const enrichment = await storer.add({
       type: ProvenanceEventType.TransferOfCustody,
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',
@@ -185,9 +175,7 @@ describe('add transfer of custody event', () => {
         id: 'http://vocab.getty.edu/aat/300435722',
         name: 'Possibly',
       },
-      about: {
-        id: 'http://example.org/object1',
-      },
+      about: 'http://example.org/object1',
       pubInfo: {
         creator: {
           id: 'http://example.com/person',

--- a/packages/enricher/src/provenance-events/storer.ts
+++ b/packages/enricher/src/provenance-events/storer.ts
@@ -6,8 +6,8 @@ import {
 } from '../definitions';
 import {getDateAsXsd, DateType} from './helpers';
 import {
-  fullProvenanceEventEnrichmentBeingCreatedSchema,
-  FullProvenanceEventEnrichmentBeingCreated,
+  provenanceEventEnrichmentBeingCreatedSchema,
+  ProvenanceEventEnrichmentBeingCreated,
   ProvenanceEventType,
 } from './definitions';
 import {DataFactory} from 'rdf-data-factory';
@@ -35,11 +35,9 @@ export class ProvenanceEventEnrichmentStorer {
     this.nanopubClient = opts.nanopubClient;
   }
 
-  async add(
-    fullEnrichmentBeingCreated: FullProvenanceEventEnrichmentBeingCreated
-  ) {
-    const opts = fullProvenanceEventEnrichmentBeingCreatedSchema.parse(
-      fullEnrichmentBeingCreated
+  async add(enrichmentBeingCreated: ProvenanceEventEnrichmentBeingCreated) {
+    const opts = provenanceEventEnrichmentBeingCreatedSchema.parse(
+      enrichmentBeingCreated
     );
 
     const publicationStore = RdfStore.createDefault();
@@ -217,7 +215,7 @@ export class ProvenanceEventEnrichmentStorer {
       DF.quad(
         provenanceEventId,
         DF.namedNode(`http://www.cidoc-crm.org/cidoc-crm/${objectPredicate}`),
-        DF.namedNode(opts.about.id)
+        DF.namedNode(opts.about)
       )
     );
 


### PR DESCRIPTION
This PR refactors the `enricher` a bit. The cause is the issue in [this ticket](https://github.com/orgs/colonial-heritage/projects/1/views/1?pane=issue&itemId=55697938): we're unable to make clear what the enrichment is about, e.g. about the _title_ or about the _description_ of an heritage object. The implementation that the `enricher` has used so far is provisional - this PR introduces a permanent implementation.