### PR TITLE
Research guide frontend

### DIFF
--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -8,6 +8,7 @@ import {getLocale, getTranslations} from 'next-intl/server';
 import {Link} from '@/navigation';
 import {ChevronRightIcon, ChevronLeftIcon} from '@heroicons/react/24/solid';
 import StringToMarkdown from '../string-to-markdown';
+import {getDateFormatter} from '@/lib/date-formatter/actions';
 
 interface Props {
   params: {id: string};
@@ -18,6 +19,8 @@ export default async function GuidePage({params}: Props) {
   const locale = (await getLocale()) as LocaleEnum;
   const guide = await researchGuides.getById({id, locale});
   const t = await getTranslations('ResearchGuide');
+
+  const {formatDateRange} = await getDateFormatter();
 
   if (!guide) {
     return <div data-testid="no-entity">{t('noEntity')}</div>;
@@ -117,6 +120,20 @@ export default async function GuidePage({params}: Props) {
                   ))}
                 </div>
               )}
+              {guide.contentReferenceTimes &&
+                guide.contentReferenceTimes.length > 0 && (
+                  <div className="bg-consortium-sand-50 rounded px-2 py-4">
+                    <h3 tabIndex={0}>{t('contentReferenceTimes')}</h3>
+                    {guide.contentReferenceTimes.map(
+                      time =>
+                        time.date && (
+                          <div key={time.id} tabIndex={0}>
+                            {formatDateRange(time.date)}
+                          </div>
+                        )
+                    )}
+                  </div>
+                )}
             </div>
           </div>
         </div>

