### PR TITLE
feat: objects main entity of page

### DIFF
--- a/packages/api/src/definitions.ts
+++ b/packages/api/src/definitions.ts
@@ -74,6 +74,7 @@ export type HeritageObject = Thing & {
   dateCreated?: TimeSpan;
   images?: Image[];
   isPartOf?: Dataset;
+  mainEntityOfPage?: string; // URL of web page
 };
 
 export type Event = {

--- a/packages/api/src/enrichments/searcher-constituents-wikidata.integration.test.ts
+++ b/packages/api/src/enrichments/searcher-constituents-wikidata.integration.test.ts
@@ -30,9 +30,9 @@ describe('search', () => {
           description: 'fotograaf',
         },
         {
-          id: 'http://www.wikidata.org/entity/Q375926',
-          name: 'Rembrandt Peale',
-          description: 'Amerikaans kunstschilder (1778-1860)',
+          id: 'http://www.wikidata.org/entity/Q105964347',
+          name: 'Rembrandt',
+          description: 'Metaalwarenfabriek Rembrandt BV',
         },
       ],
     });
@@ -53,14 +53,15 @@ describe('search', () => {
           description: "Rembrandt's mother",
         },
         {
-          id: 'http://www.wikidata.org/entity/Q105964347',
-          name: 'Rembrandt',
-          description: 'Metaalwarenfabriek Rembrandt BV',
-        },
-        {
           id: 'http://www.wikidata.org/entity/Q1300641',
           name: 'Rembrandt Bugatti',
           description: 'Italian sculptor (1884–1916)',
+        },
+        {
+          id: 'http://www.wikidata.org/entity/Q17330745',
+          name: "Rembrandt's father",
+          description:
+            "model and member of the Leiden Guild of St. Luke (not Rembrandt's father)",
         },
       ],
     });

--- a/packages/api/src/objects/fetcher.integration.test.ts
+++ b/packages/api/src/objects/fetcher.integration.test.ts
@@ -158,6 +158,7 @@ describe('getById', () => {
           },
         },
       ]),
+      mainEntityOfPage: 'https://id.rijksmuseum.nl/200112226',
       isPartOf: {
         id: 'https://example.org/datasets/1',
         name: 'Dataset 1',

--- a/packages/api/src/objects/fetcher.ts
+++ b/packages/api/src/objects/fetcher.ts
@@ -78,6 +78,7 @@ export class HeritageObjectFetcher {
           ex:dateCreated ?dateCreatedTimeSpan ;
           ex:locationCreated ?locationCreated ;
           ex:image ?digitalObject ;
+          ex:mainEntityOfPage ?mainEntityOfPage ;
           ex:isPartOf ?dataset .
 
         ?type a ex:DefinedTerm ;
@@ -317,6 +318,17 @@ export class HeritageObjectFetcher {
         }
 
         ####################
+        # Web page of the object
+        ####################
+
+        OPTIONAL {
+          ?this crm:P129i_is_subject_of/la:digitally_carried_by [
+            crm:P2_has_type <http://vocab.getty.edu/aat/300264578> ; # Web page
+            la:access_point ?mainEntityOfPage
+          ]
+        }
+
+        ####################
         # Part of dataset
         ####################
 
@@ -408,6 +420,10 @@ export class HeritageObjectFetcher {
             'ex:locationCreated'
           );
           const images = createImages(rawHeritageObject, 'ex:image');
+          const mainEntityOfPage = getPropertyValue(
+            rawHeritageObject,
+            'ex:mainEntityOfPage'
+          );
           const dataset = onlyOne(
             createDatasets(rawHeritageObject, 'ex:isPartOf')
           );
@@ -426,6 +442,7 @@ export class HeritageObjectFetcher {
             dateCreated,
             locationsCreated,
             images,
+            mainEntityOfPage,
             isPartOf: dataset,
           };
 

--- a/packages/api/src/objects/searcher.integration.test.ts
+++ b/packages/api/src/objects/searcher.integration.test.ts
@@ -160,6 +160,7 @@ describe('search', () => {
                 'http://images.memorix.nl/rce/thumb/1600x1600/fceac847-88f4-8066-d960-326dc79be0d3.jpg',
             },
           ]),
+          mainEntityOfPage: 'https://id.rijksmuseum.nl/200108369',
           isPartOf: {
             id: 'https://example.org/datasets/1',
             name: 'Dataset 1',
@@ -348,6 +349,7 @@ describe('search', () => {
               },
             },
           ]),
