### PR TITLE
feat: add support for type of source in Research Aids

### DIFF
--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -1,6 +1,14 @@
 import {Event, Place, Term, Thing} from '../definitions';
 
-export type Citation = Thing & {url?: string};
+export enum CitationType {
+  PrimarySource = 'primary',
+  SecondarySource = 'secondary',
+}
+
+export type Citation = Thing & {
+  type: CitationType;
+  url?: string;
+};
 
 export type ResearchGuide = Thing & {
   alternateNames?: string[];

--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -196,6 +196,7 @@ export class ResearchGuideFetcher {
           ex:sameAs ?keywordSameAs .
 
         ?citation a ex:CreativeWork ;
+          ex:additionalType ?citationTypeLabel ;
           ex:name ?citationName ;
           ex:description ?citationDescription ;
           ex:url ?citationUrl .
@@ -278,6 +279,12 @@ export class ResearchGuideFetcher {
 
         OPTIONAL {
           ?this schema:citation ?citation .
+
+          # E.g. "Type of secondary source:Publicatie"
+          OPTIONAL {
+            ?citation rdfs:label ?citationTypeLabel
+            FILTER(LANG(?citationTypeLabel) = "${options.locale}")
+          }
 
           OPTIONAL {
             ?citation schema:name ?citationName

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -42,9 +42,20 @@ beforeAll(async () => {
         ex:sameAs <https://example.org/keyword> ;
       ] ;
       ex:citation [
-        ex:name "Citation" ;
-        ex:description "Citation Description" ;
-        ex:url <https://example.org/citation> ;
+        ex:additionalType "Type of primary source:Publicatie" ;
+        ex:name "Citation 1" ;
+        ex:description "Citation Description 1" ;
+        ex:url <https://example.org/citation1> ;
+      ], [
+        ex:additionalType "Type of secondary source:Publicatie" ;
+        ex:name "Citation 2" ;
+        ex:description "Citation Description 2" ;
+        ex:url <https://example.org/citation2> ;
+      ], [
+        # Missing 'ex:additionalType'
+        ex:name "Citation 3" ;
+        ex:description "Citation Description 3" ;
+        ex:url <https://example.org/citation3> ;
       ] ;
       ex:hasPart ex:researchGuide3 ;
       ex:seeAlso ex:researchGuide3 .
@@ -125,9 +136,24 @@ describe('createCitations', () => {
     expect(citations).toStrictEqual([
       {
         id: expect.any(String),
-        name: 'Citation',
-        description: 'Citation Description',
-        url: 'https://example.org/citation',
+        type: 'primary',
+        name: 'Citation 1',
+        description: 'Citation Description 1',
+        url: 'https://example.org/citation1',
+      },
+      {
+        id: expect.any(String),
+        type: 'secondary',
+        name: 'Citation 2',
+        description: 'Citation Description 2',
+        url: 'https://example.org/citation2',
+      },
+      {
+        id: expect.any(String),
+        type: 'primary',
+        name: 'Citation 3',
+        description: 'Citation Description 3',
+        url: 'https://example.org/citation3',
       },
     ]);
   });
@@ -278,9 +304,24 @@ describe('createResearchGuide', () => {
       citations: [
         {
           id: expect.any(String),
-          name: 'Citation',
-          description: 'Citation Description',
-          url: 'https://example.org/citation',
+          type: 'primary',
+          name: 'Citation 1',
+          description: 'Citation Description 1',
+          url: 'https://example.org/citation1',
+        },
+        {
+          id: expect.any(String),
+          type: 'secondary',
+          name: 'Citation 2',
+          description: 'Citation Description 2',
+          url: 'https://example.org/citation2',
+        },
+        {
+          id: expect.any(String),
+          type: 'primary',
+          name: 'Citation 3',
+          description: 'Citation Description 3',
+          url: 'https://example.org/citation3',
         },
       ],
     });

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -7,7 +7,7 @@ import {
   removeNullish,
 } from '../rdf-helpers';
 import type {Resource} from 'rdf-object';
-import {Citation, ResearchGuide} from './definitions';
+import {Citation, CitationType, ResearchGuide} from './definitions';
 import {Event, Term} from '../definitions';
 
 function createCitation(citationResource: Resource) {
@@ -16,8 +16,18 @@ function createCitation(citationResource: Resource) {
     getPropertyValues(citationResource, 'ex:description')
   );
   const url = onlyOne(getPropertyValues(citationResource, 'ex:url'));
+  const additionalType = onlyOne(
+    getPropertyValues(citationResource, 'ex:additionalType')
+  );
+
+  // The KG, unfortunately, does not use structured data for denoting the
+  // type of the source - we'll need to parse an unstructured literal
+  const type = additionalType?.toLowerCase().includes('secondary source')
+    ? CitationType.SecondarySource
+    : CitationType.PrimarySource;
 
   const citation: Citation = {
+    type,
     id: citationResource.value,
     name,
     description,


### PR DESCRIPTION
This PR adds support for capturing the type (primary, secondary) of the source, used in research aids

More info: https://github.com/colonial-heritage/sprints/issues/502