### PR TITLE
Add user IRI check

### DIFF
--- a/apps/researcher/src/app/[locale]/iri-check/layout.tsx
+++ b/apps/researcher/src/app/[locale]/iri-check/layout.tsx
@@ -1,0 +1,5 @@
+import {ReactNode} from 'react';
+
+export default function Layout({children}: {children: ReactNode}) {
+  return <main className="w-full px-4 sm:px-10 max-w-7xl">{children}</main>;
+}

--- a/apps/researcher/src/app/[locale]/iri-check/page.tsx
+++ b/apps/researcher/src/app/[locale]/iri-check/page.tsx
@@ -1,0 +1,36 @@
+import {createPersistentIri} from '@colonial-collections/iris';
+import {unstable_noStore as noStore} from 'next/cache';
+import {clerkClient} from '@clerk/nextjs';
+
+export default async function IriCheckPage() {
+  noStore(); // Disable caching to prevent double updates
+
+  let updated = 0;
+  const users = await clerkClient.users.getUserList();
+
+  await Promise.all(
+    users.map(async user => {
+      if (!user.unsafeMetadata?.iri) {
+        const iri = createPersistentIri();
+        await clerkClient.users.updateUser(user.id, {
+          unsafeMetadata: {
+            ...user.unsafeMetadata,
+            iri,
+          },
+        });
+        updated += 1;
+      }
+    })
+  );
+
+  if (updated > 0) {
+    console.log(`IRI Check: ${updated} users updated`);
+  }
+
+  return (
+    <div>
+      <h1>IRI Check</h1>
+      <p>{updated} user(s) updated.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Due to a bug described in this ticket:https://github.com/orgs/colonial-heritage/projects/1/views/12?pane=issue&itemId=117381940&issue=colonial-heritage%7Ccolonial-collections%7C743

There are a lot of users without an IRI. All users should have an IRI; this is a small page that automatically adds all missing IRIs.