--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function GuidePage({params}: Props) {
           {guide.name}
         </h1>
         <div className="text-sm text-neutral-600 mb-6">
-          {guide.alternateName}
+          {guide.alternateNames?.join(', ')}
         </div>
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-2/3">

--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -8,7 +8,7 @@ import {getLocale, getTranslations} from 'next-intl/server';
 import {Link} from '@/navigation';
 import {ChevronRightIcon, ChevronLeftIcon} from '@heroicons/react/24/solid';
 import StringToMarkdown from '../string-to-markdown';
-import {getDateFormatter} from '@/lib/date-formatter/actions';
+import {Event} from '@colonial-collections/api';
 
 interface Props {
   params: {id: string};
@@ -19,8 +19,6 @@ export default async function GuidePage({params}: Props) {
   const locale = (await getLocale()) as LocaleEnum;
   const guide = await researchGuides.getById({id, locale});
   const t = await getTranslations('ResearchGuide');
-
-  const {formatDateRange} = await getDateFormatter();
 
   if (!guide) {
     return <div data-testid="no-entity">{t('noEntity')}</div>;
@@ -126,14 +124,11 @@ export default async function GuidePage({params}: Props) {
                 guide.contentReferenceTimes.length > 0 && (
                   <div className="bg-consortium-sand-50 rounded px-2 py-4">
                     <h3 tabIndex={0}>{t('contentReferenceTimes')}</h3>
-                    {guide.contentReferenceTimes.map(
-                      time =>
-                        time.date && (
-                          <div key={time.id} tabIndex={0}>
-                            {formatDateRange(time.date)}
-                          </div>
-                        )
-                    )}
+                    {guide.contentReferenceTimes.map(time => (
+                      <div key={time.id}>
+                        <DateRange event={time} />
+                      </div>
+                    ))}
                   </div>
                 )}
             </div>
@@ -142,4 +137,25 @@ export default async function GuidePage({params}: Props) {
       </main>
     </div>
   );
+}
+
+async function DateRange({event}: {event: Event}) {
+  const t = await getTranslations('ResearchGuide');
+
+  if (!event.date?.startDate && !event.date?.endDate) {
+    return t('noDateRange');
+  }
+
+  const startDateFormatted = event.date?.startDate
+    ? event.date.startDate.getFullYear()
+    : t('noStartDate');
+  const endDateFormatted = event.date?.endDate
+    ? event.date.endDate.getFullYear()
+    : t('noEndDate');
+
+  if (startDateFormatted === endDateFormatted) {
+    return startDateFormatted as string;
+  }
+
+  return `${startDateFormatted} – ${endDateFormatted}`;
 }

--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -34,16 +34,13 @@ export default async function GuidePage({params}: Props) {
           {t('backButton')}
         </Link>
       </div>
-      <div className="w-full px-4 sm:px-10 max-w-7xl mx-auto mt-16  relative">
-        <nav className="*:no-underline text-sm flex gap-4 2xl:fixed 2xl:flex-col 2xl:-translate-x-32 2xl:gap-2 2xl:pt-24">
-          <a href="#description">{t('navText')}</a>
-          <a href="#citations">{t('navCitations')}</a>
-        </nav>
-      </div>
       <main className="w-full px-4 sm:px-10 max-w-7xl mx-auto mt-16 mb-40">
         <h1 className="text-2xl md:text-4xl mb-2" tabIndex={0}>
           {guide.name}
         </h1>
+        <div className="text-sm text-neutral-600 mb-6">
+          {guide.alternateName}
+        </div>
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-2/3">
             <div className="prose" id="#description">
@@ -63,7 +60,9 @@ export default async function GuidePage({params}: Props) {
                           {citation.description}
                           {' — '}
                           <span className="text-sm">
-                            <a href={citation.url}>{citation.url}</a>
+                            <a target="_blank" href={citation.url}>
+                              {citation.url}
+                            </a>
                           </span>
                         </div>
                       </li>

--- a/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/[id]/page.tsx
@@ -41,9 +41,11 @@ export default async function GuidePage({params}: Props) {
         <h1 className="text-2xl md:text-4xl mb-2" tabIndex={0}>
           {guide.name}
         </h1>
-        <div className="text-sm text-neutral-600 mb-6">
-          {guide.alternateNames?.join(', ')}
-        </div>
+        {guide.alternateNames?.length && (
+          <div className="text-sm text-neutral-600 mb-6">
+            {t('nameVariations')}: {guide.alternateNames?.join(', ')}
+          </div>
+        )}
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-2/3">
             <div className="prose" id="#description">

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -32,15 +32,10 @@ describe('filterLevel3Guides', () => {
 
     const filteredTopLevel = filterLevel3Guides(topLevel);
 
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([
-      {id: 'level3-1'},
-      {id: 'level3-2'},
-      {id: 'level3-3'},
-    ]);
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[1].seeAlso).toEqual([
-      {id: 'level3-4'},
-    ]);
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([]);
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[1].seeAlso).toEqual([]);
     expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
+      {id: 'level3-2'},
       {id: 'level3-5'},
     ]);
   });
@@ -78,9 +73,7 @@ describe('filterLevel3Guides', () => {
 
     const filteredTopLevel = filterLevel3Guides(topLevel);
 
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([
-      {id: 'level3-1'},
-    ]);
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([]);
     expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
       {id: 'level3-2'},
     ]);

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -1,8 +1,9 @@
-import {filterLevel3Guides, sortLevel1Guides} from './filterGuides';
+import {ResearchGuide} from '@colonial-collections/api/src/research-guides/definitions';
+import {filterLevel3Guides, sortResearchGuide} from './filterGuides';
 
 describe('filterLevel3Guides', () => {
-  it('only shows each level 3 guide once', () => {
-    const topLevel = {
+  it('should filter out level 1 and level 2 guides from level 3 list', () => {
+    const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
         {
@@ -10,38 +11,40 @@ describe('filterLevel3Guides', () => {
           seeAlso: [
             {
               id: 'level2-1',
-              seeAlso: [{id: 'level3-1'}, {id: 'level3-2'}, {id: 'level3-3'}],
-            },
-            {
-              id: 'level2-2',
-              seeAlso: [{id: 'level3-1'}, {id: 'level3-4'}],
-            },
-          ],
-        },
-        {
-          id: 'level1-2',
-          seeAlso: [
-            {
-              id: 'level2-3',
-              seeAlso: [{id: 'level3-2'}, {id: 'level3-5'}],
+              seeAlso: [
+                {id: 'level3-1'},
+                {id: 'level1-2'}, // This should be filtered out
+                {id: 'level2-2'}, // This should be filtered out
+              ],
             },
           ],
         },
+        {id: 'level1-2'},
       ],
     };
 
-    const filteredTopLevel = filterLevel3Guides(topLevel);
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: 'level1-1',
+          seeAlso: [
+            {
+              id: 'level2-1',
+              seeAlso: [{id: 'level3-1'}],
+            },
+          ],
+        },
+        {id: 'level1-2'},
+      ],
+    };
 
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([]);
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[1].seeAlso).toEqual([]);
-    expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
-      {id: 'level3-2'},
-      {id: 'level3-5'},
-    ]);
+    const result = filterLevel3Guides(topLevel);
+    expect(result).toEqual(expected);
   });
 
-  it('filters out level 1 and 2 guides from the level 2 seeAlso', () => {
-    const topLevel = {
+  it('should handle cases with no level 3 guides', () => {
+    const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
         {
@@ -50,53 +53,103 @@ describe('filterLevel3Guides', () => {
             {
               id: 'level2-1',
               seeAlso: [
-                {id: 'level1-2'}, // Level 1 guide
-                {id: 'level2-2'}, // Level 2 guide
-                {id: 'level3-1'}, // Level 3 guide
+                {id: 'level1-2'}, // This should be filtered out
+                {id: 'level2-2'}, // This should be filtered out
               ],
             },
           ],
         },
-        {
-          id: 'level1-2',
-          seeAlso: [
-            {
-              id: 'level2-2',
-              seeAlso: [
-                {id: 'level3-2'}, // Level 3 guide
-              ],
-            },
-          ],
-        },
+        {id: 'level1-2'},
       ],
     };
 
-    const filteredTopLevel = filterLevel3Guides(topLevel);
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: 'level1-1',
+          seeAlso: [
+            {
+              id: 'level2-1',
+              seeAlso: [],
+            },
+          ],
+        },
+        {id: 'level1-2'},
+      ],
+    };
 
-    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([]);
-    expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
-      {id: 'level3-2'},
-    ]);
+    const result = filterLevel3Guides(topLevel);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle cases with no seeAlso arrays', () => {
+    const topLevel: ResearchGuide = {
+      id: 'top',
+      seeAlso: [],
+    };
+
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [],
+    };
+
+    const result = filterLevel3Guides(topLevel);
+    expect(result).toEqual(expected);
   });
 });
 