+          mainEntityOfPage: 'https://id.rijksmuseum.nl/200112226',
           isPartOf: {
             id: 'https://example.org/datasets/1',
             name: 'Dataset 1',

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -25,19 +25,41 @@ describe('getTopLevels', () => {
         encodingFormat: 'text/markdown',
         hasParts: [
           {
+            id: 'https://guides.example.org/subset3',
+            name: '3. Name',
+            hasParts: [
+              {
+                id: 'https://guides.example.org/guide7',
+                name: 'Kunsthandel Van Lier',
+              },
+              {
+                id: 'https://guides.example.org/guide6',
+                name: 'Royal Cabinet of Curiosities',
+              },
+            ],
+          },
+          {
+            id: 'https://guides.example.org/subset1',
+            name: '1. Name',
+            hasParts: [
+              {
+                id: 'https://guides.example.org/guide3',
+                name: 'Sources',
+              },
+              {
+                id: 'https://guides.example.org/guide1',
+                name: 'Doing research',
+              },
+              {
+                id: 'https://guides.example.org/guide2',
+                name: 'How can I use the data hub for my research?',
+              },
+            ],
+          },
+          {
             id: 'https://guides.example.org/subset2',
             name: '2. Name',
             hasParts: [
-              {
-                id: 'https://guides.example.org/guide4',
-                name: 'Military and navy',
-                hasParts: [
-                  {
-                    id: 'https://guides.example.org/guide6',
-                    name: 'Royal Cabinet of Curiosities',
-                  },
-                ],
-              },
               {
                 id: 'https://guides.example.org/guide5',
                 name: 'Trade',
@@ -48,37 +70,15 @@ describe('getTopLevels', () => {
                   },
                 ],
               },
-            ],
-          },
-          {
-            id: 'https://guides.example.org/subset3',
-            name: '3. Name',
-            hasParts: [
               {
-                id: 'https://guides.example.org/guide6',
-                name: 'Royal Cabinet of Curiosities',
-              },
-              {
-                id: 'https://guides.example.org/guide7',
-                name: 'Kunsthandel Van Lier',
-              },
-            ],
-          },
-          {
-            id: 'https://guides.example.org/subset1',
-            name: '1. Name',
-            hasParts: [
-              {
-                id: 'https://guides.example.org/guide2',
-                name: 'How can I use the data hub for my research?',
-              },
-              {
-                id: 'https://guides.example.org/guide3',
-                name: 'Sources',
-              },
-              {
-                id: 'https://guides.example.org/guide1',
-                name: 'Doing research',
+                id: 'https://guides.example.org/guide4',
+                name: 'Military and navy',
+                hasParts: [
+                  {
+                    id: 'https://guides.example.org/guide6',
+                    name: 'Royal Cabinet of Curiosities',
+                  },
+                ],
               },
             ],
           },
@@ -205,6 +205,7 @@ describe('getById', () => {
           id: expect.stringContaining(
             'https://data.colonialcollections.nl/.well-known/genid/'
           ),
+          type: 'secondary',
           name: 'Regeeringsalmanak voor Nederlandsch-Indië',
           description:
             'Via Delpher, the editions can be found by selecting the title',


### PR DESCRIPTION
This PR adds a new property to a heritage object, `mainEntityOfPage`. This property contains a URL that points to a web page on the website of a data provider. Remarks:

1. The property is optional - not every data provider provides a URL
2. The property is not available on production yet - Jauco first needs to update the ETL of the Rijksmuseum
3. The property is available on testing: https://dev.app.colonialcollections.nl/nl/objects/https%3A%2F%2Fexample%252Eorg%2Fobjects%2F5

Source: https://github.com/orgs/colonial-heritage/projects/1/views/12?pane=issue&itemId=114946621&issue=colonial-heritage%7Csprints%7C509

The PR also fixes some integration tests that failed.