### PR TITLE
Remove unused imports

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/form.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/form.tsx
@@ -12,7 +12,6 @@ import {z} from 'zod';
 import {addUserNotice} from './actions';
 import {InformationCircleIcon, XMarkIcon} from '@heroicons/react/24/outline';
 import {
-  FormRow,
   InputLabel,
   LanguageSelector,
   Textarea,

--- a/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/overview.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/local-contexts-notices/overview.tsx
@@ -2,18 +2,9 @@ import {localContextsNoticesEnrichmentFetcher} from '@/lib/enricher-instances';
 import Image from 'next/image';
 import useObject from '../use-object';
 import {localContextsNoticeEnrichmentTypeMapping} from './mapping';
-import {
-  LocalizedMarkdown,
-  SlideOut,
-  SlideOutButton,
-} from '@colonial-collections/ui';
+import {LocalizedMarkdown, SlideOutButton} from '@colonial-collections/ui';
 import {ChatBubbleBottomCenterTextIcon} from '@heroicons/react/24/outline';
-import SignedIn from '@/lib/community/signed-in';
-import {SignedOut} from '@clerk/nextjs';
-import {
-  SignedInWithCommunitySideOut,
-  SignedOutSlideOut,
-} from '@/components/slide-outs';
+import {SignedInWithCommunitySideOut} from '@/components/slide-outs';
 import {LocalContextsNoticeForm} from './form';
 import {LocalContextsNoticeEnrichment} from '@colonial-collections/enricher';
 import {ProvidedBy} from '../provided-by';


### PR DESCRIPTION
Due to a recent change, some imports were not used. This pull request removes them and, with that, removes eslint warnings.