### PR TITLE
feat: inLanguage

### DIFF
--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -8,6 +8,7 @@ export enum CitationType {
 export type Citation = Thing & {
   type: CitationType;
   url?: string;
+  inLanguage: string[];
 };
 
 export type ResearchGuide = Thing & {

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -23,25 +23,11 @@ describe('getTopLevels', () => {
           'Research aides for conducting provenance research into colonial collections',
         text: 'On this page you find various research aides that can assist...',
         encodingFormat: 'text/markdown',
-        hasParts: [
-          {
-            id: 'https://guides.example.org/subset3',
-            name: '3. Name',
-            hasParts: [
-              {
-                id: 'https://guides.example.org/guide7',
-                name: 'Kunsthandel Van Lier',
-              },
-              {
-                id: 'https://guides.example.org/guide6',
-                name: 'Royal Cabinet of Curiosities',
-              },
-            ],
-          },
+        hasParts: expect.arrayContaining([
           {
             id: 'https://guides.example.org/subset1',
-            name: '1. Name',
-            hasParts: [
+            name: 'Name',
+            hasParts: expect.arrayContaining([
               {
                 id: 'https://guides.example.org/guide3',
                 name: 'Sources',
@@ -54,12 +40,12 @@ describe('getTopLevels', () => {
                 id: 'https://guides.example.org/guide2',
                 name: 'How can I use the data hub for my research?',
               },
-            ],
+            ]),
           },
           {
             id: 'https://guides.example.org/subset2',
-            name: '2. Name',
-            hasParts: [
+            name: 'Name',
+            hasParts: expect.arrayContaining([
               {
                 id: 'https://guides.example.org/guide5',
                 name: 'Trade',
@@ -80,9 +66,23 @@ describe('getTopLevels', () => {
                   },
                 ],
               },
-            ],
+            ]),
           },
-        ],
+          {
+            id: 'https://guides.example.org/subset3',
+            name: 'Name',
+            hasParts: expect.arrayContaining([
+              {
+                id: 'https://guides.example.org/guide7',
+                name: 'Kunsthandel Van Lier',
+              },
+              {
+                id: 'https://guides.example.org/guide6',
+                name: 'Royal Cabinet of Curiosities',
+              },
+            ]),
+          },
+        ]),
       },
     ]);
   });
@@ -205,6 +205,7 @@ describe('getById', () => {
           id: expect.stringContaining(
             'https://data.colonialcollections.nl/.well-known/genid/'
           ),
+          inLanguage: ['en'],
           type: 'secondary',
           name: 'Regeeringsalmanak voor Nederlandsch-Indië',
           description:
@@ -259,6 +260,7 @@ describe('get with localized names', () => {
       citations: [
         {
           name: 'Regeeringsalmanak voor Nederlandsch-Indië',
+          inLanguage: ['en'],
           description:
             'Via Delpher, the editions can be found by selecting the title',
         },
@@ -308,6 +310,7 @@ describe('get with localized names', () => {
       citations: [
         {
           name: 'Regeeringsalmanak voor Nederlandsch-Indië',
+          inLanguage: ['nl'],
           description:
             'Edities van 1865 tot en met 1942 beschikbaar via Delpher en edities van 1865 tot en met 1912 beschikbaar via de digitale collecties van de Staatsbibliothek zu Berlin.',
         },

--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -196,6 +196,7 @@ export class ResearchGuideFetcher {
           ex:sameAs ?keywordSameAs .
 
         ?citation a ex:CreativeWork ;
+          ex:inLanguage ?citationLanguage ;
           ex:additionalType ?citationTypeLabel ;
           ex:name ?citationName ;
           ex:description ?citationDescription ;
@@ -279,6 +280,11 @@ export class ResearchGuideFetcher {
 
         OPTIONAL {
           ?this schema:citation ?citation .
+
+          OPTIONAL {
+            ?citation schema:inLanguage ?citationLanguage
+            FILTER(?citationLanguage = "${options.locale}")
+          }
 
           # E.g. "Type of secondary source:Publicatie"
           OPTIONAL {

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -43,16 +43,18 @@ beforeAll(async () => {
       ] ;
       ex:citation [
         ex:additionalType "Type of primary source:Publicatie" ;
+        ex:inLanguage "en" ;
         ex:name "Citation 1" ;
         ex:description "Citation Description 1" ;
         ex:url <https://example.org/citation1> ;
       ], [
         ex:additionalType "Type of secondary source:Publicatie" ;
+        ex:inLanguage "en", "nl" ;
         ex:name "Citation 2" ;
         ex:description "Citation Description 2" ;
         ex:url <https://example.org/citation2> ;
       ], [
-        # Missing 'ex:additionalType'
+        # Missing 'ex:additionalType' and 'ex:inLanguage'
         ex:name "Citation 3" ;
         ex:description "Citation Description 3" ;
         ex:url <https://example.org/citation3> ;
@@ -137,6 +139,7 @@ describe('createCitations', () => {
       {
         id: expect.any(String),
         type: 'primary',
+        inLanguage: ['en'],
         name: 'Citation 1',
         description: 'Citation Description 1',
         url: 'https://example.org/citation1',
@@ -144,6 +147,7 @@ describe('createCitations', () => {
       {
         id: expect.any(String),
         type: 'secondary',
+        inLanguage: ['en', 'nl'],
         name: 'Citation 2',
         description: 'Citation Description 2',
         url: 'https://example.org/citation2',
@@ -151,6 +155,7 @@ describe('createCitations', () => {
       {
         id: expect.any(String),
         type: 'primary',
+        inLanguage: [],
         name: 'Citation 3',
         description: 'Citation Description 3',
         url: 'https://example.org/citation3',
@@ -305,6 +310,7 @@ describe('createResearchGuide', () => {
         {
           id: expect.any(String),
           type: 'primary',
+          inLanguage: ['en'],
           name: 'Citation 1',
           description: 'Citation Description 1',
           url: 'https://example.org/citation1',
@@ -312,6 +318,7 @@ describe('createResearchGuide', () => {
         {
           id: expect.any(String),
           type: 'secondary',
+          inLanguage: ['en', 'nl'],
           name: 'Citation 2',
           description: 'Citation Description 2',
           url: 'https://example.org/citation2',
@@ -319,6 +326,7 @@ describe('createResearchGuide', () => {
         {
           id: expect.any(String),
           type: 'primary',
+          inLanguage: [],
           name: 'Citation 3',
           description: 'Citation Description 3',
           url: 'https://example.org/citation3',

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -19,6 +19,8 @@ function createCitation(citationResource: Resource) {
   const additionalType = onlyOne(
     getPropertyValues(citationResource, 'ex:additionalType')
   );
+  const inLanguage = getPropertyValues(citationResource, 'ex:inLanguage');
+  const language = Array.isArray(inLanguage) ? inLanguage : [];
 
   // The KG, unfortunately, does not use structured data for denoting the
   // type of the source - we'll need to parse an unstructured literal
@@ -32,6 +34,7 @@ function createCitation(citationResource: Resource) {
     name,
     description,
     url,
+    inLanguage: language,
   };
 
   return citation;


### PR DESCRIPTION
This PR filters the citations of research aids based on their language (e.g. Dutch or English). This is to prevent English citations appearing in a Dutch research aid, and vice versa.

As far as I can see we do not need to present the languages of citations in the frontend.

Source: https://github.com/colonial-heritage/sprints/issues/502