### PR TITLE
Add missing heading ids (h1, h2) to StringToMarkdown

### DIFF
--- a/apps/researcher/src/app/[locale]/research-aids/string-to-markdown.tsx
+++ b/apps/researcher/src/app/[locale]/research-aids/string-to-markdown.tsx
@@ -36,6 +36,16 @@ const components = {
       {...props}
     />
   ),
+  h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => {
+    const text = extractTextFromChildren(props.children);
+    const id = textToSlug(text);
+    return <h1 id={id} {...props} />;
+  },
+  h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => {
+    const text = extractTextFromChildren(props.children);
+    const id = textToSlug(text);
+    return <h2 id={id} {...props} />;
+  },
   h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => {
     const text = extractTextFromChildren(props.children);
     const id = textToSlug(text);


### PR DESCRIPTION
Small bug: only h3 gets IDs, for example, this guide uses h2: https://app.colonialcollections.nl/en/research-aids/https%3A%2F%2Fn2t%252Enet%2Fark%3A%2F27023%2F5f0031f66044adefab19b67b1344b31d

The h2 will appear in the navigation, but it will not link to an ID. So the navigation won't work.

Fix: also add IDs to h1 and h2