-describe('sortLevel1Guides', () => {
-  it('sorts level 1 guides by their names', () => {
-    const topLevel = {
+describe('sortResearchGuide', () => {
+  it('should sort guides by their names', () => {
+    const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
-        {id: '2', name: 'B'},
-        {id: '1', name: 'A'},
-        {id: '3', name: 'C'},
+        {id: '2', name: 'Beta'},
+        {id: '1', name: 'Alpha'},
+        {id: '3', name: 'Gamma'},
       ],
     };
 
-    const sortedLevel1Guides = sortLevel1Guides(topLevel);
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [
+        {id: '1', name: 'Alpha'},
+        {id: '2', name: 'Beta'},
+        {id: '3', name: 'Gamma'},
+      ],
+    };
 
-    expect(sortedLevel1Guides).toEqual([
-      {id: '1', name: 'A'},
-      {id: '2', name: 'B'},
-      {id: '3', name: 'C'},
-    ]);
+    const result = sortResearchGuide(topLevel);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle guides with missing names', () => {
+    const topLevel: ResearchGuide = {
+      id: 'top',
+      seeAlso: [{id: '2', name: 'Beta'}, {id: '1'}, {id: '3', name: 'Gamma'}],
+    };
+
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [{id: '1'}, {id: '2', name: 'Beta'}, {id: '3', name: 'Gamma'}],
+    };
+
+    const result = sortResearchGuide(topLevel);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle empty seeAlso arrays', () => {
+    const topLevel: ResearchGuide = {
+      id: 'top',
+      seeAlso: [],
+    };
+
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [],
+    };
+
+    const result = sortResearchGuide(topLevel);
+    expect(result).toEqual(expected);
   });
 });

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -1,0 +1,109 @@
+import {filterLevel3Guides, sortLevel1Guides} from './filterGuides';
+
+describe('filterLevel3Guides', () => {
+  it('only shows each level 3 guide once', () => {
+    const topLevel = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: 'level1-1',
+          seeAlso: [
+            {
+              id: 'level2-1',
+              seeAlso: [{id: 'level3-1'}, {id: 'level3-2'}, {id: 'level3-3'}],
+            },
+            {
+              id: 'level2-2',
+              seeAlso: [{id: 'level3-1'}, {id: 'level3-4'}],
+            },
+          ],
+        },
+        {
+          id: 'level1-2',
+          seeAlso: [
+            {
+              id: 'level2-3',
+              seeAlso: [{id: 'level3-2'}, {id: 'level3-5'}],
+            },
+          ],
+        },
+      ],
+    };
+
+    const filteredTopLevel = filterLevel3Guides(topLevel);
+
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([
+      {id: 'level3-1'},
+      {id: 'level3-2'},
+      {id: 'level3-3'},
+    ]);
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[1].seeAlso).toEqual([
+      {id: 'level3-4'},
+    ]);
+    expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
+      {id: 'level3-5'},
+    ]);
+  });
+
+  it('filters out level 1 and 2 guides from the level 2 seeAlso', () => {
+    const topLevel = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: 'level1-1',
+          seeAlso: [
+            {
+              id: 'level2-1',
+              seeAlso: [
+                {id: 'level1-2'}, // Level 1 guide
+                {id: 'level2-2'}, // Level 2 guide
+                {id: 'level3-1'}, // Level 3 guide
+              ],
+            },
+          ],
+        },
+        {
+          id: 'level1-2',
+          seeAlso: [
+            {
+              id: 'level2-2',
+              seeAlso: [
+                {id: 'level3-2'}, // Level 3 guide
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const filteredTopLevel = filterLevel3Guides(topLevel);
+
+    expect(filteredTopLevel.seeAlso?.[0].seeAlso?.[0].seeAlso).toEqual([
+      {id: 'level3-1'},
+    ]);
+    expect(filteredTopLevel.seeAlso?.[1].seeAlso?.[0].seeAlso).toEqual([
+      {id: 'level3-2'},
+    ]);
+  });
+});
+
+describe('sortLevel1Guides', () => {
+  it('sorts level 1 guides by their names', () => {
+    const topLevel = {
+      id: 'top',
+      seeAlso: [
+        {id: '2', name: 'B'},
+        {id: '1', name: 'A'},
+        {id: '3', name: 'C'},
+      ],
+    };
+
+    const sortedLevel1Guides = sortLevel1Guides(topLevel);
+
+    expect(sortedLevel1Guides).toEqual([
+      {id: '1', name: 'A'},
+      {id: '2', name: 'B'},
+      {id: '3', name: 'C'},
+    ]);
+  });
+});

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -2,7 +2,7 @@ import {ResearchGuide} from '@colonial-collections/api/src/research-guides/defin
 import {filterLevel3Guides, sortResearchGuide} from './filterGuides';
 
 describe('filterLevel3Guides', () => {
-  it('should filter out level 1 and level 2 guides from level 3 list', () => {
+  it('filters out level 1 and level 2 guides from level 3 list', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
@@ -13,8 +13,8 @@ describe('filterLevel3Guides', () => {
               id: 'level2-1',
               seeAlso: [
                 {id: 'level3-1'},
-                {id: 'level1-2'}, // This should be filtered out
-                {id: 'level2-2'}, // This should be filtered out
+                {id: 'level1-2'},
+                {id: 'level2-2'},
               ],
             },
           ],
@@ -43,7 +43,7 @@ describe('filterLevel3Guides', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should handle cases with no level 3 guides', () => {
+  it('handles cases with no level 3 guides', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
@@ -53,8 +53,8 @@ describe('filterLevel3Guides', () => {
             {
               id: 'level2-1',
               seeAlso: [
-                {id: 'level1-2'}, // This should be filtered out
-                {id: 'level2-2'}, // This should be filtered out
+                {id: 'level1-2'},
+                {id: 'level2-2'},
               ],
             },
           ],
@@ -83,7 +83,7 @@ describe('filterLevel3Guides', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should handle cases with no seeAlso arrays', () => {
+  it('handles cases with no seeAlso arrays', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [],
@@ -100,7 +100,7 @@ describe('filterLevel3Guides', () => {
 });
 
 describe('sortResearchGuide', () => {
-  it('should sort guides by their names', () => {
+  it('sorts guides by their names', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [
@@ -123,7 +123,7 @@ describe('sortResearchGuide', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should handle guides with missing names', () => {
+  it('handles guides with missing names', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [{id: '2', name: 'Beta'}, {id: '1'}, {id: '3', name: 'Gamma'}],
@@ -138,7 +138,7 @@ describe('sortResearchGuide', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should handle empty seeAlso arrays', () => {
+  it('handles empty seeAlso arrays', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [],
@@ -153,7 +153,7 @@ describe('sortResearchGuide', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should sort nested seeAlso arrays', () => {
+  it('sorts nested seeAlso arrays', () => {
     const topLevel: ResearchGuide = {
       id: 'top',
       seeAlso: [

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -11,11 +11,7 @@ describe('filterLevel3Guides', () => {
           seeAlso: [
             {
               id: 'level2-1',
-              seeAlso: [
-                {id: 'level3-1'},
-                {id: 'level1-2'},
-                {id: 'level2-2'},
-              ],
+              seeAlso: [{id: 'level3-1'}, {id: 'level1-2'}, {id: 'level2-2'}],
             },
           ],
         },
@@ -52,10 +48,7 @@ describe('filterLevel3Guides', () => {
           seeAlso: [
             {
               id: 'level2-1',
-              seeAlso: [
-                {id: 'level1-2'},
-                {id: 'level2-2'},
-              ],
+              seeAlso: [{id: 'level1-2'}, {id: 'level2-2'}],
             },
           ],
         },

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -152,4 +152,53 @@ describe('sortResearchGuide', () => {
     const result = sortResearchGuide(topLevel);
     expect(result).toEqual(expected);
   });
+
+  it('should sort nested seeAlso arrays', () => {
+    const topLevel: ResearchGuide = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: '1',
+          name: 'Alpha',
+          seeAlso: [
+            {id: '3', name: 'Gamma'},
+            {id: '2', name: 'Beta'},
+          ],
+        },
+        {
+          id: '2',
+          name: 'Beta',
+          seeAlso: [
+            {id: '5', name: 'Epsilon'},
+            {id: '4', name: 'Delta'},
+          ],
+        },
+      ],
+    };
+
+    const expected: ResearchGuide = {
+      id: 'top',
+      seeAlso: [
+        {
+          id: '1',
+          name: 'Alpha',
+          seeAlso: [
+            {id: '2', name: 'Beta'},
+            {id: '3', name: 'Gamma'},
+          ],
+        },
+        {
+          id: '2',
+          name: 'Beta',
+          seeAlso: [
+            {id: '4', name: 'Delta'},
+            {id: '5', name: 'Epsilon'},
+          ],
+        },
+      ],
+    };
+
+    const result = sortResearchGuide(topLevel);
+    expect(result).toEqual(expected);
+  });
 });

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -1,4 +1,4 @@
-import {ResearchGuide} from '@colonial-collections/api/src/research-guides/definitions';
+import {ResearchGuide} from '@colonial-collections/api';
 import {filterLevel3Guides, sortResearchGuide} from './filterGuides';
 
 describe('filterLevel3Guides', () => {

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -13,9 +13,18 @@ type Guide = {
  * - Each level 1 guide's seeAlso contains level 2 guides.
  * - Each level 2 guide's seeAlso may contain level 1, level 2, and level 3 guides.
  * - Level 3 guides should only be shown once across all level 2 guides.
+ * - The first level 1 guide only shows the level 2 guides.
  */
 export const filterLevel3Guides = (topLevel: Guide): Guide => {
   const displayedLevel3Guides = new Set<string>();
+
+  // For the first level 1 guide only the level 2 guides should be displayed
+  if (topLevel.seeAlso && topLevel.seeAlso[0]) {
+    topLevel.seeAlso[0].seeAlso = topLevel.seeAlso[0].seeAlso?.map(guide => {
+      guide.seeAlso = undefined;
+      return guide;
+    });
+  }
 
   topLevel.seeAlso?.forEach(level1Guide => {
     level1Guide.seeAlso?.forEach(level2Guide => {

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -1,31 +1,14 @@
-type Guide = {
-  id: string;
-  name?: string;
-  seeAlso?: Guide[];
-};
+import {ResearchGuide} from '@colonial-collections/api/src/research-guides/definitions';
 
 /**
- * Filters out level 1 and level 2 guides from the seeAlso arrays of level 2 guides
- * and ensures each level 3 guide is only shown once.
+ * Filters out level 1 and level 2 guides from the seeAlso arrays of level 2 guides.
  *
  * Assumptions:
  * - topLevel.seeAlso contains level 1 guides.
  * - Each level 1 guide's seeAlso contains level 2 guides.
  * - Each level 2 guide's seeAlso may contain level 1, level 2, and level 3 guides.
- * - Level 3 guides should only be shown once across all level 2 guides.
- * - The first level 1 guide only shows the level 2 guides.
  */
-export const filterLevel3Guides = (topLevel: Guide): Guide => {
-  const displayedLevel3Guides = new Set<string>();
-
-  // For the first level 1 guide only the level 2 guides should be displayed
-  if (topLevel.seeAlso && topLevel.seeAlso[0]) {
-    topLevel.seeAlso[0].seeAlso = topLevel.seeAlso[0].seeAlso?.map(guide => {
-      guide.seeAlso = undefined;
-      return guide;
-    });
-  }
-
+export function filterLevel3Guides(topLevel: ResearchGuide): ResearchGuide {
   topLevel.seeAlso?.forEach(level1Guide => {
     level1Guide.seeAlso?.forEach(level2Guide => {
       const filteredSeeAlso =
@@ -39,31 +22,20 @@ export const filterLevel3Guides = (topLevel: Guide): Guide => {
             l1 => l1.seeAlso?.some(l2 => l2.id === guide.id)
           );
 
-          // If the guide is not a level 1 or level 2 guide and has not been displayed yet, it's a level 3 guide
-          if (
-            !isLevel1Guide &&
-            !isLevel2Guide &&
-            !displayedLevel3Guides.has(guide.id)
-          ) {
-            displayedLevel3Guides.add(guide.id);
-            return true;
-          }
-          return false;
+          // If the guide is not a level 1 or level 2 guide, it's a level 3 guide
+          return !isLevel1Guide && !isLevel2Guide;
         }) || [];
       level2Guide.seeAlso = filteredSeeAlso;
     });
   });
 
   return topLevel;
-};
+}
 
-/**
- * Sorts the level 1 guides by their names.
- */
-export const sortLevel1Guides = (topLevel: Guide): Guide[] => {
-  return (
+export function sortResearchGuide(topLevel: ResearchGuide) {
+  const seeAlsoSorted =
     topLevel.seeAlso?.sort((a, b) =>
       (a.name || '').localeCompare(b.name || '')
-    ) || []
-  );
-};
+    ) || [];
+  return {...topLevel, seeAlso: seeAlsoSorted};
+}

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -1,0 +1,60 @@
+type Guide = {
+  id: string;
+  name?: string;
+  seeAlso?: Guide[];
+};
+
+/**
+ * Filters out level 1 and level 2 guides from the seeAlso arrays of level 2 guides
+ * and ensures each level 3 guide is only shown once.
+ *
+ * Assumptions:
+ * - topLevel.seeAlso contains level 1 guides.
+ * - Each level 1 guide's seeAlso contains level 2 guides.
+ * - Each level 2 guide's seeAlso may contain level 1, level 2, and level 3 guides.
+ * - Level 3 guides should only be shown once across all level 2 guides.
+ */
+export const filterLevel3Guides = (topLevel: Guide): Guide => {
+  const displayedLevel3Guides = new Set<string>();
+
+  topLevel.seeAlso?.forEach(level1Guide => {
+    level1Guide.seeAlso?.forEach(level2Guide => {
+      const filteredSeeAlso =
+        level2Guide.seeAlso?.filter(guide => {
+          // Check if the guide is a level 1 guide
+          const isLevel1Guide = topLevel.seeAlso?.some(
+            l1 => l1.id === guide.id
+          );
+          // Check if the guide is a level 2 guide
+          const isLevel2Guide = topLevel.seeAlso?.some(
+            l1 => l1.seeAlso?.some(l2 => l2.id === guide.id)
+          );
+
+          // If the guide is not a level 1 or level 2 guide and has not been displayed yet, it's a level 3 guide
+          if (
+            !isLevel1Guide &&
+            !isLevel2Guide &&
+            !displayedLevel3Guides.has(guide.id)
+          ) {
+            displayedLevel3Guides.add(guide.id);
+            return true;
+          }
+          return false;
+        }) || [];
+      level2Guide.seeAlso = filteredSeeAlso;
+    });
+  });
+
+  return topLevel;
+};
+
+/**
+ * Sorts the level 1 guides by their names.
+ */
+export const sortLevel1Guides = (topLevel: Guide): Guide[] => {
+  return (
+    topLevel.seeAlso?.sort((a, b) =>
+      (a.name || '').localeCompare(b.name || '')
+    ) || []
+  );
+};

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -1,4 +1,4 @@
-import {ResearchGuide} from '@colonial-collections/api/src/research-guides/definitions';
+import {ResearchGuide} from '@colonial-collections/api';
 
 /**
  * Filters out level 1 and level 2 guides from the seeAlso arrays of level 2 guides.

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -32,10 +32,18 @@ export function filterLevel3Guides(topLevel: ResearchGuide): ResearchGuide {
   return topLevel;
 }
 
-export function sortResearchGuide(topLevel: ResearchGuide) {
-  const seeAlsoSorted =
-    topLevel.seeAlso?.sort((a, b) =>
-      (a.name || '').localeCompare(b.name || '')
-    ) || [];
-  return {...topLevel, seeAlso: seeAlsoSorted};
+export function sortResearchGuide(topLevel: ResearchGuide): ResearchGuide {
+  const sortGuides = (guide: ResearchGuide): ResearchGuide => {
+    const sortedSeeAlso =
+      guide.seeAlso?.sort((a, b) =>
+        (a.name || '').localeCompare(b.name || '')
+      ) || [];
+
+    return {
+      ...guide,
+      seeAlso: sortedSeeAlso.map(sortGuides),
+    };
+  };
+
+  return sortGuides(topLevel);
 }

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -7,7 +7,7 @@ import {getLocale, getTranslations} from 'next-intl/server';
 import StringToMarkdown from './string-to-markdown';
 import {
   filterLevel3Guides,
-  sortLevel1Guides,
+  sortResearchGuide,
 } from '@/app/[locale]/research-guide/filterGuides';
 
 export default async function Page() {
@@ -21,11 +21,11 @@ export default async function Page() {
 
   // There can be multiple top levels, but the current design only supports one.
   const topLevel = topLevels[0];
-  const filteredTopLevel = filterLevel3Guides(topLevel);
-  const level1Guides = sortLevel1Guides(filteredTopLevel);
+  const sortedGuides = sortResearchGuide(topLevel);
+  const filteredTopLevel = filterLevel3Guides(sortedGuides);
 
-  const firstLevel1Guide = level1Guides[0];
-  const nextLevel1Guides = level1Guides.slice(1);
+  const firstLevel1Guide = filteredTopLevel.seeAlso?.[0];
+  const nextLevel1Guides = filteredTopLevel.seeAlso?.slice(1) || [];
 
   return (
     <>

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -21,6 +21,8 @@ export default async function Page() {
 
   // There can be multiple top levels, but the current design only supports one.
   const topLevel = topLevels[0];
+
+  console.log(topLevel);
   const sortedGuides = sortResearchGuide(topLevel);
   const filteredTopLevel = filterLevel3Guides(sortedGuides);
 
@@ -32,32 +34,36 @@ export default async function Page() {
       <h1 className="text-2xl md:text-4xl" tabIndex={0}>
         {topLevel.name}
       </h1>
-      <div className="my-4 w-full max-w-5xl columns-1 md:columns-2 gap-6">
-        {topLevel.text && <StringToMarkdown text={topLevel.text} />}
-      </div>
-      {firstLevel1Guide && (
-        <div className="bg-consortium-sand-100 rounded mt-6 -mx-4 pr-10">
-          <h2 className="px-4 pt-4" tabIndex={0}>
-            {firstLevel1Guide.name}
-          </h2>
-          <div className="pb-4 columns-1 sm:columns-2 lg:columns-3 gap-10">
-            {firstLevel1Guide.seeAlso?.map(item => (
-              <Link
-                key={item.id}
-                href={`/research-guide/${encodeRouteSegment(item.id)}`}
-                className="break-inside-avoid-column bg-consortium-sand-100 text-consortium-sand-800 no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col py-2 px-4"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <div>{item.name}</div>
-                  <div>
-                    <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
-                  </div>
-                </div>
-              </Link>
-            ))}
+      <div className="my-4 w-full flex flex-col md:flex-row gap-6">
+        {topLevel.text && (
+          <div className="flex-1">
+            <StringToMarkdown text={topLevel.text} />
           </div>
-        </div>
-      )}
+        )}
+        {firstLevel1Guide && (
+          <div className="bg-consortium-sand-100 rounded mt-6 md:mt-0 flex-1">
+            <h2 className="px-4 pt-4" tabIndex={0}>
+              {firstLevel1Guide.name}
+            </h2>
+            <div className="pb-4 flex flex-col gap-4">
+              {firstLevel1Guide.seeAlso?.map(item => (
+                <Link
+                  key={item.id}
+                  href={`/research-guide/${encodeRouteSegment(item.id)}`}
+                  className="bg-consortium-sand-100 text-consortium-sand-800 no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col py-2 px-4"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div>{item.name}</div>
+                    <div>
+                      <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
       {nextLevel1Guides.map(level1Guide => (
         <div className="mt-10" key={level1Guide.id}>
           <h2 className="mb-4" tabIndex={0}>
@@ -73,24 +79,26 @@ export default async function Page() {
                   href={`/research-guide/${encodeRouteSegment(
                     level2Guides.id
                   )}`}
-                  className="flex items-center justify-between gap-2 no-underline"
+                  className="no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col p-2"
                 >
-                  <div className="font-semibold">{level2Guides.name}</div>
-                  <div>
-                    <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="font-semibold">{level2Guides.name}</div>
+                    <div>
+                      <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
+                    </div>
                   </div>
                 </Link>
-                {level2Guides.seeAlso?.map(linkedGuides => (
+                {level2Guides.seeAlso?.map(level3Guides => (
                   <Link
-                    key={linkedGuides.id}
+                    key={level3Guides.id}
                     href={`/research-guide/${encodeRouteSegment(
-                      linkedGuides.id
+                      level3Guides.id
                     )}`}
                     className="no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col p-2 mt-2"
-                    aria-label={`${linkedGuides.name}, item of ${level2Guides.name}`}
+                    aria-label={`${level3Guides.name}, item of ${level2Guides.name}`}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <div>{linkedGuides.name}</div>
+                      <div>{level3Guides.name}</div>
                       <div>
                         <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
                       </div>

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -5,6 +5,10 @@ import {Link} from '@/navigation';
 import {ChevronRightIcon} from '@heroicons/react/24/solid';
 import {getLocale, getTranslations} from 'next-intl/server';
 import StringToMarkdown from './string-to-markdown';
+import {
+  filterLevel3Guides,
+  sortLevel1Guides,
+} from '@/app/[locale]/research-guide/filterGuides';
 
 export default async function Page() {
   const locale = (await getLocale()) as LocaleEnum;
@@ -17,11 +21,11 @@ export default async function Page() {
 
   // There can be multiple top levels, but the current design only supports one.
   const topLevel = topLevels[0];
+  const filteredTopLevel = filterLevel3Guides(topLevel);
+  const level1Guides = sortLevel1Guides(filteredTopLevel);
 
-  const level1Guides =
-    topLevel.seeAlso?.find(item => item.identifier === '1')?.seeAlso || [];
-  const level2Guides =
-    topLevel.seeAlso?.find(item => item.identifier === '2')?.seeAlso || [];
+  const firstLevel1Guide = level1Guides[0];
+  const nextLevel1Guides = level1Guides.slice(1);
 
   return (
     <>
@@ -31,58 +35,62 @@ export default async function Page() {
       <div className="my-4 w-full max-w-5xl columns-2 gap-6">
         {topLevel.text && <StringToMarkdown text={topLevel.text} />}
       </div>
-      <div className="bg-consortium-sand-100 rounded mt-6 -mx-4 pr-10">
-        <h2 className="px-4 pt-4" tabIndex={0}>
-          {t('level1Title')}
-        </h2>
-        <div className="pb-4 columns-3 gap-10">
-          {level1Guides.map(item => (
-            <Link
-              key={item.id}
-              href={`/research-guide/${encodeRouteSegment(item.id)}`}
-              className="break-inside-avoid-column bg-consortium-sand-100 text-consortium-sand-800 no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col py-2 px-4"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div>{item.name}</div>
-                <div>
-                  <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </div>
-      <div className="mt-10 flex flex-col lg:flex-row gap-10">
-        <div className="w-full lg:w-1/2">
-          <h2 className="mb-4" tabIndex={0}>
-            {t('level2Title')}
+      {firstLevel1Guide && (
+        <div className="bg-consortium-sand-100 rounded mt-6 -mx-4 pr-10">
+          <h2 className="px-4 pt-4" tabIndex={0}>
+            {firstLevel1Guide.name}
           </h2>
-          <div className="flex flex-col md:block md:columns-2 md:gap-6 *:break-inside">
-            {level2Guides.map(item => (
-              <div
+          <div className="pb-4 columns-3 gap-10">
+            {firstLevel1Guide.seeAlso?.map(item => (
+              <Link
                 key={item.id}
-                className="bg-consortium-sand-100 text-consortium-sand-800 rounded flex flex-col p-2 mb-6"
+                href={`/research-guide/${encodeRouteSegment(item.id)}`}
+                className="break-inside-avoid-column bg-consortium-sand-100 text-consortium-sand-800 no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col py-2 px-4"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div>{item.name}</div>
+                  <div>
+                    <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+      {nextLevel1Guides.map(level1Guide => (
+        <div className="mt-10" key={level1Guide.id}>
+          <h2 className="mb-4" tabIndex={0}>
+            {level1Guide.name}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {level1Guide.seeAlso?.map(level2Guides => (
+              <div
+                key={level2Guides.id}
+                className="bg-consortium-sand-100 text-consortium-sand-800 rounded flex flex-col p-4"
               >
                 <Link
-                  href={`/research-guide/${encodeRouteSegment(item.id)}`}
+                  href={`/research-guide/${encodeRouteSegment(
+                    level2Guides.id
+                  )}`}
                   className="flex items-center justify-between gap-2 no-underline"
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="font-semibold">{item.name}</div>
-                    <div>
-                      <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
-                    </div>
+                  <div className="font-semibold">{level2Guides.name}</div>
+                  <div>
+                    <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
                   </div>
                 </Link>
-                {item.seeAlso?.map(subItem => (
+                {level2Guides.seeAlso?.map(linkedGuides => (
                   <Link
-                    key={subItem.id}
-                    href={`/research-guide/${encodeRouteSegment(subItem.id)}`}
-                    className="no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col p-2 -ml-2"
-                    aria-label={`${subItem.name}, item of ${item.name}`}
+                    key={linkedGuides.id}
+                    href={`/research-guide/${encodeRouteSegment(
+                      linkedGuides.id
+                    )}`}
+                    className="no-underline hover:bg-consortium-sand-200 transition rounded flex flex-col p-2 mt-2"
+                    aria-label={`${linkedGuides.name}, item of ${level2Guides.name}`}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <div>{subItem.name}</div>
+                      <div>{linkedGuides.name}</div>
                       <div>
                         <ChevronRightIcon className="w-5 h-5 fill--consortiumSand-900" />
                       </div>
@@ -93,7 +101,7 @@ export default async function Page() {
             ))}
           </div>
         </div>
-      </div>
+      ))}
     </>
   );
 }

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -32,7 +32,7 @@ export default async function Page() {
       <h1 className="text-2xl md:text-4xl" tabIndex={0}>
         {topLevel.name}
       </h1>
-      <div className="my-4 w-full max-w-5xl columns-2 gap-6">
+      <div className="my-4 w-full max-w-5xl columns-1 md:columns-2 gap-6">
         {topLevel.text && <StringToMarkdown text={topLevel.text} />}
       </div>
       {firstLevel1Guide && (
@@ -40,7 +40,7 @@ export default async function Page() {
           <h2 className="px-4 pt-4" tabIndex={0}>
             {firstLevel1Guide.name}
           </h2>
-          <div className="pb-4 columns-3 gap-10">
+          <div className="pb-4 columns-1 sm:columns-2 lg:columns-3 gap-10">
             {firstLevel1Guide.seeAlso?.map(item => (
               <Link
                 key={item.id}

--- a/apps/researcher/src/app/[locale]/research-guide/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/page.tsx
@@ -22,7 +22,6 @@ export default async function Page() {
   // There can be multiple top levels, but the current design only supports one.
   const topLevel = topLevels[0];
 
-  console.log(topLevel);
   const sortedGuides = sortResearchGuide(topLevel);
   const filteredTopLevel = filterLevel3Guides(sortedGuides);
 

--- a/apps/researcher/src/app/[locale]/research-guide/string-to-markdown.tsx
+++ b/apps/researcher/src/app/[locale]/research-guide/string-to-markdown.tsx
@@ -13,7 +13,12 @@ function escapeHtml(unsafe: string) {
 
 const components = {
   a: (props: AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a target="_blank" rel="noopener noreferrer" {...props} />
+    <a
+      target="_blank"
+      className="font-normal no-underline border-b border-dashed border-gray-400"
+      rel="noopener noreferrer"
+      {...props}
+    />
   ),
 };
 

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -552,6 +552,7 @@
     "relatedItems": "Related items",
     "keywords": "Keywords",
     "contentLocations": "Geographical",
+    "contentReferenceTimes": "Period of activity",
     "noTopLevel": "The research guide will be added soon. Please check back later.",
     "noEntity": "Research guide could not be found",
     "backButton": "Back to overview"

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -554,6 +554,9 @@
     "contentReferenceTimes": "Period of activity",
     "noTopLevel": "The research guide will be added soon. Please check back later.",
     "noEntity": "Research guide could not be found",
-    "backButton": "Back to overview"
+    "backButton": "Back to overview",
+    "noDateRange": "No activity period known",
+    "noStartDate": "No start date known",
+    "noEndDate": "Present"
   }
 }

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -544,8 +544,7 @@
     "cancel": "Cancel"
   },
   "ResearchGuide": {
-    "level1Title": "How to do Provenance Research",
-    "level2Title": "Topics",
+    "nameVariations": "Name variations",
     "navText": "Description",
     "navCitations": "Resources",
     "citations": "Resources",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -554,6 +554,9 @@
       "contentReferenceTimes": "Actieve periode",
       "noTopLevel": "De onderzoeksgids wordt binnenkort toegevoegd. Kom later terug.",
       "noEntity": "Onderzoeksgids kon niet worden gevonden",
-      "backButton": "Terug naar overzicht"
+      "backButton": "Terug naar overzicht",
+      "noDateRange": "Geen actieve periode bekend",
+      "noStartDate": "Geen startdatum bekend",
+      "noEndDate": "Heden"
     }
 }

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -552,6 +552,7 @@
       "relatedItems": "Gerelateerde items",
       "keywords": "Trefwoorden", 
       "contentLocations": "Geografisch",
+      "contentReferenceTimes": "Actieve periode",
       "noTopLevel": "De onderzoeksgids wordt binnenkort toegevoegd. Kom later terug.",
       "noEntity": "Onderzoeksgids kon niet worden gevonden",
       "backButton": "Terug naar overzicht"

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -544,8 +544,7 @@
       "cancel": "Annuleren"
     },
     "ResearchGuide": { 
-      "level1Title": "Hoe herkomstonderzoek te doen",
-      "level2Title": "Onderwerpen",
+      "nameVariations": "Naamvarianten",
       "navText": "Beschrijving",
       "navCitations": "Bronnen",
       "citations": "Bronnen",


### PR DESCRIPTION
This pull request updated the top level of the research guide based on the new API and design.

Top level page: 

- The identifier property is removed, so there is some logic added to determine the level
 - Sort by name
 - Use the names of the new level 1 guides
 - Separate design for the first level 1 guide
 - Show 4 level 2 guides next to each other; do not break within the level 2 guide
 - Only show level 3 guides below the level 2 guides; filter out level 1 and 2

Details page:

- Open links to Resources in new tab
- Remove the 'Description' and 'Resources' buttons
- Display the 'name variants' field/information
- Display the 'active period' field/information