### PR TITLE
Show 100 communities in list

### DIFF
--- a/apps/researcher/src/app/[locale]/communities/settings.ts
+++ b/apps/researcher/src/app/[locale]/communities/settings.ts
@@ -1,1 +1,1 @@
-export const itemsPerPageLimit = 12;
+export const itemsPerPageLimit = 100;


### PR DESCRIPTION
The paginator for communities is not working correctly because the total communities are not set correctly.

With a Clerk update, we can get the total communities. With the new API, the response of getOrganizationList is `Promise<PaginatedResourceResponse<Organization[]>>`. But with the version of Clerk we use, we only get `Promise<Organization[]>`, see docs:: https://clerk.com/docs/references/backend/organization/get-organization-list  

For now, the quick fix is showing more communities in the results.