### PR TITLE
Fix too many related guides appearing

### DIFF
--- a/packages/api/src/research-guides/fetcher.ts
+++ b/packages/api/src/research-guides/fetcher.ts
@@ -292,6 +292,11 @@ export class ResearchGuideFetcher {
         # Get a selection of information from related guides, if any
         OPTIONAL {
           ?this rdfs:seeAlso ?itemListWithRelatedGuides .
+
+          # only include "pure" ItemLists and not TextDigitalDocuments, which also happen to be ItemLists
+          ?itemListWithRelatedGuides a schema:ItemList .
+          FILTER NOT EXISTS { ?itemListWithRelatedGuides a schema:TextDigitalDocument }
+
           ?itemListWithRelatedGuides schema:itemListElement ?itemListElementOfRelatedGuide .
           ?itemListElementOfRelatedGuide schema:item ?relatedGuide .
 


### PR DESCRIPTION
Related guides appear twice, once direct using a seeAlso relation and once through an intermediary itemList relation so that they can be ordered.

However, a guide page can itself also be an itemList, so the direct seeAlso link might cause the ordered components of the page to also be included as if they are related guides