### PR TITLE
fix(metadata): show "noData" fallback when description is missing

### DIFF
--- a/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
@@ -34,6 +34,18 @@ export function Metadata({
     ? enrichments.filter(enrichment => enrichment.type === enrichmentType)
     : [];
 
+  const isEmptyChildren =
+    children === null ||
+    children === undefined ||
+    (typeof children === 'string' && children.trim() === '') ||
+    (typeof children === 'object' &&
+      children !== null &&
+      'props' in children &&
+      (children.props.text === undefined ||
+        children.props.text === null ||
+        (typeof children.props.text === 'string' &&
+          children.props.text.trim() === '')));
+
   return (
     <>
       <div className="flex flex-col gap-4">
@@ -51,33 +63,33 @@ export function Metadata({
               </div>
             </div>
           </div>
-          {!children && metadataEnrichments.length === 0 ? (
-            <div className="text-neutral-600 italic w-full py-6 text-sm xl:w-4/5 border-t border-neutral-400">
-              {t.rich('noData', {
-                subject: () => (
-                  <span className="lowercase">{t(translationKey)}</span>
-                ),
-              })}
-            </div>
-          ) : (
-            <div className="w-full xl:w-4/5 flex flex-col gap-2 border-t border-neutral-400">
+          <div className="w-full xl:w-4/5 flex flex-col gap-2 border-t border-neutral-400">
+            {isEmptyChildren ? (
+              <div className="text-neutral-600 italic w-full py-6 text-sm">
+                {t.rich('noData', {
+                  subject: () => (
+                    <span className="lowercase">{t(translationKey)}</span>
+                  ),
+                })}
+              </div>
+            ) : (
               <MetadataEntry translationKey={translationKey} isCurrentPublisher>
                 {children}
               </MetadataEntry>
-              {metadataEnrichments?.map(enrichment => (
-                <MetadataEntry
-                  key={enrichment.id}
-                  translationKey={translationKey}
-                  dateCreated={enrichment.pubInfo.dateCreated}
-                  citation={enrichment.citation}
-                  creator={enrichment.pubInfo.creator}
-                  languageCode={enrichment.inLanguage}
-                >
-                  <ReadMoreText text={enrichment.description} />
-                </MetadataEntry>
-              ))}
-            </div>
-          )}
+            )}
+            {metadataEnrichments?.map(enrichment => (
+              <MetadataEntry
+                key={enrichment.id}
+                translationKey={translationKey}
+                dateCreated={enrichment.pubInfo.dateCreated}
+                citation={enrichment.citation}
+                creator={enrichment.pubInfo.creator}
+                languageCode={enrichment.inLanguage}
+              >
+                <ReadMoreText text={enrichment.description} />
+              </MetadataEntry>
+            ))}
+          </div>
         </div>
         {enrichmentType && (
           <AddMetadataEnrichment

--- a/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
+++ b/apps/researcher/src/app/[locale]/objects/[id]/metadata.tsx
@@ -64,7 +64,7 @@ export function Metadata({
             </div>
           </div>
           <div className="w-full xl:w-4/5 flex flex-col gap-2 border-t border-neutral-400">
-            {isEmptyChildren ? (
+            {isEmptyChildren && metadataEnrichments.length === 0 && (
               <div className="text-neutral-600 italic w-full py-6 text-sm">
                 {t.rich('noData', {
                   subject: () => (
@@ -72,7 +72,8 @@ export function Metadata({
                   ),
                 })}
               </div>
-            ) : (
+            )}
+            {!isEmptyChildren && (
               <MetadataEntry translationKey={translationKey} isCurrentPublisher>
                 {children}
               </MetadataEntry>


### PR DESCRIPTION
### Summary

This PR fixes a bug in the Metadata component where the "noData" fallback message was not shown if the description (or other text-based children) was missing or empty. The previous logic did not correctly detect when children were React elements with empty or undefined text props. 

For description, the metadata child was: `<ReadMoreText text={object.description} />`. Even if `object.description` was null, and ReadMoreText returns null, the old check still did not see it as an empty child because it was a React component.

### Changes

- Improved the `isEmptyChildren` check to handle cases where children are React elements with empty, null, or undefined `text` props, as well as empty strings and null/undefined values.
- Only show the 'noData text is `isEmptyChildren` and no metadataEnrichments. 

Ticket: https://github.com/colonial-heritage/sprints/issues/531