### PR TITLE
feat: updated datamodel of research guides

### DIFF
--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -66,11 +66,11 @@ export default async function GuidePage({params}: Props) {
             </div>
           </div>
           <div className="w-full md:w-1/3">
-            {guide.hasParts && guide.hasParts?.length > 0 && (
+            {guide.seeAlso && guide.seeAlso?.length > 0 && (
               <>
                 <h2 className="mb-2">{t('relatedItems')}</h2>
                 <div className="flex flex-col gap-2 mb-4">
-                  {guide.hasParts?.map(item => (
+                  {guide.seeAlso?.map(item => (
                     <Link
                       key={item.id}
                       href={`/research-guide/${encodeRouteSegment(item.id)}`}

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -27,7 +27,7 @@ export default async function Page() {
       <div className="bg-consortium-sand-100 rounded mt-6 -mx-4 pr-10">
         <h2 className="px-4 pt-4">{t('level1Title')}</h2>
         <div className="pb-4 columns-3 gap-10">
-          {topLevel.hasParts?.map(item => (
+          {topLevel.seeAlso?.map(item => (
             <Link
               key={item.id}
               href={`/research-guide/${encodeRouteSegment(item.id)}`}

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -8,7 +8,7 @@ import {MDXRemote} from 'next-mdx-remote/rsc';
 
 export default async function Page() {
   const locale = (await getLocale()) as LocaleEnum;
-  const topLevels = await researchGuides.getByTopLevel({locale});
+  const topLevels = await researchGuides.getTopLevels({locale});
   const t = await getTranslations('ResearchGuide');
 
   if (!topLevels.length) {

--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -3,6 +3,7 @@ import {Place, Term, Thing} from '../definitions';
 export type Citation = Thing & {url?: string};
 
 export type ResearchGuide = Thing & {
+  identifier?: string;
   abstract?: string;
   text?: string;
   encodingFormat?: string;
@@ -11,4 +12,5 @@ export type ResearchGuide = Thing & {
   citations?: Citation[];
   isPartOf?: ResearchGuide[];
   hasParts?: ResearchGuide[];
+  seeAlso?: Thing[];
 };

--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -10,7 +10,5 @@ export type ResearchGuide = Thing & {
   contentLocations?: Place[];
   keywords?: Term[];
   citations?: Citation[];
-  isPartOf?: ResearchGuide[];
-  hasParts?: ResearchGuide[];
-  seeAlso?: Thing[];
+  seeAlso?: ResearchGuide[];
 };

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -14,7 +14,7 @@ describe('getTopLevels', () => {
   it('returns the top level guides', async () => {
     const researchGuides = await researchGuideFetcher.getTopLevels();
 
-    // The sorting order is undefined and can change. Don't use toStrictEqual()
+    // The sorting order is undefined and can change - dDon't use toStrictEqual()
     expect(researchGuides).toMatchObject([
       {
         id: 'https://guides.example.org/top-set',
@@ -23,29 +23,41 @@ describe('getTopLevels', () => {
           'Research aides for conducting provenance research into colonial collections',
         text: 'Digital research guide',
         encodingFormat: 'text/markdown',
-        hasParts: expect.arrayContaining([
+        seeAlso: expect.arrayContaining([
           {
             id: 'https://guides.example.org/level-3-set',
             identifier: '3',
-            hasParts: expect.arrayContaining([
-              {
-                id: 'https://guides.example.org/level-3a',
-                name: 'Royal Cabinet of Curiosities',
-              },
+            seeAlso: expect.arrayContaining([
               {
                 id: 'https://guides.example.org/level-3c',
                 name: 'Kunsthandel Van Lier',
+                seeAlso: [
+                  {
+                    id: 'https://guides.example.org/level-2a',
+                    name: 'Military and navy',
+                  },
+                ],
+              },
+              {
+                id: 'https://guides.example.org/level-3a',
+                name: 'Royal Cabinet of Curiosities',
+                seeAlso: [
+                  {
+                    id: 'https://guides.example.org/level-2c',
+                    name: 'Trade',
+                  },
+                ],
               },
             ]),
           },
           {
             id: 'https://guides.example.org/level-2-set',
             identifier: '2',
-            hasParts: expect.arrayContaining([
+            seeAlso: expect.arrayContaining([
               {
                 id: 'https://guides.example.org/level-2c',
                 name: 'Trade',
-                hasParts: [
+                seeAlso: [
                   {
                     id: 'https://guides.example.org/level-3c',
                     name: 'Kunsthandel Van Lier',
@@ -55,7 +67,7 @@ describe('getTopLevels', () => {
               {
                 id: 'https://guides.example.org/level-2a',
                 name: 'Military and navy',
-                hasParts: [
+                seeAlso: [
                   {
                     id: 'https://guides.example.org/level-3a',
                     name: 'Royal Cabinet of Curiosities',
@@ -67,7 +79,7 @@ describe('getTopLevels', () => {
           {
             id: 'https://guides.example.org/level-1-set',
             identifier: '1',
-            hasParts: expect.arrayContaining([
+            seeAlso: expect.arrayContaining([
               {
                 id: 'https://guides.example.org/level-1b',
                 name: 'How can I use the data hub for my research?',
@@ -75,32 +87,20 @@ describe('getTopLevels', () => {
               {
                 id: 'https://guides.example.org/level-1c',
                 name: 'Sources',
-                hasParts: [
+                seeAlso: [
                   {
                     id: 'https://guides.example.org/level-2c',
                     name: 'Trade',
-                    hasParts: [
-                      {
-                        id: 'https://guides.example.org/level-3c',
-                        name: 'Kunsthandel Van Lier',
-                      },
-                    ],
                   },
                 ],
               },
               {
                 id: 'https://guides.example.org/level-1a',
                 name: 'Doing research',
-                hasParts: [
+                seeAlso: [
                   {
                     id: 'https://guides.example.org/level-2a',
                     name: 'Military and navy',
-                    hasParts: [
-                      {
-                        id: 'https://guides.example.org/level-3a',
-                        name: 'Royal Cabinet of Curiosities',
-                      },
-                    ],
                   },
                 ],
               },
@@ -175,18 +175,12 @@ describe('getById', () => {
         'Army and Navy personnel who operated in colonized territories collected objects in various ways during the colonial era.',
       text: 'Dutch authority in the [Dutch East Indies](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) and on the [Caribbean Islands](https://www.geonames.org/8505032/netherlands-antilles.html) relied heavily on the use of the military...',
       encodingFormat: 'text/markdown',
-      hasParts: [
+      seeAlso: expect.arrayContaining([
         {
           id: 'https://guides.example.org/level-3a',
           name: 'Royal Cabinet of Curiosities',
         },
-      ],
-      isPartOf: [
-        {
-          id: 'https://guides.example.org/level-1a',
-          name: 'Doing research',
-        },
-      ],
+      ]),
       contentLocations: [
         {
           id: expect.stringContaining(
@@ -233,16 +227,12 @@ describe('get with localized names', () => {
       abstract:
         'Army and Navy personnel who operated in colonized territories collected objects in various ways during the colonial era.',
       text: 'Dutch authority in the [Dutch East Indies](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) and on the [Caribbean Islands](https://www.geonames.org/8505032/netherlands-antilles.html) relied heavily on the use of the military...',
-      hasParts: [
+      seeAlso: expect.arrayContaining([
         {
+          id: 'https://guides.example.org/level-3a',
           name: 'Royal Cabinet of Curiosities',
         },
-      ],
-      isPartOf: [
-        {
-          name: 'Doing research',
-        },
-      ],
+      ]),
       contentLocations: [
         {
           name: 'Netherlands Antilles',
@@ -275,16 +265,12 @@ describe('get with localized names', () => {
       abstract:
         'Leger- en marinepersoneel dat actief was in gekoloniseerde gebieden, verzamelde op verschillende manieren objecten tijdens het koloniale tijdperk.',
       text: 'Het Nederlandse gezag in [Nederlands-Indië](https://www.geonames.org/1643084/republic-of-indonesia.html), [Suriname](https://www.geonames.org/3382998/republic-of-suriname.html) en op de [Caribische eilanden](https://www.geonames.org/8505032/netherlands-antilles.html) steunde in belangrijke mate op de inzet van het leger.',
-      hasParts: [
+      seeAlso: expect.arrayContaining([
         {
+          id: 'https://guides.example.org/level-3a',
           name: 'Koninklijk Kabinet van Zeldzaamheden',
         },
-      ],
-      isPartOf: [
-        {
-          name: 'Onderzoeken',
-        },
-      ],
+      ]),
       contentLocations: [
         {
           name: 'Antillen',

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -14,7 +14,7 @@ describe('getTopLevels', () => {
   it('returns the top level guides', async () => {
     const researchGuides = await researchGuideFetcher.getTopLevels();
 
-    // The sorting order is undefined and can change - dDon't use toStrictEqual()
+    // The sorting order is undefined and can change - don't use toStrictEqual()
     expect(researchGuides).toMatchObject([
       {
         id: 'https://guides.example.org/top-set',

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -10,13 +10,103 @@ beforeEach(() => {
   });
 });
 
-describe('getByTopLevel', () => {
+describe('getTopLevels', () => {
   it('returns the top level guides', async () => {
-    const researchGuides = await researchGuideFetcher.getByTopLevel();
+    const researchGuides = await researchGuideFetcher.getTopLevels();
 
+    // The sorting order is undefined and can change. Don't use toStrictEqual()
     expect(researchGuides).toMatchObject([
       {
-        id: 'https://guides.example.org/top-level',
+        id: 'https://guides.example.org/top-set',
+        name: 'Digital research guide',
+        abstract:
+          'Research aides for conducting provenance research into colonial collections',
+        text: 'Digital research guide',
+        encodingFormat: 'text/markdown',
+        hasParts: expect.arrayContaining([
+          {
+            id: 'https://guides.example.org/level-3-set',
+            identifier: '3',
+            hasParts: expect.arrayContaining([
+              {
+                id: 'https://guides.example.org/level-3a',
+                name: 'Royal Cabinet of Curiosities',
+              },
+              {
+                id: 'https://guides.example.org/level-3c',
+                name: 'Kunsthandel Van Lier',
+              },
+            ]),
+          },
+          {
+            id: 'https://guides.example.org/level-2-set',
+            identifier: '2',
+            hasParts: expect.arrayContaining([
+              {
+                id: 'https://guides.example.org/level-2c',
+                name: 'Trade',
+                hasParts: [
+                  {
+                    id: 'https://guides.example.org/level-3c',
+                    name: 'Kunsthandel Van Lier',
+                  },
+                ],
+              },
+              {
+                id: 'https://guides.example.org/level-2a',
+                name: 'Military and navy',
+                hasParts: [
+                  {
+                    id: 'https://guides.example.org/level-3a',
+                    name: 'Royal Cabinet of Curiosities',
+                  },
+                ],
+              },
+            ]),
+          },
+          {
+            id: 'https://guides.example.org/level-1-set',
+            identifier: '1',
+            hasParts: expect.arrayContaining([
+              {
+                id: 'https://guides.example.org/level-1b',
+                name: 'How can I use the data hub for my research?',
+              },
+              {
+                id: 'https://guides.example.org/level-1c',
+                name: 'Sources',
+                hasParts: [
+                  {
+                    id: 'https://guides.example.org/level-2c',
+                    name: 'Trade',
+                    hasParts: [
+                      {
+                        id: 'https://guides.example.org/level-3c',
+                        name: 'Kunsthandel Van Lier',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'https://guides.example.org/level-1a',
+                name: 'Doing research',
+                hasParts: [
+                  {
+                    id: 'https://guides.example.org/level-2a',
+                    name: 'Military and navy',
+                    hasParts: [
+                      {
+                        id: 'https://guides.example.org/level-3a',
+                        name: 'Royal Cabinet of Curiosities',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]),
+          },
+        ]),
       },
     ]);
   });

--- a/packages/api/src/research-guides/index.integration.test.ts
+++ b/packages/api/src/research-guides/index.integration.test.ts
@@ -14,9 +14,9 @@ beforeEach(() => {
   });
 });
 
-describe('getByTopLevel', () => {
+describe('getTopLevels', () => {
   it('returns the top level research guides', async () => {
-    const results = await researchGuides.getByTopLevel();
+    const results = await researchGuides.getTopLevels();
 
     expect(results).toHaveLength(1);
   });

--- a/packages/api/src/research-guides/index.ts
+++ b/packages/api/src/research-guides/index.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 import {
   GetByIdOptions,
   GetByIdsOptions,
-  GetByTopLevelOptions,
+  GetTopLevelsOptions,
   ResearchGuideFetcher,
 } from './fetcher';
 
@@ -27,8 +27,8 @@ export class ResearchGuides {
     });
   }
 
-  async getByTopLevel(options?: GetByTopLevelOptions) {
-    return this.researchGuideFetcher.getByTopLevel(options);
+  async getTopLevels(options?: GetTopLevelsOptions) {
+    return this.researchGuideFetcher.getTopLevels(options);
   }
 
   async getByIds(options: GetByIdsOptions) {

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -19,6 +19,7 @@ beforeAll(async () => {
       ex:name "Name 1" .
 
     ex:researchGuide2 a ex:CreativeWork ;
+      ex:identifier "1" ;
       ex:name "Name 2" ;
       ex:abstract "Abstract" ;
       ex:text "Text" ;
@@ -37,10 +38,19 @@ beforeAll(async () => {
         ex:name "Citation" ;
         ex:description "Citation Description" ;
         ex:url <https://example.org/citation> ;
-      ] .
+      ] ;
+      ex:seeAlso ex:researchGuide4 .
 
     ex:researchGuide3 a ex:CreativeWork ;
-      ex:name "Name 3" .
+      ex:name "Name 3" ;
+      ex:hasPart ex:researchGuide5 .
+
+    ex:researchGuide5 a ex:CreativeWork ;
+      ex:name "Name 5" ;
+      ex:hasPart ex:researchGuide6 .
+
+    ex:researchGuide6 a ex:CreativeWork ;
+      ex:name "Name 6" .
 
     ex:researchGuide4 a ex:CreativeWork ;
       ex:name "Name A", "Name B" ;
@@ -99,11 +109,26 @@ describe('createResearchGuide', () => {
 
     expect(researchGuide).toStrictEqual({
       id: 'https://example.org/researchGuide2',
+      identifier: '1',
       name: 'Name 2',
       abstract: 'Abstract',
       text: 'Text',
       encodingFormat: 'text/html',
-      hasParts: [{id: 'https://example.org/researchGuide3', name: 'Name 3'}],
+      hasParts: [
+        {
+          id: 'https://example.org/researchGuide3',
+          name: 'Name 3',
+          hasParts: [
+            {
+              id: 'https://example.org/researchGuide5',
+              name: 'Name 5',
+              hasParts: [
+                {id: 'https://example.org/researchGuide6', name: 'Name 6'},
+              ],
+            },
+          ],
+        },
+      ],
       isPartOf: [{id: 'https://example.org/researchGuide1', name: 'Name 1'}],
       contentLocations: [
         {
@@ -121,6 +146,12 @@ describe('createResearchGuide', () => {
           name: 'Citation',
           description: 'Citation Description',
           url: 'https://example.org/citation',
+        },
+      ],
+      seeAlso: [
+        {
+          id: 'https://example.org/researchGuide4',
+          name: 'Name A',
         },
       ],
     });

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -21,11 +21,9 @@ beforeAll(async () => {
     ex:researchGuide2 a ex:CreativeWork ;
       ex:identifier "1" ;
       ex:name "Name 2" ;
-      ex:abstract "Abstract" ;
+      ex:abstract "Abstract 2" ;
       ex:text "Text" ;
       ex:encodingFormat "text/html" ;
-      ex:hasPart ex:researchGuide3 ;
-      ex:isPartOf ex:researchGuide1 ;
       ex:contentLocation [
         ex:name "Content Location" ;
         ex:sameAs <https://example.org/place> ;
@@ -39,18 +37,20 @@ beforeAll(async () => {
         ex:description "Citation Description" ;
         ex:url <https://example.org/citation> ;
       ] ;
-      ex:seeAlso ex:researchGuide4 .
+      ex:seeAlso ex:researchGuide3 .
 
     ex:researchGuide3 a ex:CreativeWork ;
       ex:name "Name 3" ;
-      ex:hasPart ex:researchGuide5 .
+      ex:seeAlso ex:researchGuide5 .
 
     ex:researchGuide5 a ex:CreativeWork ;
       ex:name "Name 5" ;
-      ex:hasPart ex:researchGuide6 .
+      ex:abstract "Abstract 5" ;
+      ex:seeAlso ex:researchGuide6 .
 
     ex:researchGuide6 a ex:CreativeWork ;
-      ex:name "Name 6" .
+      ex:name "Name 6" ;
+      ex:abstract "Abstract 6" .
 
     ex:researchGuide4 a ex:CreativeWork ;
       ex:name "Name A", "Name B" ;
@@ -111,25 +111,29 @@ describe('createResearchGuide', () => {
       id: 'https://example.org/researchGuide2',
       identifier: '1',
       name: 'Name 2',
-      abstract: 'Abstract',
+      abstract: 'Abstract 2',
       text: 'Text',
       encodingFormat: 'text/html',
-      hasParts: [
+      seeAlso: [
         {
           id: 'https://example.org/researchGuide3',
           name: 'Name 3',
-          hasParts: [
+          seeAlso: [
             {
               id: 'https://example.org/researchGuide5',
               name: 'Name 5',
-              hasParts: [
-                {id: 'https://example.org/researchGuide6', name: 'Name 6'},
+              abstract: 'Abstract 5',
+              seeAlso: [
+                {
+                  id: 'https://example.org/researchGuide6',
+                  name: 'Name 6',
+                  abstract: 'Abstract 6',
+                },
               ],
             },
           ],
         },
       ],
-      isPartOf: [{id: 'https://example.org/researchGuide1', name: 'Name 1'}],
       contentLocations: [
         {
           id: 'n3-0',
@@ -138,7 +142,11 @@ describe('createResearchGuide', () => {
         },
       ],
       keywords: [
-        {id: 'n3-1', name: 'Keyword', sameAs: 'https://example.org/keyword'},
+        {
+          id: 'n3-1',
+          name: 'Keyword',
+          sameAs: 'https://example.org/keyword',
+        },
       ],
       citations: [
         {
@@ -146,12 +154,6 @@ describe('createResearchGuide', () => {
           name: 'Citation',
           description: 'Citation Description',
           url: 'https://example.org/citation',
-        },
-      ],
-      seeAlso: [
-        {
-          id: 'https://example.org/researchGuide4',
-          name: 'Name A',
         },
       ],
     });

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -7,7 +7,7 @@ import {
 } from '../rdf-helpers';
 import type {Resource} from 'rdf-object';
 import {Citation, ResearchGuide} from './definitions';
-import {Term} from '../definitions';
+import {Term, Thing} from '../definitions';
 
 function createCitation(citationResource: Resource) {
   const name = onlyOne(getPropertyValues(citationResource, 'ex:name'));
@@ -34,6 +34,9 @@ export function createCitations(resource: Resource, propertyName: string) {
 }
 
 export function createResearchGuide(researchGuideResource: Resource) {
+  const identifier = onlyOne(
+    getPropertyValues(researchGuideResource, 'ex:identifier')
+  );
   const name = onlyOne(getPropertyValues(researchGuideResource, 'ex:name'));
   const abstract = onlyOne(
     getPropertyValues(researchGuideResource, 'ex:abstract')
@@ -50,9 +53,11 @@ export function createResearchGuide(researchGuideResource: Resource) {
   );
   const keywords = createThings<Term>(researchGuideResource, 'ex:keyword');
   const citations = createCitations(researchGuideResource, 'ex:citation');
+  const seeAlso = createThings<Thing>(researchGuideResource, 'ex:seeAlso');
 
   const researchGuideWithUndefinedValues: ResearchGuide = {
     id: researchGuideResource.value,
+    identifier,
     name,
     abstract,
     text,
@@ -62,6 +67,7 @@ export function createResearchGuide(researchGuideResource: Resource) {
     contentLocations,
     keywords,
     citations,
+    seeAlso,
   };
 
   const researchGuide = removeNullish<ResearchGuide>(


### PR DESCRIPTION
This PR makes several changes to the implementation of the research guides API, per the changes that Kinsuk has proposed to the datamodel of the guides. This breaks the [current implementation](https://colonial-collections-researcher-git-fe-e5de5c-colonial-heritage.vercel.app/en/research-guide).

Notes:

1. Kinsuk's modeling work is not finished yet - this PR implements the parts that are more or less stable.
1. The `getTopLevels()` function returns all top level research guides - currently just one. A top level research guide can point to zeo or more other guides via a `seeAlso` property.
1. A `seeAlso` property has been added to the `ResearchGuide` type. You can use this property for creating the ['Related topics' section in the design](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/screen/79a31724-cf7e-45a5-98e9-a17de47cf892).
1. An `identifier` property has been added to the `ResearchGuide` type. You can use this property to check the 'level' of the guide and use that to present a guide on the ['top level page'](https://xd.adobe.com/view/0b89f99f-6624-494c-b10e-55001de41bf8-5eda/) or not. More specifically:
    1. If you want to populate the 'How to do provenance research' section in the design, look in the response of `getTopLevels()` for a research guide with identifier = 1; in its `seeAlso` you'll find the IDs and names of the guides that should be presented
    1. If you want to populate the 'Topics' section in the design, look in the response of `getTopLevels()` for a research guide with identifier = 2; in its `seeAlso` you'll find the IDs and names of the guides that should be presented