### PR TITLE
Escape breaking characters in markdown string

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/form.tsx
@@ -87,7 +87,6 @@ export function LocalContextsNoticeForm({
   const {
     handleSubmit,
     setError,
-    getValues,
     watch,
     formState: {errors, isSubmitting},
   } = methods;

--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -6,8 +6,8 @@ import {
 import researchGuides from '@/lib/research-guides-instance';
 import {getLocale, getTranslations} from 'next-intl/server';
 import {Link} from '@/navigation';
-import {MDXRemote} from 'next-mdx-remote/rsc';
 import {ChevronRightIcon, ChevronLeftIcon} from '@heroicons/react/24/solid';
+import StringToMarkdown from '../string-to-markdown';
 
 interface Props {
   params: {id: string};
@@ -45,7 +45,7 @@ export default async function GuidePage({params}: Props) {
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-2/3">
             <div className="prose" id="#description">
-              {guide.text && <MDXRemote source={guide.text} />}
+              {guide.text && <StringToMarkdown text={guide.text} />}
               {guide.citations && guide.citations.length > 0 && (
                 <>
                   <h2 id="citations">{t('citations')}</h2>

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -4,7 +4,7 @@ import researchGuides from '@/lib/research-guides-instance';
 import {Link} from '@/navigation';
 import {ChevronRightIcon} from '@heroicons/react/24/solid';
 import {getLocale, getTranslations} from 'next-intl/server';
-import {MDXRemote} from 'next-mdx-remote/rsc';
+import StringToMarkdown from './string-to-markdown';
 
 export default async function Page() {
   const locale = (await getLocale()) as LocaleEnum;
@@ -27,7 +27,7 @@ export default async function Page() {
     <>
       <h1 className="text-2xl md:text-4xl">{topLevel.name}</h1>
       <div className="my-4 w-full max-w-5xl columns-2 gap-6">
-        {topLevel.text && <MDXRemote source={topLevel.text} />}
+        {topLevel.text && <StringToMarkdown text={topLevel.text} />}
       </div>
       <div className="bg-consortium-sand-100 rounded mt-6 -mx-4 pr-10">
         <h2 className="px-4 pt-4">{t('level1Title')}</h2>

--- a/apps/researcher/src/app/[locale]/research-guide/string-to-markdown.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/string-to-markdown.tsx
@@ -1,0 +1,15 @@
+import {MDXRemote} from 'next-mdx-remote/rsc';
+
+// Escape html characters to be sure the text renders without any issues.
+function escapeHtml(unsafe: string) {
+  return unsafe
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+export default function StringToMarkdown({text}: {text: string}) {
+  return <MDXRemote source={escapeHtml(text)} />;
+}


### PR DESCRIPTION
The string "You can contact \<loket***@***.nl\> to request information" will break the `MDXRemote` component. `MDXRemote` thinks it's HTML, but it's invalid HTML. So it returns an error. Escaping the string will fix this issue.