### PR TITLE
Fix unit tests

### DIFF
--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.test.ts
@@ -15,7 +15,7 @@ describe('filterLevel3Guides', () => {
             },
           ],
         },
-        {id: 'level1-2'},
+        {id: 'level1-2', seeAlso: [{id: 'level2-2'}]},
       ],
     };
 
@@ -31,7 +31,7 @@ describe('filterLevel3Guides', () => {
             },
           ],
         },
-        {id: 'level1-2'},
+        {id: 'level1-2', seeAlso: [{id: 'level2-2', seeAlso: []}]},
       ],
     };
 
@@ -48,7 +48,7 @@ describe('filterLevel3Guides', () => {
           seeAlso: [
             {
               id: 'level2-1',
-              seeAlso: [{id: 'level1-2'}, {id: 'level2-2'}],
+              seeAlso: [{id: 'level1-2'}],
             },
           ],
         },

--- a/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
+++ b/apps/researcher/src/app/[locale]/research-guide/filterGuides.ts
@@ -37,11 +37,11 @@ export function sortResearchGuide(topLevel: ResearchGuide): ResearchGuide {
     const sortedSeeAlso =
       guide.seeAlso?.sort((a, b) =>
         (a.name || '').localeCompare(b.name || '')
-      ) || [];
+      ) || undefined;
 
     return {
       ...guide,
-      seeAlso: sortedSeeAlso.map(sortGuides),
+      seeAlso: sortedSeeAlso?.map(sortGuides),
     };
   };
 


### PR DESCRIPTION
Fix unit tests: The top-level tree determines the level 1 and 2 guides, so all IDs used in the tests for levels 1 and 2 must be mentioned in the tree.