### PR TITLE
Use a higher limit for iri check

### DIFF
--- a/apps/researcher/src/app/[locale]/iri-check/page.tsx
+++ b/apps/researcher/src/app/[locale]/iri-check/page.tsx
@@ -6,7 +6,10 @@ export default async function IriCheckPage() {
   noStore(); // Disable caching to prevent double updates
 
   let updated = 0;
-  const users = await clerkClient.users.getUserList();
+  const users = await clerkClient.users.getUserList({
+    orderBy: '-created_at',
+    limit: 200,
+  });
 
   await Promise.all(
     users.map(async user => {


### PR DESCRIPTION
The check worked, but only 7 users were updated. `getUserList` has a default limit of 10; therefore, it will not retrieve all users. I updated it to 200. There are about 140 user currently.

Docs: https://clerk.com/docs/references/backend/user/get-user-list