### PR TITLE
feat: order research aids

### DIFF
--- a/packages/api/src/research-guides/definitions.ts
+++ b/packages/api/src/research-guides/definitions.ts
@@ -22,4 +22,5 @@ export type ResearchGuide = Thing & {
   citations?: Citation[];
   hasParts?: ResearchGuide[];
   seeAlso?: ResearchGuide[];
+  position?: number; // In a list of research guides
 };

--- a/packages/api/src/research-guides/fetcher.integration.test.ts
+++ b/packages/api/src/research-guides/fetcher.integration.test.ts
@@ -14,7 +14,6 @@ describe('getTopLevels', () => {
   it('returns the top level guides', async () => {
     const researchGuides = await researchGuideFetcher.getTopLevels();
 
-    // The sorting order is undefined and can change - don't use toStrictEqual()
     expect(researchGuides).toMatchObject([
       {
         id: 'https://guides.example.org/topset',
@@ -23,29 +22,50 @@ describe('getTopLevels', () => {
           'Research aides for conducting provenance research into colonial collections',
         text: 'On this page you find various research aides that can assist...',
         encodingFormat: 'text/markdown',
-        hasParts: expect.arrayContaining([
+        hasParts: [
           {
             id: 'https://guides.example.org/subset1',
             name: 'Name',
-            hasParts: expect.arrayContaining([
+            hasParts: [
               {
                 id: 'https://guides.example.org/guide3',
                 name: 'Sources',
+                position: 6,
               },
               {
                 id: 'https://guides.example.org/guide1',
                 name: 'Doing research',
+                position: 4,
               },
               {
                 id: 'https://guides.example.org/guide2',
                 name: 'How can I use the data hub for my research?',
+                position: 5,
               },
-            ]),
+            ],
+            position: 1,
+          },
+          {
+            id: 'https://guides.example.org/subset3',
+            name: 'Name',
+            hasParts: [
+              {
+                id: 'https://guides.example.org/guide6',
+                name: 'Royal Cabinet of Curiosities',
+                position: 9,
+              },
+              {
+                id: 'https://guides.example.org/guide7',
+                name: 'Kunsthandel Van Lier',
+                position: 10,
+              },
+            ],
+            position: 3,
           },
           {
             id: 'https://guides.example.org/subset2',
             name: 'Name',
-            hasParts: expect.arrayContaining([
+            hasParts: [
               {
                 id: 'https://guides.example.org/guide5',
                 name: 'Trade',
@@ -53,8 +73,10 @@ describe('getTopLevels', () => {
                   {
                     id: 'https://guides.example.org/guide7',
                     name: 'Kunsthandel Van Lier',
+                    position: 17,
                   },
                 ],
+                position: 8,
               },
               {
                 id: 'https://guides.example.org/guide4',
@@ -63,26 +85,15 @@ describe('getTopLevels', () => {
                   {
                     id: 'https://guides.example.org/guide6',
                     name: 'Royal Cabinet of Curiosities',
+                    position: 12,
                   },
                 ],
+                position: 7,
               },
-            ]),
+            ],
+            position: 2,
           },
-          {
-            id: 'https://guides.example.org/subset3',
-            name: 'Name',
-            hasParts: expect.arrayContaining([
-              {
-                id: 'https://guides.example.org/guide7',
-                name: 'Kunsthandel Van Lier',
-              },
-              {
-                id: 'https://guides.example.org/guide6',
-                name: 'Royal Cabinet of Curiosities',
-              },
-            ]),
-          },
-        ]),
+        ],
       },
     ]);
   });
@@ -170,16 +181,19 @@ describe('getById', () => {
         {
           id: 'https://guides.example.org/guide6',
           name: 'Royal Cabinet of Curiosities',
+          position: 12,
         },
       ]),
       seeAlso: expect.arrayContaining([
         {
           id: 'https://guides.example.org/guide6',
           name: 'Royal Cabinet of Curiosities',
+          position: 14,
         },
         {
           id: 'https://guides.example.org/guide1',
           name: 'Doing research',
+          position: 13,
         },
       ]),
       contentLocations: expect.arrayContaining([
@@ -235,16 +249,19 @@ describe('get with localized names', () => {
         {
           id: 'https://guides.example.org/guide6',
           name: 'Royal Cabinet of Curiosities',
+          position: 12,
         },
       ]),
       seeAlso: expect.arrayContaining([
         {
           id: 'https://guides.example.org/guide6',
           name: 'Royal Cabinet of Curiosities',
+          position: 14,
         },
         {
           id: 'https://guides.example.org/guide1',
           name: 'Doing research',
+          position: 13,
         },
       ]),
       contentLocations: [
@@ -285,16 +302,19 @@ describe('get with localized names', () => {
         {
           id: 'https://guides.example.org/guide6',
           name: 'Koninklijk Kabinet van Zeldzaamheden',
+          position: 12,
         },
       ]),
       seeAlso: expect.arrayContaining([
         {
           id: 'https://guides.example.org/guide6',
           name: 'Koninklijk Kabinet van Zeldzaamheden',
+          position: 14,
         },
         {
           id: 'https://guides.example.org/guide1',
           name: 'Onderzoeken',
+          position: 13,
         },
       ]),
       contentLocations: [

--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -67,15 +67,27 @@ export class ResearchGuideFetcher {
           ex:abstract ?topSetAbstract ;
           ex:text ?topSetText ;
           ex:encodingFormat ?topSetEncodingFormat ;
-          ex:hasPart ?subSet .
+          ex:hasPart ?itemListElementOfTopSet .
+
+        ?itemListElementOfTopSet a ex:ListItem ;
+          ex:item ?subSet ;
+          ex:position ?subSetPosition .
 
         ?subSet a ex:CreativeWork ;
           ex:name ?subSetName ;
-          ex:hasPart ?level1Guide .
+          ex:hasPart ?itemListElementOfSubSet .
+
+        ?itemListElementOfSubSet a ex:ListItem ;
+          ex:item ?level1Guide ;
+          ex:position ?level1GuidePosition .
 
         ?level1Guide a ex:CreativeWork ;
           ex:name ?level1GuideName ;
-          ex:hasPart ?level2Guide .
+          ex:hasPart ?itemListElementOfLevel1Guide .
+
+        ?itemListElementOfLevel1Guide a ex:ListItem ;
+          ex:item ?level2Guide ;
+          ex:position ?level2GuidePosition .
 
         ?level2Guide a ex:CreativeWork ;
           ex:name ?level2GuideName .
@@ -105,19 +117,34 @@ export class ResearchGuideFetcher {
         }
 
         OPTIONAL {
-          ?topSet la:has_member ?subSet .
+          ?topSet schema:itemListElement ?itemListElementOfTopSet .
+          ?itemListElementOfTopSet schema:item ?subSet ;
+            schema:position ?subSetPosition .
+
           ?subSet schema:name ?subSetName
           FILTER(LANG(?subSetName) = "${options.locale}")
 
           # Get a selection of information from member guides, if any
           OPTIONAL {
-            ?subSet la:has_member ?level1Guide .
+            ?subSet schema:itemListElement ?itemListElementOfSubSet .
+            ?itemListElementOfSubSet schema:item ?level1Guide .
+
+            OPTIONAL {
+              ?itemListElementOfSubSet schema:position ?level1GuidePosition
+            }
+
             ?level1Guide schema:name ?level1GuideName
             FILTER(LANG(?level1GuideName) = "${options.locale}")
 
             # Get a selection of information from member guides, if any
             OPTIONAL {
-              ?level1Guide la:has_member ?level2Guide .
+              ?level1Guide schema:itemListElement ?itemListElementOfLevel1Guide .
+              ?itemListElementOfLevel1Guide schema:item ?level2Guide .
+
+              OPTIONAL {
+                ?itemListElementOfLevel1Guide schema:position ?level2GuidePosition
+              }
+
               ?level2Guide schema:name ?level2GuideName
               FILTER(LANG(?level2GuideName) = "${options.locale}")
             }
@@ -174,15 +201,23 @@ export class ResearchGuideFetcher {
           ex:abstract ?abstract ;
           ex:text ?text ;
           ex:encodingFormat ?encodingFormat ;
-          ex:hasPart ?memberGuide ;
-          ex:seeAlso ?relatedGuide ;
+          ex:hasPart ?itemListElementOfMemberGuide ;
+          ex:seeAlso ?itemListElementOfRelatedGuide ;
           ex:contentLocation ?spatial ;
           ex:keyword ?keyword ;
           ex:citation ?citation ;
           ex:contentReferenceTime ?contentReferenceTime .
 
+        ?itemListElementOfMemberGuide a ex:ListItem ;
+          ex:item ?memberGuide ;
+          ex:position ?memberGuidePosition .
+
         ?memberGuide a ex:CreativeWork ;
           ex:name ?memberGuideName .
+
+        ?itemListElementOfRelatedGuide a ex:ListItem ;
+          ex:item ?relatedGuide ;
+          ex:position ?relatedGuidePosition .
 
         ?relatedGuide a ex:CreativeWork ;
           ex:name ?relatedGuideName .
@@ -240,14 +275,27 @@ export class ResearchGuideFetcher {
 
         # Get a selection of information from member guides, if any
         OPTIONAL {
-          ?this la:has_member ?memberGuide .
+          ?this schema:itemListElement ?itemListElementOfMemberGuide .
+          ?itemListElementOfMemberGuide schema:item ?memberGuide .
+
+          OPTIONAL {
+            ?itemListElementOfMemberGuide schema:position ?memberGuidePosition
+          }
+
           ?memberGuide schema:name ?memberGuideName
           FILTER(LANG(?memberGuideName) = "${options.locale}")
         }
 
         # Get a selection of information from related guides, if any
         OPTIONAL {
-          ?this rdfs:seeAlso ?relatedGuide .
+          ?this rdfs:seeAlso ?itemListWithRelatedGuides .
+          ?itemListWithRelatedGuides schema:itemListElement ?itemListElementOfRelatedGuide .
+          ?itemListElementOfRelatedGuide schema:item ?relatedGuide .
+
+          OPTIONAL {
+            ?itemListElementOfRelatedGuide schema:position ?relatedGuidePosition
+          }
+
           ?relatedGuide schema:name ?relatedGuideName
           FILTER(LANG(?relatedGuideName) = "${options.locale}")
         }

--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -118,8 +118,11 @@ export class ResearchGuideFetcher {
 
         OPTIONAL {
           ?topSet schema:itemListElement ?itemListElementOfTopSet .
-          ?itemListElementOfTopSet schema:item ?subSet ;
-            schema:position ?subSetPosition .
+          ?itemListElementOfTopSet schema:item ?subSet .
+
+          OPTIONAL {
+            ?itemListElementOfTopSet schema:position ?subSetPosition
+          }
 
           ?subSet schema:name ?subSetName
           FILTER(LANG(?subSetName) = "${options.locale}")

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -54,24 +54,59 @@ beforeAll(async () => {
         ex:description "Citation Description 2" ;
         ex:url <https://example.org/citation2> ;
       ], [
-        # Missing 'ex:additionalType' and 'ex:inLanguage'
+        # Intentionally missing 'ex:additionalType' and 'ex:inLanguage'
         ex:name "Citation 3" ;
         ex:description "Citation Description 3" ;
         ex:url <https://example.org/citation3> ;
       ] ;
-      ex:hasPart ex:researchGuide3 ;
-      ex:seeAlso ex:researchGuide3 .
+      ex:hasPart [
+        a ex:ListItem ;
+        ex:position 1 ;
+        ex:item ex:researchGuide3
+      ], [
+        a ex:ListItem ;
+        # Intentionally not set
+        #ex:position 2 ;
+        ex:item ex:researchGuide6
+      ] ;
+      ex:seeAlso [
+        a ex:ListItem ;
+        ex:position 1 ;
+        ex:item ex:researchGuide3
+      ], [
+        a ex:ListItem ;
+        # Intentionally not set
+        #ex:position 2 ;
+        ex:item ex:researchGuide6
+      ] .
 
     ex:researchGuide3 a ex:CreativeWork ;
       ex:name "Name 3" ;
-      ex:hasPart ex:researchGuide5 ;
-      ex:seeAlso ex:researchGuide5 .
+      ex:hasPart [
+        a ex:ListItem ;
+        ex:position 1 ;
+        ex:item ex:researchGuide5
+      ] ;
+      ex:seeAlso [
+        a ex:ListItem ;
+        ex:position 1 ;
+        ex:item ex:researchGuide5
+      ] .
 
     ex:researchGuide5 a ex:CreativeWork ;
       ex:name "Name 5" ;
       ex:abstract "Abstract 5" ;
-      ex:hasPart ex:researchGuide6 ;
-      ex:seeAlso ex:researchGuide6 .
+      ex:hasPart [
+        a ex:ListItem ;
+        ex:position 1 ;
+        # Intentionally not set
+        #ex:item ex:researchGuide6
+      ] ;
+      ex:seeAlso [
+        a ex:ListItem ;
+        ex:position 1 ;
+        ex:item ex:researchGuide6
+      ] .
 
     ex:researchGuide6 a ex:CreativeWork ;
       ex:name "Name 6" ;
@@ -196,102 +231,6 @@ describe('createResearchGuide', () => {
           },
         },
       ],
-      hasParts: [
-        {
-          id: 'https://example.org/researchGuide3',
-          name: 'Name 3',
-          hasParts: [
-            {
-              id: 'https://example.org/researchGuide5',
-              name: 'Name 5',
-              abstract: 'Abstract 5',
-              hasParts: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-              seeAlso: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-            },
-          ],
-          seeAlso: [
-            {
-              id: 'https://example.org/researchGuide5',
-              name: 'Name 5',
-              abstract: 'Abstract 5',
-              hasParts: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-              seeAlso: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      seeAlso: [
-        {
-          id: 'https://example.org/researchGuide3',
-          name: 'Name 3',
-          hasParts: [
-            {
-              id: 'https://example.org/researchGuide5',
-              name: 'Name 5',
-              abstract: 'Abstract 5',
-              hasParts: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-              seeAlso: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-            },
-          ],
-          seeAlso: [
-            {
-              id: 'https://example.org/researchGuide5',
-              name: 'Name 5',
-              abstract: 'Abstract 5',
-              hasParts: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-              seeAlso: [
-                {
-                  id: 'https://example.org/researchGuide6',
-                  name: 'Name 6',
-                  abstract: 'Abstract 6',
-                },
-              ],
-            },
-          ],
-        },
-      ],
       contentLocations: [
         {
           id: expect.any(String),
@@ -330,6 +269,96 @@ describe('createResearchGuide', () => {
           name: 'Citation 3',
           description: 'Citation Description 3',
           url: 'https://example.org/citation3',
+        },
+      ],
+      hasParts: [
+        {
+          id: 'https://example.org/researchGuide3',
+          name: 'Name 3',
+          hasParts: [
+            {
+              id: 'https://example.org/researchGuide5',
+              name: 'Name 5',
+              abstract: 'Abstract 5',
+              seeAlso: [
+                {
+                  id: 'https://example.org/researchGuide6',
+                  name: 'Name 6',
+                  abstract: 'Abstract 6',
+                  position: 1,
+                },
+              ],
+              position: 1,
+            },
+          ],
+          seeAlso: [
+            {
+              id: 'https://example.org/researchGuide5',
+              name: 'Name 5',
+              abstract: 'Abstract 5',
+              seeAlso: [
+                {
+                  id: 'https://example.org/researchGuide6',
+                  name: 'Name 6',
+                  abstract: 'Abstract 6',
+                  position: 1,
+                },
+              ],
+              position: 1,
+            },
+          ],
+          position: 1,
+        },
+        {
+          id: 'https://example.org/researchGuide6',
+          name: 'Name 6',
+          abstract: 'Abstract 6',
+          position: 0,
+        },
+      ],
+      seeAlso: [
+        {
+          id: 'https://example.org/researchGuide3',
+          name: 'Name 3',
+          hasParts: [
+            {
+              id: 'https://example.org/researchGuide5',
+              name: 'Name 5',
+              abstract: 'Abstract 5',
+              seeAlso: [
+                {
+                  id: 'https://example.org/researchGuide6',
+                  name: 'Name 6',
+                  abstract: 'Abstract 6',
+                  position: 1,
+                },
+              ],
+              position: 1,
+            },
+          ],
+          seeAlso: [
+            {
+              id: 'https://example.org/researchGuide5',
+              name: 'Name 5',
+              abstract: 'Abstract 5',
+              seeAlso: [
+                {
+                  id: 'https://example.org/researchGuide6',
+                  name: 'Name 6',
+                  abstract: 'Abstract 6',
+                  position: 1,
+                },
+              ],
+              position: 1,
+            },
+          ],
+          position: 1,
+        },
+        {
+          id: 'https://example.org/researchGuide6',
+          name: 'Name 6',
+          abstract: 'Abstract 6',
+          position: 0,
         },
       ],
     });

--- a/packages/api/src/research-guides/rdf-helpers.test.ts
+++ b/packages/api/src/research-guides/rdf-helpers.test.ts
@@ -313,7 +313,6 @@ describe('createResearchGuide', () => {
           id: 'https://example.org/researchGuide6',
           name: 'Name 6',
           abstract: 'Abstract 6',
-          position: 0,
         },
       ],
       seeAlso: [
@@ -358,7 +357,6 @@ describe('createResearchGuide', () => {
           id: 'https://example.org/researchGuide6',
           name: 'Name 6',
           abstract: 'Abstract 6',
-          position: 0,
         },
       ],
     });

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -82,11 +82,10 @@ function createResearchGuideFromListItem(
     getPropertyValues(listItemResource, 'ex:position')
   );
 
-  // If `position` is missing, use `0` instead
-  const position = rawPosition !== undefined ? parseInt(rawPosition) : 0;
-
-  // The position of the guide within the current list
-  researchGuide.position = position;
+  if (rawPosition !== undefined) {
+    // The position of the guide within the current list
+    researchGuide.position = parseInt(rawPosition);
+  }
 
   return researchGuide;
 }

--- a/packages/api/src/research-guides/rdf-helpers.ts
+++ b/packages/api/src/research-guides/rdf-helpers.ts
@@ -2,6 +2,7 @@ import {
   createPlaces,
   createThings,
   createTimeSpan,
+  getProperty,
   getPropertyValues,
   onlyOne,
   removeNullish,
@@ -47,19 +48,6 @@ export function createCitations(resource: Resource, propertyName: string) {
   return citations.length > 0 ? citations : undefined;
 }
 
-function createResearchGuides(
-  resource: Resource,
-  propertyName: string,
-  stackSize: number
-) {
-  const properties = resource.properties[propertyName];
-  const researchGuides = properties.map(property =>
-    createResearchGuide(property, stackSize)
-  );
-
-  return researchGuides.length > 0 ? researchGuides : undefined;
-}
-
 function createEvent(eventResource: Resource) {
   const timespan = createTimeSpan(eventResource);
 
@@ -78,11 +66,61 @@ export function createEvents(resource: Resource, propertyName: string) {
   return events.length > 0 ? events : undefined;
 }
 
+function createResearchGuideFromListItem(
+  listItemResource: Resource,
+  stackSize: number
+) {
+  const researchGuideResource = getProperty(listItemResource, 'ex:item');
+
+  if (researchGuideResource === undefined) {
+    return undefined; // Missing `item` property - should not happen
+  }
+
+  const researchGuide = createResearchGuide(researchGuideResource, stackSize);
+
+  const rawPosition = onlyOne(
+    getPropertyValues(listItemResource, 'ex:position')
+  );
+
+  // If `position` is missing, use `0` instead
+  const position = rawPosition !== undefined ? parseInt(rawPosition) : 0;
+
+  // The position of the guide within the current list
+  researchGuide.position = position;
+
+  return researchGuide;
+}
+
+function createMembers(
+  resource: Resource,
+  propertyName: string,
+  stackSize: number
+) {
+  const properties = resource.properties[propertyName];
+
+  const researchGuides = properties.reduce(
+    (researchGuides: ResearchGuide[], property) => {
+      const researchGuide = createResearchGuideFromListItem(
+        property,
+        stackSize
+      );
+      if (researchGuide !== undefined) {
+        researchGuides.push(researchGuide);
+      }
+      return researchGuides;
+    },
+    []
+  );
+
+  return researchGuides.length > 0 ? researchGuides : undefined;
+}
+
 export function createResearchGuide(
   researchGuideResource: Resource,
   stackSize = 1
 ) {
   const name = onlyOne(getPropertyValues(researchGuideResource, 'ex:name'));
+
   const alternateNames = getPropertyValues(
     researchGuideResource,
     'ex:alternateName'
@@ -95,22 +133,22 @@ export function createResearchGuide(
     getPropertyValues(researchGuideResource, 'ex:encodingFormat')
   );
 
-  let hasParts: ResearchGuide[] | undefined = undefined;
+  let memberResearchGuides: ResearchGuide[] | undefined = undefined;
 
   // Prevent infinite recursion
   if (stackSize < 5) {
-    hasParts = createResearchGuides(
+    memberResearchGuides = createMembers(
       researchGuideResource,
       'ex:hasPart',
       stackSize + 1
     );
   }
 
-  let seeAlso: ResearchGuide[] | undefined = undefined;
+  let relatedResearchGuides: ResearchGuide[] | undefined = undefined;
 
   // Prevent infinite recursion
   if (stackSize < 5) {
-    seeAlso = createResearchGuides(
+    relatedResearchGuides = createMembers(
       researchGuideResource,
       'ex:seeAlso',
       stackSize + 1
@@ -136,8 +174,8 @@ export function createResearchGuide(
     text,
     encodingFormat,
     contentReferenceTimes,
-    hasParts,
-    seeAlso,
+    hasParts: memberResearchGuides,
+    seeAlso: relatedResearchGuides,
     contentLocations,
     keywords,
     citations,


### PR DESCRIPTION
This PR adds ordering to the 'member aids' (`hasParts`) of a research aid and to the 'related aids' (`seeAlso`) of a research aid.

It does so by introducing a new, optional property on a `ResearchGuide`: `position`. The frontend can use this property to sort the research aids. If the `position` of a research aid is `0`, then either it is the first aid in a list or the position was not set explicitly in the NIOD source data (in which case there can be more research aids with a position `0`).

**This PR, at this moment, only works with the data on the testing environment**, accessible via https://dev.app.colonialcollections.nl/nl/research-aids. Some changes still need to be made to the NIOD ETL before the data with the ordering is available on production.

The new data from NIOD has been put in a temporary 'acceptance' knowledge graph, so that we can test the changes to the data. This knowledge graph can be queried in the frontend by setting env var `SPARQL_ENDPOINT_URL` to `https://api.colonialcollections.nl/datasets/data-hub/knowledge-graph-acceptance/sparql`.

Source: https://github.com/colonial-heritage/sprints/issues/500