### PR TITLE
Refactor and bug fix navigation links, only show links needed and use textToSlug

### DIFF
--- a/apps/researcher/src/app/[locale]/research-aids/[id]/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-aids/[id]/page.tsx
@@ -4,6 +4,7 @@ import {
   encodeRouteSegment,
 } from '@/lib/clerk-route-segment-transformer';
 import researchGuides from '@/lib/research-guides-instance';
+import {textToSlug} from '../linkable-headers';
 import {getLocale, getTranslations} from 'next-intl/server';
 import GuideNavigationBar from '../guide-navigation-bar';
 import {Link} from '@/navigation';
@@ -35,24 +36,28 @@ export default async function GuidePage({params}: Props) {
   }
 
   const pageNavigationHeaders = getMarkdownHeaders(guide.text);
-  const navLinks = [
-    ...pageNavigationHeaders.map(header => ({
-      slug: header.slug,
-      name: header.name,
-    })),
-    {
-      slug: 'resources',
+  const navLinks = pageNavigationHeaders.map(header => ({
+    slug: header.slug,
+    name: header.name,
+  }));
+  if (guide.citations && guide.citations.length > 0) {
+    navLinks.push({
+      slug: textToSlug(t('pageNavigationSources')),
       name: t('pageNavigationSources'),
-    },
-    {
-      slug: 'relatedItems',
+    });
+  }
+  if (guide.seeAlso && guide.seeAlso.length > 0) {
+    navLinks.push({
+      slug: textToSlug(t('pageNavigationRelatedItems')),
       name: t('pageNavigationRelatedItems'),
-    },
-    {
-      slug: 'keywords',
+    });
+  }
+  if (guide.keywords && guide.keywords.length > 0) {
+    navLinks.push({
+      slug: textToSlug(t('pageNavigationKeywords')),
       name: t('pageNavigationKeywords'),
-    },
-  ];
+    });
+  }
 
   return (
     <>
@@ -97,7 +102,11 @@ export default async function GuidePage({params}: Props) {
             {guide.text && <StringToMarkdown text={guide.text} />}
             {guide.citations && guide.citations.length > 0 && (
               <>
-                <h2 id="resources" className="scroll-mt-20" tabIndex={0}>
+                <h2
+                  id={textToSlug(t('pageNavigationSources'))}
+                  className="scroll-mt-20"
+                  tabIndex={0}
+                >
                   {t('citations')}
                 </h2>
                 <CitationList
@@ -171,7 +180,11 @@ async function RelatedItems({guide}: {guide: ResearchGuide}) {
   if (!guide.seeAlso || guide.seeAlso.length === 0) return null;
   return (
     <>
-      <h2 className="mb-2 scroll-mt-20" id="relatedItems" tabIndex={0}>
+      <h2
+        className="mb-2 scroll-mt-20"
+        id={textToSlug(t('pageNavigationRelatedItems'))}
+        tabIndex={0}
+      >
         {t('relatedItems')}
       </h2>
       <div className="flex flex-col gap-2">
@@ -204,7 +217,11 @@ async function KeywordsSection({guide}: {guide: ResearchGuide}) {
   if (!hasKeywords && !hasLocations && !hasTimes) return null;
   return (
     <>
-      <h2 className="mt-10 text-lg scroll-mt-20" id="keywords" tabIndex={0}>
+      <h2
+        className="mt-10 text-lg scroll-mt-20"
+        id={textToSlug(t('pageNavigationKeywords'))}
+        tabIndex={0}
+      >
         {t('keywords')}
       </h2>
       <p className="italic text-neutral-500 my-1">{t('keywordsNewSearch')}</p>

--- a/apps/researcher/src/app/[locale]/research-aids/linkable-headers.ts
+++ b/apps/researcher/src/app/[locale]/research-aids/linkable-headers.ts
@@ -1,4 +1,4 @@
-export function textToSlug(text: string): string {
+export function textToSlug(text = ''): string {
   return text
     .toLowerCase()
     .normalize('NFD')

--- a/apps/researcher/src/app/[locale]/research-aids/page.tsx
+++ b/apps/researcher/src/app/[locale]/research-aids/page.tsx
@@ -7,6 +7,7 @@ import {getLocale, getTranslations} from 'next-intl/server';
 import GuideNavigationBar from './guide-navigation-bar';
 import StringToMarkdown from './string-to-markdown';
 import {sortResearchGuide} from '@/app/[locale]/research-aids/sort-guides';
+import {textToSlug} from './linkable-headers';
 
 export default async function Page() {
   const locale = (await getLocale()) as LocaleEnum;
@@ -25,10 +26,12 @@ export default async function Page() {
   const firstLevel1Guide = sortedGuides.hasParts?.[0];
   const nextLevel1Guides = sortedGuides.hasParts?.slice(1) || [];
 
-  const navLinks = [
-    {slug: 'topics', name: t('pageNavigationTopics')},
-    {slug: 'locations', name: t('pageNavigationLocations')},
-  ];
+  const navLinks = nextLevel1Guides
+    .filter(level1Guide => typeof level1Guide.name === 'string')
+    .map(level1Guide => ({
+      slug: textToSlug(level1Guide.name as string),
+      name: level1Guide.name as string,
+    }));
 
   return (
     <>
@@ -69,7 +72,10 @@ export default async function Page() {
         {nextLevel1Guides.map(level1Guide => (
           <div className="w-full lg:w-1/2" key={level1Guide.id}>
             <div className="mt-20 *:text-consortium-blue-800">
-              <h3 className="text-2xl pb-4 scroll-m-16" id="topics">
+              <h3
+                className="text-2xl pb-4 scroll-m-16"
+                id={textToSlug(level1Guide.name)}
+              >
                 {level1Guide.name}
               </h3>
               <div className="columns-1 xl:columns-2 gap-10 w-full">


### PR DESCRIPTION
While testing the guide navigation in production, I saw some bugs:

Research aids homepage:
- The navigation was hardcoded, but it linked to variable guides. This is not robust. The only downside of this change is that it also introduces a number in the navigation. But hopefully the numbers will be gone soon.

Guide page:
- Not all guides have 'citations', 'related items', and 'keywords'. Only show in the navigation if it links to something.
- While I was making changes, I also added translatable slugs instead of hard-coded IDs, because the variable links (links from the markdown) were also translated. So it's more uniform.