### PR TITLE
feat: replace onboarding animation with walkthrough videos

### DIFF
--- a/apps/researcher/next.config.mjs
+++ b/apps/researcher/next.config.mjs
@@ -12,6 +12,13 @@ const nextConfig = {
   experimental: {
     mdxRs: true,
   },
+  webpack: config => {
+    config.module.rules.push({
+      test: /\.yaml$/,
+      type: 'asset/source',
+    });
+    return config;
+  },
   // https://vercel.com/docs/image-optimization
   images: {
     remotePatterns: [{hostname: '**'}],

--- a/apps/researcher/src/app/[locale]/(home)/page.tsx
+++ b/apps/researcher/src/app/[locale]/(home)/page.tsx
@@ -6,7 +6,7 @@ import {SortBy} from '@/lib/community/definitions';
 import {getTranslations} from 'next-intl/server';
 import {SearchFieldHome} from './search-field';
 import {Link} from '@/navigation';
-import Image from 'next/image';
+import Walkthrough from '@/components/walkthrough/walkthrough';
 
 export default async function Home() {
   const t = await getTranslations('Home');
@@ -102,20 +102,12 @@ export default async function Home() {
         </div>
 
         <div className="bg-white" id="how-this-works">
-          <div className=" w-full max-w-6xl px-4 sm:px-10 flex flex-col gap-10 relative pb-10 py-20 text-consortium-blue-800 mx-auto mb-32">
+          <div className="w-full max-w-6xl px-4 sm:px-10 flex flex-col gap-10 relative pb-10 py-20 text-consortium-blue-800 mx-auto mb-32">
             <h2 className="text-5xl" tabIndex={0}>
               {t('howThisWorksTitle')}
             </h2>
             <p className="max-w-md">{t('howThisWorksText')}</p>
-            <div>
-              <Image
-                src="/images/onboarding.gif"
-                alt={t('howThisWorksAlt')}
-                width="900"
-                height="300"
-                className="w-full h-auto"
-              />
-            </div>
+            <Walkthrough />
           </div>
         </div>
       </main>

--- a/apps/researcher/src/components/walkthrough/schema.test.ts
+++ b/apps/researcher/src/components/walkthrough/schema.test.ts
@@ -1,0 +1,93 @@
+import {parseWalkthrough} from './schema';
+
+describe('parseWalkthrough', () => {
+  it('returns parsed videos for valid YAML', () => {
+    const yaml = `
+videos:
+  - title: Search
+    text: Type a keyword.
+    vimeoId: "123"
+  - title: Add a narrative
+    text: Click the button.
+    vimeoId: "456"
+    vimeoHash: abc
+`;
+    expect(parseWalkthrough(yaml)).toEqual([
+      {title: 'Search', text: 'Type a keyword.', vimeoId: '123', active: true},
+      {
+        title: 'Add a narrative',
+        text: 'Click the button.',
+        vimeoId: '456',
+        vimeoHash: 'abc',
+        active: true,
+      },
+    ]);
+  });
+
+  it('skips invalid entries and reports them via onInvalid', () => {
+    const yaml = `
+videos:
+  - title: Valid
+    text: Good.
+    vimeoId: "1"
+  - title: ""
+    text: Missing title
+    vimeoId: "2"
+  - title: Bad id
+    text: Non-numeric
+    vimeoId: "abc"
+`;
+    const onInvalid = jest.fn();
+    const result = parseWalkthrough(yaml, {onInvalid});
+
+    expect(result).toEqual([
+      {title: 'Valid', text: 'Good.', vimeoId: '1', active: true},
+    ]);
+    expect(onInvalid).toHaveBeenCalledTimes(2);
+    expect(onInvalid.mock.calls[0][0]).toBe(1);
+    expect(onInvalid.mock.calls[1][0]).toBe(2);
+  });
+
+  it('accepts entries with empty or missing text', () => {
+    const yaml = `
+videos:
+  - title: No text
+    vimeoId: "1"
+  - title: Empty text
+    text: ""
+    vimeoId: "2"
+`;
+    expect(parseWalkthrough(yaml)).toEqual([
+      {title: 'No text', text: '', vimeoId: '1', active: true},
+      {title: 'Empty text', text: '', vimeoId: '2', active: true},
+    ]);
+  });
+
+  it('skips inactive entries', () => {
+    const yaml = `
+videos:
+  - title: Active
+    text: Visible.
+    vimeoId: "1"
+  - title: Inactive
+    text: Hidden.
+    vimeoId: "2"
+    active: false
+`;
+    expect(parseWalkthrough(yaml)).toEqual([
+      {title: 'Active', text: 'Visible.', vimeoId: '1', active: true},
+    ]);
+  });
+
+  it('returns empty array for YAML with no videos key', () => {
+    expect(parseWalkthrough('other: value')).toEqual([]);
+  });
+
+  it('returns empty array and calls onInvalid for malformed top-level shape', () => {
+    const onInvalid = jest.fn();
+    const result = parseWalkthrough('videos: "not an array"', {onInvalid});
+
+    expect(result).toEqual([]);
+    expect(onInvalid).toHaveBeenCalledWith(-1, expect.anything());
+  });
+});

--- a/apps/researcher/src/components/walkthrough/schema.ts
+++ b/apps/researcher/src/components/walkthrough/schema.ts
@@ -1,0 +1,37 @@
+import yaml from 'yaml';
+import {z} from 'zod';
+
+const VideoSchema = z.object({
+  title: z.string().min(1),
+  active: z.boolean().default(true),
+  text: z.string().default(''),
+  vimeoId: z.string().regex(/^\d+$/),
+  vimeoHash: z.string().optional(),
+});
+
+const WalkthroughSchema = z.object({
+  videos: z.array(z.unknown()).default([]),
+});
+
+export type Video = z.infer<typeof VideoSchema>;
+
+export function parseWalkthrough(
+  raw: string,
+  {onInvalid}: {onInvalid?: (index: number, issues: unknown) => void} = {}
+): Video[] {
+  const parsed = WalkthroughSchema.safeParse(yaml.parse(raw));
+  if (!parsed.success) {
+    onInvalid?.(-1, parsed.error.issues);
+    return [];
+  }
+
+  return parsed.data.videos.flatMap((entry, index) => {
+    const result = VideoSchema.safeParse(entry);
+    if (!result.success) {
+      onInvalid?.(index, result.error.issues);
+      return [];
+    }
+    if (!result.data.active) return [];
+    return [result.data];
+  });
+}

--- a/apps/researcher/src/components/walkthrough/walkthrough-tabs.tsx
+++ b/apps/researcher/src/components/walkthrough/walkthrough-tabs.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {Tab} from '@headlessui/react';
+import classNames from 'classnames';
+import type {Video} from './schema';
+
+interface Props {
+  videos: Video[];
+}
+
+function vimeoSrc(video: Video) {
+  const base = `https://player.vimeo.com/video/${video.vimeoId}`;
+  return video.vimeoHash ? `${base}?h=${video.vimeoHash}` : base;
+}
+
+export default function WalkthroughTabs({videos}: Props) {
+  return (
+    <Tab.Group
+      as="div"
+      className="flex flex-col md:flex-row gap-4 md:gap-6 w-full"
+    >
+      <Tab.List className="flex flex-row md:flex-col w-full md:w-1/5 gap-2 flex-wrap">
+        {videos.map(video => (
+          <Tab
+            key={video.vimeoId}
+            className={({selected}) =>
+              classNames(
+                'text-left px-2 py-1 rounded text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-consortium-blue-400',
+                selected
+                  ? 'bg-consortium-blue-50 text-consortium-blue-800'
+                  : 'bg-neutral-200 hover:bg-neutral-300'
+              )
+            }
+          >
+            {video.title}
+          </Tab>
+        ))}
+      </Tab.List>
+      <Tab.Panels className="flex flex-col w-full md:w-4/5">
+        {videos.map(video => (
+          <Tab.Panel
+            key={video.vimeoId}
+            className="flex flex-col focus:outline-none"
+          >
+            <div className="bg-neutral-200 rounded-t p-2">
+              <div className="aspect-w-16 aspect-h-9">
+                <iframe
+                  src={vimeoSrc(video)}
+                  title={video.title}
+                  allow="autoplay; fullscreen; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+            </div>
+            <div className="bg-neutral-200 rounded-b py-4 px-4">
+              {video.text}
+            </div>
+          </Tab.Panel>
+        ))}
+      </Tab.Panels>
+    </Tab.Group>
+  );
+}

--- a/apps/researcher/src/components/walkthrough/walkthrough.tsx
+++ b/apps/researcher/src/components/walkthrough/walkthrough.tsx
@@ -1,0 +1,47 @@
+import {readFile} from 'node:fs/promises';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getLocale} from 'next-intl/server';
+import {parseWalkthrough} from './schema';
+import WalkthroughTabs from './walkthrough-tabs';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+async function loadVideos(locale: string) {
+  const path = join(
+    moduleDir,
+    '..',
+    '..',
+    'messages',
+    locale,
+    'walkthrough.yaml'
+  );
+  const raw = await readFile(path, 'utf-8');
+  return parseWalkthrough(raw, {
+    onInvalid: (index, issues) => {
+      console.warn(
+        `[walkthrough] skipping invalid entry at index ${index} (locale "${locale}"):`,
+        issues
+      );
+    },
+  });
+}
+
+export default async function Walkthrough() {
+  const locale = await getLocale();
+
+  let videos;
+  try {
+    videos = await loadVideos(locale);
+  } catch (error) {
+    console.warn(
+      `[walkthrough] could not load walkthrough for locale "${locale}":`,
+      error
+    );
+    return null;
+  }
+
+  if (videos.length === 0) return null;
+
+  return <WalkthroughTabs videos={videos} />;
+}

--- a/apps/researcher/src/components/walkthrough/walkthrough.tsx
+++ b/apps/researcher/src/components/walkthrough/walkthrough.tsx
@@ -1,22 +1,18 @@
-import {readFile} from 'node:fs/promises';
-import {dirname, join} from 'node:path';
-import {fileURLToPath} from 'node:url';
 import {getLocale} from 'next-intl/server';
 import {parseWalkthrough} from './schema';
 import WalkthroughTabs from './walkthrough-tabs';
 
-const moduleDir = dirname(fileURLToPath(import.meta.url));
+// Bundled at build time via webpack asset/source rule
+import enYaml from '../../messages/en/walkthrough.yaml';
+import nlYaml from '../../messages/nl/walkthrough.yaml';
 
-async function loadVideos(locale: string) {
-  const path = join(
-    moduleDir,
-    '..',
-    '..',
-    'messages',
-    locale,
-    'walkthrough.yaml'
-  );
-  const raw = await readFile(path, 'utf-8');
+const yamlByLocale: Record<string, string> = {
+  en: enYaml,
+  nl: nlYaml,
+};
+
+function loadVideos(locale: string) {
+  const raw = yamlByLocale[locale] ?? yamlByLocale.en;
   return parseWalkthrough(raw, {
     onInvalid: (index, issues) => {
       console.warn(
@@ -29,17 +25,7 @@ async function loadVideos(locale: string) {
 
 export default async function Walkthrough() {
   const locale = await getLocale();
-
-  let videos;
-  try {
-    videos = await loadVideos(locale);
-  } catch (error) {
-    console.warn(
-      `[walkthrough] could not load walkthrough for locale "${locale}":`,
-      error
-    );
-    return null;
-  }
+  const videos = loadVideos(locale);
 
   if (videos.length === 0) return null;
 

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -22,8 +22,8 @@
     "communitiesTitle": "Heritage communities",
     "communitiesDescription": "Upon creating an account, every individual or group of people can start their own community on this platform. A community is able to create lists of objects, bringing together their heritage. Communities can also add narratives to the objects in these collections.",
     "communitiesLink": "Below are some communities to inspire you. <link>Click here to see all the communities on the platform.</link>.",
-    "howThisWorksTitle": "How does this platform work?",
-    "howThisWorksText": "Watch these short videos to learn how to use the platform: search for objects, add narratives, join communities and more."
+    "howThisWorksTitle": "How does the Datahub work?",
+    "howThisWorksText": "Watch these video tutorials to learn how to use the platform — search for objects, add narratives, join communities, and more."
   },
   "ObjectSearch": {
     "title": "Search for heritage objects",

--- a/apps/researcher/src/messages/en/messages.json
+++ b/apps/researcher/src/messages/en/messages.json
@@ -23,8 +23,7 @@
     "communitiesDescription": "Upon creating an account, every individual or group of people can start their own community on this platform. A community is able to create lists of objects, bringing together their heritage. Communities can also add narratives to the objects in these collections.",
     "communitiesLink": "Below are some communities to inspire you. <link>Click here to see all the communities on the platform.</link>.",
     "howThisWorksTitle": "How does this platform work?",
-    "howThisWorksText": "Here is a short explanation on how to use the following functionalities on this website: search for objects, add narratives and use communities.",
-    "howThisWorksAlt": "An animation about how this site works."
+    "howThisWorksText": "Watch these short videos to learn how to use the platform: search for objects, add narratives, join communities and more."
   },
   "ObjectSearch": {
     "title": "Search for heritage objects",

--- a/apps/researcher/src/messages/en/walkthrough.yaml
+++ b/apps/researcher/src/messages/en/walkthrough.yaml
@@ -5,6 +5,7 @@ videos:
   - title: Searching objects and belongings
     text: ''
     vimeoId: "1146568055"
+    active: false
   - title: Creating and joining communities
     text: ''
     vimeoId: "1146571219"

--- a/apps/researcher/src/messages/en/walkthrough.yaml
+++ b/apps/researcher/src/messages/en/walkthrough.yaml
@@ -1,0 +1,23 @@
+videos:
+  - title: Introducing the Datahub
+    text: This video tutorial introduces the viewer to the Colonial Collections Datahub of the Colonial Collections Consortium. It highlights what a user can find on the platform and explains key features that can be used.
+    vimeoId: "1146519930"
+  - title: Searching objects and belongings
+    text: ''
+    vimeoId: "1146568055"
+  - title: Creating and joining communities
+    text: ''
+    vimeoId: "1146571219"
+    active: false
+  - title: Adding narratives
+    text: ''
+    vimeoId: "1146583635"
+    active: false
+  - title: Local context notices
+    text: ''
+    vimeoId: "1146593863"
+    active: false
+  - title: Research Aids
+    text: ''
+    vimeoId: "1146609367"
+    active: false

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -22,8 +22,8 @@
     "communitiesTitle": "Erfgoedgemeenschap",
     "communitiesDescription": "Na het aanmaken van een account kan elk individu of elke groep mensen zijn eigen gemeenschap starten op dit platform. Een gemeenschap kan lijsten van objecten maken en zo haar erfgoed samenbrengen. Communities kunnen ook context en perspectieven toevoegen aan de objecten in deze collecties.",
     "communitiesLink": "Hieronder staan enkele communities om je te inspireren. <link>Klik hier om alle communities op het platform zien.</link>.",
-    "howThisWorksTitle": "Hoe werkt dit platform?",
-    "howThisWorksText": "Bekijk deze korte video's om te leren hoe je het platform kunt gebruiken: objecten zoeken, verhalen toevoegen, lid worden van communities en meer."
+    "howThisWorksTitle": "Hoe werkt de Datahub?",
+    "howThisWorksText": "Bekijk deze videotutorials om te leren hoe je het platform gebruikt — objecten zoeken, perspectieven toevoegen, lid worden van communities en meer."
   },
   "SignUp": {
     "pageTitle": "Maak een account aan",

--- a/apps/researcher/src/messages/nl/messages.json
+++ b/apps/researcher/src/messages/nl/messages.json
@@ -23,8 +23,7 @@
     "communitiesDescription": "Na het aanmaken van een account kan elk individu of elke groep mensen zijn eigen gemeenschap starten op dit platform. Een gemeenschap kan lijsten van objecten maken en zo haar erfgoed samenbrengen. Communities kunnen ook context en perspectieven toevoegen aan de objecten in deze collecties.",
     "communitiesLink": "Hieronder staan enkele communities om je te inspireren. <link>Klik hier om alle communities op het platform zien.</link>.",
     "howThisWorksTitle": "Hoe werkt dit platform?",
-    "howThisWorksText": "Hier volgt een korte uitleg over het gebruik van de volgende functionaliteiten op deze website: objecten zoeken, perspectieven toevoegen en communities gebruiken.",
-    "howThisWorksAlt": "Een animatie over hoe deze site werkt."
+    "howThisWorksText": "Bekijk deze korte video's om te leren hoe je het platform kunt gebruiken: objecten zoeken, verhalen toevoegen, lid worden van communities en meer."
   },
   "SignUp": {
     "pageTitle": "Maak een account aan",

--- a/apps/researcher/src/messages/nl/walkthrough.yaml
+++ b/apps/researcher/src/messages/nl/walkthrough.yaml
@@ -5,6 +5,7 @@ videos:
   - title: Objecten zoeken
     text: ''
     vimeoId: "1146568055"
+    active: false
   - title: Communities aanmaken en lid worden
     text: ''
     vimeoId: "1146571219"

--- a/apps/researcher/src/messages/nl/walkthrough.yaml
+++ b/apps/researcher/src/messages/nl/walkthrough.yaml
@@ -1,6 +1,6 @@
 videos:
   - title: Introductie van de Datahub
-    text: Deze videotutorial introduceert de kijker in de Koloniale Collecties Datahub van het Colonial Collections Consortium. Het laat zien wat een gebruiker op het platform kan vinden en legt de belangrijkste functies uit.
+    text: Deze videotutorial introduceert de kijker aan de Koloniale Collecties Datahub van het Consortium Koloniale Collecties. Het laat zien wat een gebruiker op het platform kan vinden en licht de belangrijkste functionaliteiten toe.
     vimeoId: "1146519930"
   - title: Objecten zoeken
     text: ''

--- a/apps/researcher/src/messages/nl/walkthrough.yaml
+++ b/apps/researcher/src/messages/nl/walkthrough.yaml
@@ -1,0 +1,23 @@
+videos:
+  - title: Introductie van de Datahub
+    text: Deze videotutorial introduceert de kijker in de Koloniale Collecties Datahub van het Colonial Collections Consortium. Het laat zien wat een gebruiker op het platform kan vinden en legt de belangrijkste functies uit.
+    vimeoId: "1146519930"
+  - title: Objecten zoeken
+    text: ''
+    vimeoId: "1146568055"
+  - title: Communities aanmaken en lid worden
+    text: ''
+    vimeoId: "1146571219"
+    active: false
+  - title: Verhalen toevoegen
+    text: ''
+    vimeoId: "1146583635"
+    active: false
+  - title: Local Contexts Notices
+    text: ''
+    vimeoId: "1146593863"
+    active: false
+  - title: Zoekhulpen
+    text: ''
+    vimeoId: "1146609367"
+    active: false

--- a/apps/researcher/src/types/yaml.d.ts
+++ b/apps/researcher/src/types/yaml.d.ts
@@ -1,0 +1,4 @@
+declare module '*.yaml' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
The homepage "How does this platform work?" section shows a static GIF animation. The consortium has Vimeo walkthrough videos that explain the platform better than the animation does.

This pull request replaces the GIF with a tabbed video player that loads walkthrough content from YAML files per locale. Each video entry has an active flag, set to false to hide.

## What I changed

- I created a walkthrough/ component with a Zod schema that parses YAML, validates entries, and silently skips invalid or inactive ones (we don't want a broken homepage)
- I added walkthrough.yaml for both EN and NL with all 6 videos. Only the first 2 are active right now, the rest are set to active: false
- I swapped the GIF `<Image>` in page.tsx for the new `<Walkthrough>` component and kept the intro text
- I updated `howThisWorksText` in both locales to reference the videos instead of the old animation
- I added unit tests covering valid YAML, invalid entries, empty text, inactive entries, and edge cases
- bundle walkthrough YAML at build time. Source files aren't deployed to Vercel, so readFile fails at runtime. Import YAML as raw strings via webpack asset/source rule instead.

## Before merge

- Set the second video ("Searching objects and belongings") to `active: false` - I did not do this already, so the preview shows the design with more than one video.
- Review all text changes/additions.
- Camiel: Before activating any video, make sure it's set to public in Vimeo first. The second video currently doesn't load because it's still private

Preview: https://colonial-collections-researcher-git-videos-colonial-heritage.vercel.app/